### PR TITLE
Delete protection support for rds instance.

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -66,6 +66,7 @@ See AWS documentation for the [available instance types](https://aws.amazon.com/
 
 ### Optional
 
+- **deletion_protection** (Boolean) If the DB instance should have deletion protection enabled.The database can't be deleted when this value is set to `true`. The default is `false`.
 - **encrypt_storage** (Boolean) Whether or not to encrypt the RDS instance storage.
 - **engine_version** (String) The database engine version to use the for the RDS instance.
 If you don't know the available engine versions for your RDS instance, you can use the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html) to retrieve a list.

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -167,6 +167,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 				"The database can't be deleted when this value is set to `true`. The default is `false`.",
 			Type:     schema.TypeBool,
 			Optional: true,
+			Default:  false,
 		},
 	}
 }
@@ -264,7 +265,8 @@ func resourceDuploRdsInstanceCreate(ctx context.Context, d *schema.ResourceData,
 	diags = resourceDuploRdsInstanceRead(ctx, d, m)
 
 	identifier := d.Get("identifier").(string)
-	deleteProtection := d.Get("deletion_protection").(bool)
+	deleteProtection := new(bool)
+	*deleteProtection = d.Get("deletion_protection").(bool)
 	// Update delete protection settings.
 	log.Printf("[DEBUG] Updating delete protection settings to '%v' for db instance '%s'.", deleteProtection, identifier)
 	err = c.RdsInstanceChangeDeleteProtection(tenantID, duplosdk.DuploRdsInstanceDeleteProtection{
@@ -314,9 +316,12 @@ func resourceDuploRdsInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 	diags := resourceDuploRdsInstanceRead(ctx, d, m)
 
 	if d.HasChange("deletion_protection") {
+		log.Printf("[DEBUG] Updating delete protection settings to '%v' for db instance '%s'.", d.Get("deletion_protection").(bool), d.Get("identifier").(string))
+		deleteProtection := new(bool)
+		*deleteProtection = d.Get("deletion_protection").(bool)
 		err = c.RdsInstanceChangeDeleteProtection(tenantID, duplosdk.DuploRdsInstanceDeleteProtection{
 			DBInstanceIdentifier: d.Get("identifier").(string),
-			DeletionProtection:   d.Get("deletion_protection").(bool),
+			DeletionProtection:   deleteProtection,
 		})
 
 		if err != nil {

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -51,7 +51,7 @@ type DuploRdsInstancePasswordChange struct {
 
 type DuploRdsInstanceDeleteProtection struct {
 	DBInstanceIdentifier string `json:"DBInstanceIdentifier"`
-	DeletionProtection   bool   `json:"DeletionProtection,omitempty"`
+	DeletionProtection   *bool  `json:"DeletionProtection,omitempty"`
 }
 
 /*************************************************

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -49,6 +49,11 @@ type DuploRdsInstancePasswordChange struct {
 	StorePassword  bool   `json:"StorePassword,omitempty"`
 }
 
+type DuploRdsInstanceDeleteProtection struct {
+	DBInstanceIdentifier string `json:"DBInstanceIdentifier"`
+	DeletionProtection   bool   `json:"DeletionProtection,omitempty"`
+}
+
 /*************************************************
  * API CALLS to duplo
  */
@@ -134,6 +139,15 @@ func (c *Client) RdsInstanceChangePassword(tenantID string, duploObject DuploRds
 	return c.postAPI(
 		fmt.Sprintf("RdsInstanceChangePassword(%s, %s)", tenantID, duploObject.Identifier),
 		fmt.Sprintf("subscriptions/%s/RDSInstancePasswordChange", tenantID),
+		&duploObject,
+		nil,
+	)
+}
+
+func (c *Client) RdsInstanceChangeDeleteProtection(tenantID string, duploObject DuploRdsInstanceDeleteProtection) ClientError {
+	return c.postAPI(
+		fmt.Sprintf("RdsInstanceChangeDeleteProtection(%s, %s)", tenantID, duploObject.DBInstanceIdentifier),
+		fmt.Sprintf("subscriptions/%s/ModifyRDSDBInstance", tenantID),
 		&duploObject,
 		nil,
 	)


### PR DESCRIPTION
- Delete protection support for rds instance.
- API update delete protection is called after updating state from create API response. Because we need DB identifier for updating delete protection settings. This identifier is computed from the backend.