### PR TITLE
DUPLO-5427: Support of cloudfront attribute `function_association`.

### DIFF
--- a/docs/data-sources/k8_secret.md
+++ b/docs/data-sources/k8_secret.md
@@ -24,7 +24,7 @@ description: |-
 
 - **id** (String) The ID of this resource.
 - **secret_annotations** (Map of String) Annotations for the secret
-- **secret_data** (String, Sensitive) A JSON encoded string representing the secret metadata. You can use the `jsonencode()` function to convert map or object data, if needed.
+- **secret_data** (String, Sensitive) A JSON encoded string representing the secret metadata. You can use the `jsonencode()` function to convert map or object data, if needed. You can use the `jsondecode()` function to read data.
 - **secret_type** (String) The type of the secret.  Usually `"Opaque"`.
 - **secret_version** (String)
 

--- a/docs/resources/k8_secret.md
+++ b/docs/resources/k8_secret.md
@@ -39,7 +39,7 @@ resource "duplocloud_k8_secret" "myapp" {
 ### Optional
 
 - **secret_annotations** (Map of String) Annotations for the secret
-- **secret_data** (String, Sensitive) A JSON encoded string representing the secret metadata. You can use the `jsonencode()` function to convert map or object data, if needed.
+- **secret_data** (String, Sensitive) A JSON encoded string representing the secret metadata. You can use the `jsonencode()` function to convert map or object data, if needed. You can use the `jsondecode()` function to read data.
 - **timeouts** (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/duplocloud/resource_duplo_k8_secret.go
+++ b/duplocloud/resource_duplo_k8_secret.go
@@ -47,7 +47,7 @@ func k8sSecretSchema() map[string]*schema.Schema {
 		},
 		"secret_data": {
 			Description: "A JSON encoded string representing the secret metadata. " +
-				"You can use the `jsonencode()` function to convert map or object data, if needed.",
+				"You can use the `jsonencode()` function to convert map or object data, if needed. You can use the `jsondecode()` function to read data.",
 			Type:             schema.TypeString,
 			Optional:         true,
 			Sensitive:        true,

--- a/duplosdk/aws_cloudfront_distribution.go
+++ b/duplosdk/aws_cloudfront_distribution.go
@@ -15,6 +15,7 @@ type DuploAwsCloudfrontDefaultCacheBehavior struct {
 	FieldLevelEncryptionId     string                                        `json:"FieldLevelEncryptionId"`
 	OriginRequestPolicyId      string                                        `json:"OriginRequestPolicyId,omitempty"`
 	LambdaFunctionAssociations *DuploAwsCloudfrontLambdaFunctionAssociations `json:"LambdaFunctionAssociations"`
+	FunctionAssociations       *DuploAwsCloudfrontFunctionAssociations       `json:"FunctionAssociations"`
 	MaxTTL                     int                                           `json:"MaxTTL,omitempty"`
 	MinTTL                     int                                           `json:"MinTTL,omitempty"`
 	SmoothStreaming            bool                                          `json:"SmoothStreaming"`
@@ -32,6 +33,7 @@ type DuploAwsCloudfrontCacheBehavior struct {
 	FieldLevelEncryptionId     string                                        `json:"FieldLevelEncryptionId"`
 	OriginRequestPolicyId      string                                        `json:"OriginRequestPolicyId,omitempty"`
 	LambdaFunctionAssociations *DuploAwsCloudfrontLambdaFunctionAssociations `json:"LambdaFunctionAssociations"`
+	FunctionAssociations       *DuploAwsCloudfrontFunctionAssociations       `json:"FunctionAssociations"`
 	MaxTTL                     int                                           `json:"MaxTTL,omitempty"`
 	MinTTL                     int                                           `json:"MinTTL,omitempty"`
 	SmoothStreaming            bool                                          `json:"SmoothStreaming"`
@@ -47,10 +49,20 @@ type DuploAwsCloudfrontLambdaFunctionAssociations struct {
 	Quantity int                                            `json:"Quantity"`
 }
 
+type DuploAwsCloudfrontFunctionAssociations struct {
+	Items    *[]DuploAwsCloudfrontFunctionAssociation `json:"Items"`
+	Quantity int                                      `json:"Quantity"`
+}
+
+type DuploAwsCloudfrontFunctionAssociation struct {
+	EventType   *DuploStringValue `json:"EventType"`
+	FunctionARN string            `json:"FunctionARN"`
+}
+
 type DuploAwsCloudfrontLambdaFunctionAssociation struct {
-	EventType         string `json:"EventType"`
-	LambdaFunctionARN string `json:"LambdaFunctionARN"`
-	IncludeBody       bool   `json:"IncludeBody"`
+	EventType         *DuploStringValue `json:"EventType"`
+	LambdaFunctionARN string            `json:"LambdaFunctionARN"`
+	IncludeBody       bool              `json:"IncludeBody"`
 }
 
 type DuploAwsCloudfrontCacheBehaviors struct {

--- a/duplosdk/tenant_aws_cloud_resources.go
+++ b/duplosdk/tenant_aws_cloud_resources.go
@@ -25,6 +25,10 @@ const (
 	ResourceTypeSQSQueue int = 3
 
 	ResourceTypeSNSTopic int = 4
+
+	ResourceTypeLambdaFunction int = 7
+
+	ResourceTypeElasticSearch int = 24
 )
 
 type CustomComponentType int


### PR DESCRIPTION
- Support of cloudfront attribute `function_association`.
- Fix : cannot unmarshal response from JSON: json: cannot unmarshal object into Go struct field DuploAwsCloudfrontLambdaFunctionAssociation.DefaultCacheBehavior.LambdaFunctionAssociations.Items.EventType of type string