### PR TITLE
`allocated_storage` attribute added for duplocloud_rds_instance.

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -67,6 +67,7 @@ See AWS documentation for the [available instance types](https://aws.amazon.com/
 
 ### Optional
 
+- **allocated_storage** (Number) (Required unless a `snapshot_id` is provided) The allocated storage in gibibytes.
 - **db_subnet_group_name** (String) Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group.
 - **deletion_protection** (Boolean) If the DB instance should have deletion protection enabled.The database can't be deleted when this value is set to `true`. This setting is not applicable for document db cluster instance. Defaults to `false`.
 - **enable_logging** (Boolean) Whether or not to enable the RDS instance logging. This setting is not applicable for document db cluster instance. Defaults to `false`.

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -67,7 +67,7 @@ See AWS documentation for the [available instance types](https://aws.amazon.com/
 
 ### Optional
 
-- **allocated_storage** (Number) (Required unless a `snapshot_id` is provided) The allocated storage in gibibytes.
+- **allocated_storage** (Number) (Required unless a `snapshot_id` is provided) The allocated storage in gigabytes.
 - **db_subnet_group_name** (String) Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group.
 - **deletion_protection** (Boolean) If the DB instance should have deletion protection enabled.The database can't be deleted when this value is set to `true`. This setting is not applicable for document db cluster instance. Defaults to `false`.
 - **enable_logging** (Boolean) Whether or not to enable the RDS instance logging. This setting is not applicable for document db cluster instance. Defaults to `false`.

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -159,7 +159,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^db\.`), "RDS instance types must start with 'db.'"),
 		},
 		"allocated_storage": {
-			Description: "(Required unless a `snapshot_id` is provided) The allocated storage in gibibytes.",
+			Description: "(Required unless a `snapshot_id` is provided) The allocated storage in gigabytes.",
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Computed:    true,

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -158,6 +158,12 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			ForceNew:     true,
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^db\.`), "RDS instance types must start with 'db.'"),
 		},
+		"allocated_storage": {
+			Description: "(Required unless a `snapshot_id` is provided) The allocated storage in gibibytes.",
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+		},
 		"encrypt_storage": {
 			Description: "Whether or not to encrypt the RDS instance storage.",
 			Type:        schema.TypeBool,
@@ -489,6 +495,7 @@ func rdsInstanceFromState(d *schema.ResourceData) (*duplosdk.DuploRdsInstance, e
 	duploObject.Cloud = 0 // AWS
 	duploObject.SizeEx = d.Get("size").(string)
 	duploObject.EncryptStorage = d.Get("encrypt_storage").(bool)
+	duploObject.AllocatedStorage = d.Get("allocated_storage").(int)
 	duploObject.EncryptionKmsKeyId = d.Get("kms_key_id").(string)
 	duploObject.EnableLogging = d.Get("enable_logging").(bool)
 	duploObject.MultiAZ = d.Get("multi_az").(bool)
@@ -531,6 +538,7 @@ func rdsInstanceToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Resour
 	jo["db_subnet_group_name"] = duploObject.DBSubnetGroupName
 	jo["size"] = duploObject.SizeEx
 	jo["encrypt_storage"] = duploObject.EncryptStorage
+	jo["allocated_storage"] = duploObject.AllocatedStorage
 	jo["kms_key_id"] = duploObject.EncryptionKmsKeyId
 	jo["enable_logging"] = duploObject.EnableLogging
 	jo["multi_az"] = duploObject.MultiAZ

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -40,6 +40,7 @@ type DuploRdsInstance struct {
 	Cloud                       int    `json:"Cloud,omitempty"`
 	SizeEx                      string `json:"SizeEx,omitempty"`
 	EncryptStorage              bool   `json:"EncryptStorage,omitempty"`
+	AllocatedStorage            int    `json:"AllocatedStorage,omitempty"`
 	EncryptionKmsKeyId          string `json:"EncryptionKmsKeyId,omitempty"`
 	EnableLogging               bool   `json:"EnableLogging,omitempty"`
 	MultiAZ                     bool   `json:"MultiAZ,omitempty"`


### PR DESCRIPTION
- `allocated_storage` attribute added for duplocloud_rds_instance.