### PR TITLE
target_group_arn field is added on duplocloud_duplo_service_lbconfigs.

### DIFF
--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -453,6 +453,7 @@ func flattenDuploServiceLbConfiguration(lb *duplosdk.DuploLbConfiguration) map[s
 		"is_native":                   lb.IsNative,
 		"is_internal":                 lb.IsInternal,
 		"extra_selector_label":        keyValueToState("extra_selector_label", lb.ExtraSelectorLabels),
+		"target_group_arn":            lb.TgArn,
 	}
 
 	if lb.LbType == 5 && lb.HostNames != nil && len(*lb.HostNames) > 0 {

--- a/duplosdk/replication_controller.go
+++ b/duplosdk/replication_controller.go
@@ -90,7 +90,7 @@ type DuploLbConfiguration struct {
 	IsNative                  bool                      `json:"IsNative,omitempty"`
 	HealthCheckConfig         *DuploLbHealthCheckConfig `json:"HealthCheckConfig,omitempty"`
 	LbIndex                   int                       `json:"LbIndex"`
-
+	TgArn                     string                    `json:"TgArn,omitempty"`
 	// Only for K8s services
 	ExtraSelectorLabels *[]DuploKeyStringValue `json:"ExtraSelectorLabels,omitempty"`
 


### PR DESCRIPTION
- target_group_arn field is added on duplocloud_duplo_service_lbconfigs.