### PR TITLE
GCP Cloud function trigger url missing issue fixed.

### DIFF
--- a/docs/resources/duplo_service.md
+++ b/docs/resources/duplo_service.md
@@ -87,7 +87,6 @@ resource "duplocloud_duplo_service" "myservice" {
 
 - **docker_image** (String) The docker image to use for the launched container(s).
 - **name** (String) The name of the service to create.
-- **replicas** (Number) The number of container replicas to deploy.
 - **tenant_id** (String) The GUID of the tenant that the service will be created in.
 
 ### Optional
@@ -105,6 +104,7 @@ Should be one of:
 - **lb_synced_deployment** (Boolean) Defaults to `false`.
 - **other_docker_config** (String)
 - **other_docker_host_config** (String)
+- **replicas** (Number) The number of container replicas to deploy. Defaults to `1`.
 - **replicas_matching_asg_name** (String)
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - **volumes** (String)

--- a/duplocloud/resource_duplo_gcp_cloud_function.go
+++ b/duplocloud/resource_duplo_gcp_cloud_function.go
@@ -273,7 +273,7 @@ func resourceGcpCloudFunctionCreate(ctx context.Context, d *schema.ResourceData,
 	tenantID := d.Get("tenant_id").(string)
 
 	// Post the object to Duplo
-	rp, err := c.GcpCloudFunctionCreate(tenantID, rq)
+	_, err := c.GcpCloudFunctionCreate(tenantID, rq)
 	if err != nil {
 		return diag.Errorf("Error creating tenant %s cloud function '%s': %s", tenantID, rq.Name, err)
 	}
@@ -288,7 +288,7 @@ func resourceGcpCloudFunctionCreate(ctx context.Context, d *schema.ResourceData,
 	}
 	d.SetId(id)
 
-	resourceGcpCloudFunctionSetData(d, tenantID, rq.Name, rp)
+	resourceGcpCloudFunctionRead(ctx, d, m)
 	log.Printf("[TRACE] resourceGcpCloudFunctionCreate ******** end")
 	return diags
 }
@@ -303,7 +303,7 @@ func resourceGcpCloudFunctionUpdate(ctx context.Context, d *schema.ResourceData,
 	if len(idParts) < 2 {
 		return diag.Errorf("Invalid resource ID: %s", id)
 	}
-	tenantID, name := idParts[0], idParts[1]
+	tenantID, _ := idParts[0], idParts[1]
 
 	// Create the request object.
 	rq := expandGcpCloudFunction(d)
@@ -312,11 +312,11 @@ func resourceGcpCloudFunctionUpdate(ctx context.Context, d *schema.ResourceData,
 	c := m.(*duplosdk.Client)
 
 	// Post the object to Duplo
-	rp, err := c.GcpCloudFunctionUpdate(tenantID, rq)
+	_, err := c.GcpCloudFunctionUpdate(tenantID, rq)
 	if err != nil {
 		return diag.Errorf("Error updating tenant %s cloud function '%s': %s", tenantID, rq.Name, err)
 	}
-	resourceGcpCloudFunctionSetData(d, tenantID, name, rp)
+	resourceGcpCloudFunctionRead(ctx, d, m)
 
 	log.Printf("[TRACE] resourceGcpCloudFunctionUpdate ******** end")
 	return nil

--- a/duplocloud/resource_duplo_service.go
+++ b/duplocloud/resource_duplo_service.go
@@ -101,14 +101,13 @@ func duploServiceSchema() map[string]*schema.Schema {
 		"replicas": {
 			Description:   "The number of container replicas to deploy.",
 			Type:          schema.TypeInt,
-			Optional:      false,
-			Required:      true,
+			Optional:      true,
+			Default:       1,
 			ConflictsWith: []string{"replicas_matching_asg_name"},
 		},
 		"replicas_matching_asg_name": {
 			Type:          schema.TypeString,
 			Optional:      true,
-			Required:      false,
 			ConflictsWith: []string{"replicas"},
 		},
 		"docker_image": {

--- a/duplosdk/tenant_gcp_cloud_resources.go
+++ b/duplosdk/tenant_gcp_cloud_resources.go
@@ -85,8 +85,8 @@ type DuploGcpCloudFunction struct {
 
 // DuploGcpCloudFunctionHTTPSTrigger represents a GCP cloud function resource for a Duplo tenant
 type DuploGcpCloudFunctionHTTPSTrigger struct {
-	SecurityLevel string `json:"SecurityLevel,omitempty"`
-	URL           string `json:"Url,omitempty"`
+	SecurityLevel string `json:"securityLevel,omitempty"`
+	URL           string `json:"url,omitempty"`
 }
 
 // DuploGcpCloudFunctionEventTrigger represents a GCP cloud function resource for a Duplo tenant


### PR DESCRIPTION
- GCP Cloud function trigger URL missing issue fixed.
- resource duplocloud_duplo_service: replicas: ConflictsWith cannot be set with Required fixed.
