### PR TITLE
Avoid passing empty string for ScheduleExpression.

### DIFF
--- a/duplosdk/aws_cloudwatch.go
+++ b/duplosdk/aws_cloudwatch.go
@@ -5,7 +5,7 @@ import "fmt"
 type DuploCloudWatchEventRule struct {
 	Name               string                 `json:"Name"`
 	Description        string                 `json:"Description,omitempty"`
-	ScheduleExpression string                 `json:"ScheduleExpression"`
+	ScheduleExpression string                 `json:"ScheduleExpression,omitempty"`
 	State              string                 `json:"State"`
 	Tags               *[]DuploKeyStringValue `json:"Tags,omitempty"`
 	EventBusName       string                 `json:"EventBusName,omitempty"`

--- a/duplosdk/aws_cloudwatch.go
+++ b/duplosdk/aws_cloudwatch.go
@@ -16,7 +16,7 @@ type DuploCloudWatchEventRule struct {
 type DuploCloudWatchEventRuleGetReq struct {
 	Name               string            `json:"Name"`
 	Description        string            `json:"Description,omitempty"`
-	ScheduleExpression string            `json:"ScheduleExpression"`
+	ScheduleExpression string            `json:"ScheduleExpression,omitempty"`
 	EventBusName       string            `json:"EventBusName,omitempty"`
 	RoleArn            string            `json:"RoleArn,omitempty"`
 	Arn                string            `json:"Arn,omitempty"`


### PR DESCRIPTION
- Avoid passing empty string for ScheduleExpression.