### PR TITLE
DaemonSet, RDS MultiAZ and RDS logging support is added.

### DIFF
--- a/docs/data-sources/duplo_service.md
+++ b/docs/data-sources/duplo_service.md
@@ -31,6 +31,7 @@ description: |-
 - **docker_image** (String)
 - **extra_config** (String)
 - **id** (String) The ID of this resource.
+- **is_daemonset** (Boolean)
 - **lb_synced_deployment** (Boolean)
 - **other_docker_config** (String)
 - **other_docker_host_config** (String)

--- a/docs/data-sources/duplo_services.md
+++ b/docs/data-sources/duplo_services.md
@@ -37,6 +37,7 @@ Read-Only:
 - **commands** (List of String)
 - **docker_image** (String)
 - **extra_config** (String)
+- **is_daemonset** (Boolean)
 - **lb_synced_deployment** (Boolean)
 - **name** (String)
 - **other_docker_config** (String)

--- a/docs/resources/duplo_service.md
+++ b/docs/resources/duplo_service.md
@@ -103,7 +103,7 @@ Should be one of:
 - **cloud_creds_from_k8s_service_account** (Boolean) Whether or not the service gets it's cloud credentials from Kubernetes service account. Defaults to `false`.
 - **commands** (String)
 - **extra_config** (String)
-- **is_daemonSet** (Boolean) This is applicable only if `agent_platform=7`. A DaemonSet is a controller that ensures that the pod runs on all the nodes of the cluster. Defaults to `false`.
+- **is_daemonset** (Boolean) This is applicable only if `agent_platform=7`. A DaemonSet is a controller that ensures that the pod runs on all the nodes of the cluster. Defaults to `false`.
 - **lb_synced_deployment** (Boolean) Defaults to `false`.
 - **other_docker_config** (String)
 - **other_docker_host_config** (String)

--- a/docs/resources/duplo_service.md
+++ b/docs/resources/duplo_service.md
@@ -103,6 +103,7 @@ Should be one of:
 - **cloud_creds_from_k8s_service_account** (Boolean) Whether or not the service gets it's cloud credentials from Kubernetes service account. Defaults to `false`.
 - **commands** (String)
 - **extra_config** (String)
+- **is_daemonSet** (Boolean) This is applicable only if `agent_platform=7`. A DaemonSet is a controller that ensures that the pod runs on all the nodes of the cluster. Defaults to `false`.
 - **lb_synced_deployment** (Boolean) Defaults to `false`.
 - **other_docker_config** (String)
 - **other_docker_host_config** (String)

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -73,6 +73,7 @@ See AWS documentation for the [available instance types](https://aws.amazon.com/
 If you don't know the available engine versions for your RDS instance, you can use the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html) to retrieve a list.
 - **master_password** (String, Sensitive) The master password of the RDS instance.
 - **master_username** (String) The master username of the RDS instance.
+- **multi_az** (Boolean) Specifies if the RDS instance is multi-AZ. Defaults to `false`.
 - **parameter_group_name** (String) A RDS parameter group name to apply to the RDS instance.
 - **snapshot_id** (String) A database snapshot to initialize the RDS instance from, at launch.
 - **store_details_in_secret_manager** (Boolean) Whether or not to store RDS details in the AWS secrets manager.

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -67,6 +67,7 @@ See AWS documentation for the [available instance types](https://aws.amazon.com/
 ### Optional
 
 - **deletion_protection** (Boolean) If the DB instance should have deletion protection enabled.The database can't be deleted when this value is set to `true`. This setting is not applicable for document db cluster instance. Defaults to `false`.
+- **enable_logging** (Boolean) Whether or not to enable the RDS instance logging. This setting is not applicable for document db cluster instance. Defaults to `false`.
 - **encrypt_storage** (Boolean) Whether or not to encrypt the RDS instance storage.
 - **engine_version** (String) The database engine version to use the for the RDS instance.
 If you don't know the available engine versions for your RDS instance, you can use the [AWS CLI](https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html) to retrieve a list.

--- a/duplocloud/data_source_duplo_service.go
+++ b/duplocloud/data_source_duplo_service.go
@@ -78,6 +78,10 @@ func duploServiceComputedSchema() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Computed: true,
 		},
+		"is_daemonset": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
 		"tags": {
 			Type:     schema.TypeList,
 			Computed: true,
@@ -127,6 +131,7 @@ func flattenDuploService(d *schema.ResourceData, duplo *duplosdk.DuploReplicatio
 	d.Set("lb_synced_deployment", duplo.IsLBSyncedDeployment)
 	d.Set("any_host_allowed", duplo.IsAnyHostAllowed)
 	d.Set("cloud_creds_from_k8s_service_account", duplo.IsCloudCredsFromK8sServiceAccount)
+	d.Set("is_daemonset", duplo.IsDaemonset)
 	d.Set("replicas_matching_asg_name", duplo.ReplicasMatchingAsgName)
 	d.Set("replicas", duplo.Replicas)
 	d.Set("tags", keyValueToState("tags", duplo.Tags))

--- a/duplocloud/resource_duplo_ecs_service.go
+++ b/duplocloud/resource_duplo_ecs_service.go
@@ -311,6 +311,9 @@ func resourceDuploEcsServiceDelete(ctx context.Context, d *schema.ResourceData, 
 		}
 	}
 
+	// Wait for 40 seconds to avoid race condition.
+	time.Sleep(time.Duration(40) * time.Second)
+
 	log.Printf("[TRACE] resourceDuploEcsServiceDelete ******** end")
 	return nil
 }

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -163,6 +163,12 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     false,
 		},
