### PR TITLE
Replica should not be a mandatory attribute for the services when ASG is set for the service.

### DIFF
--- a/duplocloud/resource_duplo_service.go
+++ b/duplocloud/resource_duplo_service.go
@@ -99,16 +99,16 @@ func duploServiceSchema() map[string]*schema.Schema {
 			Default:  0,
 		},
 		"replicas": {
-			Description: "The number of container replicas to deploy.",
-			Type:        schema.TypeInt,
-			Optional:    false,
-			Required:    true,
+			Description:   "The number of container replicas to deploy.",
+			Type:          schema.TypeInt,
+			Optional:      false,
+			Required:      true,
 			ConflictsWith: []string{"replicas_matching_asg_name"},
 		},
 		"replicas_matching_asg_name": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Required: false,
+			Type:          schema.TypeString,
+			Optional:      true,
+			Required:      false,
 			ConflictsWith: []string{"replicas"},
 		},
 		"docker_image": {

--- a/duplocloud/resource_duplo_service.go
+++ b/duplocloud/resource_duplo_service.go
@@ -103,11 +103,13 @@ func duploServiceSchema() map[string]*schema.Schema {
 			Type:        schema.TypeInt,
 			Optional:    false,
 			Required:    true,
+			ConflictsWith: []string{"replicas_matching_asg_name"},
 		},
 		"replicas_matching_asg_name": {
 			Type:     schema.TypeString,
 			Optional: true,
 			Required: false,
+			ConflictsWith: []string{"replicas"},
 		},
 		"docker_image": {
 			Description: "The docker image to use for the launched container(s).",


### PR DESCRIPTION
- Replica should not be a mandatory attribute for the services when ASG is set for the service.
