### PR TITLE
Data source `duplocloud_infrastructure` does not return subnets if the name has a hyphen.

### DIFF
--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -597,7 +597,9 @@ func infrastructureRead(c *duplosdk.Client, d *schema.ResourceData, name string)
 				// If cloud is aws
 				if config.Cloud == 0 {
 					if strings.HasPrefix(vnetSubnet.Name, config.Name) {
-						nameParts := strings.SplitN(vnetSubnet.Name, "-", 3)
+						// Split on infra name first
+						parts := strings.SplitN(vnetSubnet.Name, config.Name, 2)
+						nameParts := strings.SplitN(parts[1], "-", 3)
 						if zone == "" {
 							zone = nameParts[1]
 						}

--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -110,8 +110,8 @@ type DuploInfrastructureConfig struct {
 	Region                  string                   `json:"Region"`
 	AzCount                 int                      `json:"AzCount"`
 	EnableK8Cluster         bool                     `json:"EnableK8Cluster"`
-	EnableECSCluster        bool                     `json:"EnableECSCluster,omitempty"`
-	EnableContainerInsights bool                     `json:"EnableContainerInsights,omitempty"`
+	EnableECSCluster        bool                     `json:"EnableECSCluster"`
+	EnableContainerInsights bool                     `json:"EnableContainerInsights"`
 	Vnet                    *DuploInfrastructureVnet `json:"Vnet"`
 	ProvisioningStatus      string                   `json:"ProvisioningStatus"`
 	CustomData              *[]DuploKeyStringValue   `json:"CustomData,omitempty"`


### PR DESCRIPTION
- Data source `duplocloud_infrastructure` does not return subnets if the name has a hyphen.