+		"multi_az": {
+			Description: "Specifies if the RDS instance is multi-AZ.",
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+		},
 		"instance_status": {
 			Description: "The current status of the RDS instance.",
 			Type:        schema.TypeString,
@@ -448,6 +454,7 @@ func rdsInstanceFromState(d *schema.ResourceData) (*duplosdk.DuploRdsInstance, e
 	duploObject.SizeEx = d.Get("size").(string)
 	duploObject.EncryptStorage = d.Get("encrypt_storage").(bool)
 	duploObject.EnableLogging = d.Get("enable_logging").(bool)
+	duploObject.MultiAZ = d.Get("multi_az").(bool)
 	duploObject.InstanceStatus = d.Get("instance_status").(string)
 
 	return duploObject, nil
@@ -485,6 +492,7 @@ func rdsInstanceToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Resour
 	jo["size"] = duploObject.SizeEx
 	jo["encrypt_storage"] = duploObject.EncryptStorage
 	jo["enable_logging"] = duploObject.EnableLogging
+	jo["multi_az"] = duploObject.MultiAZ
 	jo["instance_status"] = duploObject.InstanceStatus
 
 	jsonData2, _ := json.Marshal(jo)

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -157,6 +157,12 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			Optional:    true,
 			ForceNew:    true,
 		},
+		"enable_logging": {
+			Description: "Whether or not to enable the RDS instance logging. This setting is not applicable for document db cluster instance.",
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+		},
 		"instance_status": {
 			Description: "The current status of the RDS instance.",
 			Type:        schema.TypeString,
@@ -441,6 +447,7 @@ func rdsInstanceFromState(d *schema.ResourceData) (*duplosdk.DuploRdsInstance, e
 	duploObject.Cloud = 0 // AWS
 	duploObject.SizeEx = d.Get("size").(string)
 	duploObject.EncryptStorage = d.Get("encrypt_storage").(bool)
+	duploObject.EnableLogging = d.Get("enable_logging").(bool)
 	duploObject.InstanceStatus = d.Get("instance_status").(string)
 
 	return duploObject, nil
@@ -477,6 +484,7 @@ func rdsInstanceToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Resour
 	jo["parameter_group_name"] = duploObject.DBParameterGroupName
 	jo["size"] = duploObject.SizeEx
 	jo["encrypt_storage"] = duploObject.EncryptStorage
+	jo["enable_logging"] = duploObject.EnableLogging
 	jo["instance_status"] = duploObject.InstanceStatus
 
 	jsonData2, _ := json.Marshal(jo)

--- a/duplocloud/resource_duplo_service.go
+++ b/duplocloud/resource_duplo_service.go
@@ -138,6 +138,12 @@ func duploServiceSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     false,
 		},
+		"is_daemonSet": {
+			Description: "This is applicable only if `agent_platform=7`. A DaemonSet is a controller that ensures that the pod runs on all the nodes of the cluster.",
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+		},
 	}
 }
 
@@ -211,6 +217,7 @@ func resourceDuploServiceCreate(ctx context.Context, d *schema.ResourceData, m i
 		Replicas:                          d.Get("replicas").(int),
 		IsLBSyncedDeployment:              d.Get("lb_synced_deployment").(bool),
 		IsAnyHostAllowed:                  d.Get("any_host_allowed").(bool),
+		IsDaemonset:                       d.Get("is_daemonSet").(bool),
 		IsCloudCredsFromK8sServiceAccount: d.Get("cloud_creds_from_k8s_service_account").(bool),
 	}
 
