### PR TITLE
DUPLO-9414 deprecate custom_data from infra settings

### DIFF
--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -395,7 +395,7 @@ func resourceInfrastructureUpdate(ctx context.Context, d *schema.ResourceData, m
 	if d.HasChange("setting") {
 		var existing *[]duplosdk.DuploKeyStringValue
 		if v, ok := getAsStringArray(d, "specified_settings"); ok && v != nil {
-			existing = selectKeyValues(config.CustomData, *v)
+			existing = selectKeyValues(config.Setting, *v)
 		} else {
 			existing = &[]duplosdk.DuploKeyStringValue{}
 		}
@@ -410,7 +410,7 @@ func resourceInfrastructureUpdate(ctx context.Context, d *schema.ResourceData, m
 
 		// Apply the changes via Duplo
 		if d.Get("delete_unspecified_settings").(bool) {
-			err = c.InfrastructureReplaceSetting(duplosdk.DuploInfrastructureSetting{InfraName: infraName, CustomData: settings})
+			err = c.InfrastructureReplaceSetting(duplosdk.DuploInfrastructureSetting{InfraName: infraName, Setting: settings})
 		} else {
 			err = c.InfrastructureChangeSetting(infraName, existing, settings)
 		}
@@ -499,10 +499,10 @@ func duploInfrastructureConfigFromState(d *schema.ResourceData) duplosdk.DuploIn
 		},
 	}
 
-	if d.HasChange("custom_data") {
-		config.CustomData = keyValueFromState("custom_data", d)
-	} else if d.HasChange("setting") {
+	if d.HasChange("setting") {
 		config.CustomData = keyValueFromState("setting", d)
+	} else if d.HasChange("custom_data") {
+		config.CustomData = keyValueFromState("custom_data", d)
 	}
 
 	return config
@@ -561,7 +561,6 @@ func infrastructureRead(c *duplosdk.Client, d *schema.ResourceData, name string)
 	d.Set("subnet_cidr", infra.Vnet.SubnetCidr)
 	d.Set("status", infra.ProvisioningStatus)
 
-	d.Set("custom_data", keyValueToState("custom_data", config.CustomData))
 	d.Set("all_settings", keyValueToState("all_settings", config.CustomData))
 
 	// Build a list of current state, to replace the user-supplied settings.

--- a/duplocloud/resource_duplo_infrastructure_setting.go
+++ b/duplocloud/resource_duplo_infrastructure_setting.go
@@ -38,10 +38,11 @@ func resourceInfrastructureSetting() *schema.Resource {
 				ForceNew:    true,
 			},
 			"setting": {
-				Description: "A list of configuration settings to manage, expressed as key / value pairs.",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        KeyValueSchema(),
+				Description:   "A list of configuration settings to manage, expressed as key / value pairs.",
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          KeyValueSchema(),
+				ConflictsWith: []string{"custom_data"},
 			},
 			"delete_unspecified_settings": {
 				Description: "Whether or not this resource should delete any settings not specified by this resource. " +
@@ -51,10 +52,12 @@ func resourceInfrastructureSetting() *schema.Resource {
 				Default:  false,
 			},
 			"custom_data": {
-				Description: "A complete list of configuration settings for this infrastructure, even ones not being managed by this resource.",
-				Type:        schema.TypeList,
-				Computed:    true,
-				Elem:        KeyValueSchema(),
+				Description:   "A complete list of configuration settings for this infrastructure, even ones not being managed by this resource.",
+				Type:          schema.TypeList,
+				Optional:      true,
+				Elem:          KeyValueSchema(),
+				Deprecated:    "The custom_data argument is only applied on creation, and is deprecated in favor of the settings argument.",
+				ConflictsWith: []string{"setting"},
 			},
 			"specified_settings": {
 				Description: "A list of configuration setting key being managed by this resource.",
@@ -85,11 +88,10 @@ func resourceInfrastructureSettingRead(ctx context.Context, d *schema.ResourceDa
 
 	// Set the simple fields first.
 	d.Set("infra_name", duplo.InfraName)
-	d.Set("custom_data", keyValueToState("custom_data", duplo.CustomData))
 
 	// Build a list of current state, to replace the user-supplied settings.
 	if v, ok := getAsStringArray(d, "specified_settings"); ok && v != nil {
-		d.Set("setting", keyValueToState("setting", selectKeyValues(duplo.CustomData, *v)))
+		d.Set("setting", keyValueToState("setting", selectKeyValues(duplo.Setting, *v)))
 	}
 
 	log.Printf("[TRACE] resourceInfrastructureSettingRead(%s): end", infraName)
@@ -114,7 +116,7 @@ func resourceInfrastructureSettingCreateOrUpdate(ctx context.Context, d *schema.
 	}
 	var existing *[]duplosdk.DuploKeyStringValue
 	if v, ok := getAsStringArray(d, "specified_settings"); ok && v != nil {
-		existing = selectKeyValues(config.CustomData, *v)
+		existing = selectKeyValues(config.Setting, *v)
 	} else {
 		existing = &[]duplosdk.DuploKeyStringValue{}
 	}
@@ -129,7 +131,7 @@ func resourceInfrastructureSettingCreateOrUpdate(ctx context.Context, d *schema.
 
 	// Apply the changes via Duplo
 	if d.Get("delete_unspecified_settings").(bool) {
-		err = c.InfrastructureReplaceSetting(duplosdk.DuploInfrastructureSetting{InfraName: infraName, CustomData: settings})
+		err = c.InfrastructureReplaceSetting(duplosdk.DuploInfrastructureSetting{InfraName: infraName, Setting: settings})
 	} else {
 		err = c.InfrastructureChangeSetting(infraName, existing, settings)
 	}
@@ -161,8 +163,8 @@ func resourceInfrastructureSettingDelete(ctx context.Context, d *schema.Resource
 		d.SetId("") // object missing
 		return nil
 	}
-	// Get the previous and desired infrastructure settingss
-	previous, _ := getInfrastructureSettingChange(all.CustomData, d)
+	// Get the previous and desired infrastructure settings
+	previous, _ := getInfrastructureSettingChange(all.Setting, d)
 	desired := &[]duplosdk.DuploKeyStringValue{}
 	if d.Get("delete_unspecified_settings").(bool) {
 		err = c.InfrastructureReplaceSetting(duplosdk.DuploInfrastructureSetting{InfraName: infraName})
@@ -217,7 +219,7 @@ func expandInfrastructureSetting(fieldName string, d *schema.ResourceData) *[]du
 	return &ary
 }
 
-// Utiliy function to return a filtered list of tenant metadata, given the selected keys.
+// Utility function to return a filtered list of tenant metadata, given the selected keys.
 func selectInfrastructureSettings(all *[]duplosdk.DuploKeyStringValue, keys []string) *[]duplosdk.DuploKeyStringValue {
 	specified := map[string]interface{}{}
 	for _, k := range keys {

--- a/duplocloud/utils_test.go
+++ b/duplocloud/utils_test.go
@@ -1,6 +1,8 @@
 package duplocloud
 
 import (
+	"reflect"
+	"terraform-provider-duplocloud/duplosdk"
 	"testing"
 )
 
@@ -33,5 +35,52 @@ func TestSortCommaDelimitedString(t *testing.T) {
 		if actual != c.expected {
 			t.Errorf("Expected %s, got %s", c.expected, actual)
 		}
+	}
+}
+
+func Test_keyValueToState(t *testing.T) {
+	// Test case with non-nil input
+	input := []duplosdk.DuploKeyStringValue{
+		{Key: "key1", Value: "value1"},
+		{Key: "key2", Value: "value2"},
+		{Key: "key3", Value: "value3"},
+	}
+	expectedOutput := []interface{}{
+		map[string]interface{}{"key": "key1", "value": "value1"},
+		map[string]interface{}{"key": "key2", "value": "value2"},
+		map[string]interface{}{"key": "key3", "value": "value3"},
+	}
+	type args struct {
+		fieldName    string
+		duploObjects *[]duplosdk.DuploKeyStringValue
+	}
+	tests := []struct {
+		name string
+		args args
+		want []interface{}
+	}{
+		{
+			name: "non-nil input",
+			args: args{
+				fieldName:    "testFieldName",
+				duploObjects: &input,
+			},
+			want: expectedOutput,
+		},
+		{
+			name: "nil input",
+			args: args{
+				fieldName:    "testFieldName",
+				duploObjects: nil,
+			},
+			want: []interface{}{},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := keyValueToState(tt.args.fieldName, tt.args.duploObjects); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("keyValueToState() = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -50,7 +50,7 @@ type DuploInfrastructure struct {
 	CustomData              *[]DuploKeyStringValue `json:"CustomData,omitempty"`
 }
 
-// DuploInfrastructureVnet represents a Duplo infrastructure VNET subnet
+// DuploInfrastructureVnetSubnet represents a Duplo infrastructure VNET subnet
 type DuploInfrastructureVnetSubnet struct {
 	// Only used by write APIs
 	State              string `json:"State,omitempty"`
@@ -158,14 +158,6 @@ type DuploAzureRecoveryServicesVaultRq struct {
 	ResourceGroup string `json:"resourceGroup,omitempty"`
 }
 
-type SgRuleType int
-
-const (
-	IPADDRESS SgRuleType = iota
-	SERVICETAG
-	APP_SG
-)
-
 type InfrastructureSgUpdate struct {
 	Name          string                           `json:"Name"`
 	SgName        string                           `json:"SgName"`
@@ -176,11 +168,11 @@ type InfrastructureSgUpdate struct {
 
 // DuploInfrastructureSetting represents a Duplo infrastruture's settings
 type DuploInfrastructureSetting struct {
-	InfraName  string                 `json:"InfraName,omitempty"`
-	CustomData *[]DuploKeyStringValue `json:"CustomData,omitempty"`
+	InfraName string                 `json:"InfraName,omitempty"`
+	Setting   *[]DuploKeyStringValue `json:"Setting,omitempty"`
 }
 
-// DuploTenantConfigUpdateRequest represents a request to update a Duplo tenant's configuration
+// DuploInfrastructureSettingUpdateRequest represents a request to update a Duplo tenant's configuration
 type DuploInfrastructureSettingUpdateRequest struct {
 	Key   string `json:"Key,omitempty"`
 	State string `json:"State,omitempty"`
@@ -195,7 +187,7 @@ type DuploInfrastructureECSConfigUpdate struct {
 
 // InfrastructureList retrieves a list of infrastructures via the Duplo API.
 func (c *Client) InfrastructureList() (*[]DuploInfrastructureConfig, ClientError) {
-	list := []DuploInfrastructureConfig{}
+	var list []DuploInfrastructureConfig
 	err := c.getAPI("InfrastructureList()", "adminproxy/GetInfrastructureConfigs", &list)
 	if err != nil {
 		return nil, err
@@ -205,7 +197,7 @@ func (c *Client) InfrastructureList() (*[]DuploInfrastructureConfig, ClientError
 
 // InfrastructureGetList retrieves a list of infrastructures via the Duplo API.
 func (c *Client) InfrastructureGetList() (*[]DuploInfrastructure, ClientError) {
-	list := []DuploInfrastructure{}
+	var list []DuploInfrastructure
 	err := c.getAPI("InfrastructureGetList()", "v2/admin/InfrastructureV2", &list)
 	if err != nil {
 		return nil, err
@@ -247,7 +239,7 @@ func (c *Client) InfrastructureGetSetting(infraName string) (*DuploInfrastructur
 	if config == nil || err != nil {
 		return nil, err
 	}
-	return &DuploInfrastructureSetting{InfraName: config.Name, CustomData: config.CustomData}, nil
+	return &DuploInfrastructureSetting{InfraName: config.Name, Setting: config.CustomData}, nil
 }
 
 // InfrastructureReplaceSetting replaces tenant configuration metadata via the Duplo API.
@@ -256,7 +248,7 @@ func (c *Client) InfrastructureReplaceSetting(setting DuploInfrastructureSetting
 	if err != nil {
 		return err
 	}
-	return c.InfrastructureChangeSetting(setting.InfraName, existing.CustomData, setting.CustomData)
+	return c.InfrastructureChangeSetting(setting.InfraName, existing.Setting, setting.Setting)
 }
 
 // InfrastructureChangeSetting changes tenant configuration metadata via the Duplo API, using the supplied


### PR DESCRIPTION
## Change description

Deprecate `custom_data` for infrastructure settings.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1](https://app.clickup.com/t/8655600/DUPLO-9414) 

## Checklists

### Development

- [x] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
