### PR TITLE
TF provider should not show diffs for empty k8s configmap.

### DIFF
--- a/duplocloud/resource_duplo_k8_config_map.go
+++ b/duplocloud/resource_duplo_k8_config_map.go
@@ -38,6 +38,9 @@ func k8sConfigMapSchema() map[string]*schema.Schema {
 			Optional:     false,
 			Required:     true,
 			ValidateFunc: ValidateJSONObjectString,
+			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+				return d.Id() != "" && ((old == "null" && new == "{}") || (old == "{}" && new == "null") || old == new)
+			},
 		},
 		"metadata": {
 			Description: "A JSON encoded string representing the configmap metadata. " +

--- a/duplosdk/duplo_lbconfigs.go
+++ b/duplosdk/duplo_lbconfigs.go
@@ -52,6 +52,17 @@ func (c *Client) DuploServiceLBConfigsGet(tenantID string, name string) (*DuploS
 	return &rp, err
 }
 
+func (c *Client) DuploServiceLBConfigsExists(tenantID string, name string) bool {
+	rp := DuploServiceLBConfigs{}
+	err := c.getAPI(fmt.Sprintf("DuploServiceLBConfigsGet(%s, %s)", tenantID, name),
+		fmt.Sprintf("v2/subscriptions/%s/ServiceLBConfigsV2/%s", tenantID, name),
+		&rp)
+	if err == nil && (rp.LBConfigs == nil || len(*rp.LBConfigs) == 0) {
+		return false
+	}
+	return true
+}
+
 // DuploServiceLBConfigsCreate creates a service's load balancer via the Duplo API.
 func (c *Client) DuploServiceLBConfigsCreate(tenantID string, rq *DuploServiceLBConfigs) (*DuploServiceLBConfigs, ClientError) {
 	return c.DuploServiceLBConfigsCreateOrUpdate(tenantID, rq, false)

--- a/duplosdk/duplo_service.go
+++ b/duplosdk/duplo_service.go
@@ -47,6 +47,17 @@ func (c *Client) DuploServiceGet(tenantID string, name string) (*DuploService, C
 	return &rp, err
 }
 
+func (c *Client) DuploServiceExist(tenantID string, name string) bool {
+	rp := DuploService{}
+	err := c.getAPI(fmt.Sprintf("DuploServiceGet(%s, %s)", tenantID, name),
+		fmt.Sprintf("v2/subscriptions/%s/ReplicationControllerApiV2/%s", tenantID, name),
+		&rp)
+	if err != nil || rp.Name == "" {
+		return false
+	}
+	return true
+}
+
 // DuploServiceCreate creates a service via the Duplo API.
 func (c *Client) DuploServiceCreate(tenantID string, rq *DuploService) (*DuploService, ClientError) {
 	return c.DuploServiceCreateOrUpdate(tenantID, rq, false)


### PR DESCRIPTION
- TF provider should not show diffs for empty k8s configmap.
- Error when service is manually deleted by the user and destroyed from terraform, it should pass tf destroy even if the resource is deleted manually from Duplo portal.