@@ -252,6 +259,7 @@ func resourceDuploServiceUpdate(ctx context.Context, d *schema.ResourceData, m i
 		Replicas:                          d.Get("replicas").(int),
 		IsLBSyncedDeployment:              d.Get("lb_synced_deployment").(bool),
 		IsAnyHostAllowed:                  d.Get("any_host_allowed").(bool),
+		IsDaemonset:                       d.Get("is_daemonSet").(bool),
 		IsCloudCredsFromK8sServiceAccount: d.Get("cloud_creds_from_k8s_service_account").(bool),
 	}
 

--- a/duplocloud/resource_duplo_service.go
+++ b/duplocloud/resource_duplo_service.go
@@ -138,7 +138,7 @@ func duploServiceSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     false,
 		},
-		"is_daemonSet": {
+		"is_daemonset": {
 			Description: "This is applicable only if `agent_platform=7`. A DaemonSet is a controller that ensures that the pod runs on all the nodes of the cluster.",
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -217,7 +217,7 @@ func resourceDuploServiceCreate(ctx context.Context, d *schema.ResourceData, m i
 		Replicas:                          d.Get("replicas").(int),
 		IsLBSyncedDeployment:              d.Get("lb_synced_deployment").(bool),
 		IsAnyHostAllowed:                  d.Get("any_host_allowed").(bool),
-		IsDaemonset:                       d.Get("is_daemonSet").(bool),
+		IsDaemonset:                       d.Get("is_daemonset").(bool),
 		IsCloudCredsFromK8sServiceAccount: d.Get("cloud_creds_from_k8s_service_account").(bool),
 	}
 
@@ -259,7 +259,7 @@ func resourceDuploServiceUpdate(ctx context.Context, d *schema.ResourceData, m i
 		Replicas:                          d.Get("replicas").(int),
 		IsLBSyncedDeployment:              d.Get("lb_synced_deployment").(bool),
 		IsAnyHostAllowed:                  d.Get("any_host_allowed").(bool),
-		IsDaemonset:                       d.Get("is_daemonSet").(bool),
+		IsDaemonset:                       d.Get("is_daemonset").(bool),
 		IsCloudCredsFromK8sServiceAccount: d.Get("cloud_creds_from_k8s_service_account").(bool),
 	}
 

--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -174,10 +174,10 @@ func resourceTenantCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		return diags
 	}
 
-	// Wait for 3 minutes to allow tenant creation.
+	// Wait for 2 minutes to allow tenant creation.
 	if d.Get("wait_until_created").(bool) {
 		log.Printf("[TRACE] resourceTenantCreate(%s): waiting for 2 minutes because 'wait_until_created' is 'true'", rq.AccountName)
-		time.Sleep(time.Duration(45) * time.Second)
+		time.Sleep(time.Duration(120) * time.Second)
 	}
 
 	log.Printf("[TRACE] resourceTenantCreate(%s): end", rq.AccountName)

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -40,6 +40,7 @@ type DuploRdsInstance struct {
 	SizeEx                      string `json:"SizeEx,omitempty"`
 	EncryptStorage              bool   `json:"EncryptStorage,omitempty"`
 	EnableLogging               bool   `json:"EnableLogging,omitempty"`
+	MultiAZ                     bool   `json:"MultiAZ,omitempty"`
 	InstanceStatus              string `json:"InstanceStatus,omitempty"`
 }
 

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -39,6 +39,7 @@ type DuploRdsInstance struct {
 	Cloud                       int    `json:"Cloud,omitempty"`
 	SizeEx                      string `json:"SizeEx,omitempty"`
 	EncryptStorage              bool   `json:"EncryptStorage,omitempty"`
+	EnableLogging               bool   `json:"EnableLogging,omitempty"`
 	InstanceStatus              string `json:"InstanceStatus,omitempty"`
 }
 


### PR DESCRIPTION
- DaemonSet support is added in duplo service.
- Logging support is added in rds instance.
- Multi az support is added for rds.
- tenant creation wait time is increased from 45 sec to 2 min to avoid issues we observed in kloudspot, Like - Invalid IAM instance profile Name.
- Wait 40 seconds after destroying an ECS service to avoid race conditions.