### PR TITLE
DUPLO-10062: python 3.1 support for lambda runtime

### DIFF
--- a/duplocloud/resource_duplo_aws_lambda_function.go
+++ b/duplocloud/resource_duplo_aws_lambda_function.go
@@ -127,7 +127,7 @@ func awsLambdaFunctionSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringInSlice([]string{
 				"nodejs", "nodejs4.3", "nodejs6.10", "nodejs8.10", "nodejs10.x", "nodejs12.x", "nodejs14.x", "nodejs16.x",
 				"java8", "java8.al2", "java11",
-				"python2.7", "python3.1", "python3.6", "python3.7", "python3.8", "python3.9",
+				"python2.7", "python3.10", "python3.6", "python3.7", "python3.8", "python3.9",
 				"dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "dotnetcore3.1",
 				"nodejs4.3-edge",
 				"go1.x",

--- a/duplocloud/resource_duplo_aws_lambda_function.go
+++ b/duplocloud/resource_duplo_aws_lambda_function.go
@@ -127,7 +127,7 @@ func awsLambdaFunctionSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringInSlice([]string{
 				"nodejs", "nodejs4.3", "nodejs6.10", "nodejs8.10", "nodejs10.x", "nodejs12.x", "nodejs14.x", "nodejs16.x",
 				"java8", "java8.al2", "java11",
-				"python2.7", "python3.6", "python3.7", "python3.8", "python3.9",
+				"python2.7", "python3.1", "python3.6", "python3.7", "python3.8", "python3.9",
 				"dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "dotnetcore3.1",
 				"nodejs4.3-edge",
 				"go1.x",


### PR DESCRIPTION
python 3.1 support for lambda runtime. (blocpower-duplo)