### PR TITLE
 DUPLO-11537: Set default to 512, remove Computed

### DIFF
--- a/docs/resources/aws_lambda_function.md
+++ b/docs/resources/aws_lambda_function.md
@@ -52,9 +52,9 @@ resource "duplocloud_aws_lambda_function" "myfunction" {
 
 - **description** (String) A description of the lambda function.
 - **environment** (Block List, Max: 1) Allow customization of the lambda execution environment. (see [below for nested schema](#nestedblock--environment))
-- **ephemeral_storage** (Number) The Ephemeral Storage size, in MB, that your lambda function is allowed to use at runtime.
+- **ephemeral_storage** (Number) The Ephemeral Storage size, in MB, that your lambda function is allowed to use at runtime. Defaults to `512`.
 - **handler** (String) The [entrypoint](https://docs.aws.amazon.com/lambda/latest/dg/walkthrough-custom-events-create-test-function.html) of the lambda function in your code.
-- **image_uri** (String) The docker image that holds the lambda function's code. Used (and required) only when `package_type` is `"Image"`.
+- **image_uri** (String) The docker image that holds the lambda function's code. Used (and required) only when `package_type` is `"Image"`. The image must be in a private ECR.
 - **layers** (List of String) List of Lambda Layer Version ARNs (maximum of 5) to attach to your Lambda Function.
 - **memory_size** (Number) The maximum amount of memory, in MB, that your lambda function is allowed to use at runtime. Defaults to `128`.
 - **package_type** (String) The type of lambda package.  Must be `Zip` or `Image`.  Defaults to `Zip`.

--- a/duplocloud/resource_duplo_aws_lambda_function.go
+++ b/duplocloud/resource_duplo_aws_lambda_function.go
@@ -194,8 +194,8 @@ func awsLambdaFunctionSchema() map[string]*schema.Schema {
 		"ephemeral_storage": {
 			Description:  "The Ephemeral Storage size, in MB, that your lambda function is allowed to use at runtime.",
 			Type:         schema.TypeInt,
+			Default:      512,
 			Optional:     true,
-			Computed:     true,
 			ValidateFunc: validation.IntBetween(512, 10240),
 		},
 	}

--- a/duplocloud/resource_duplo_aws_lambda_function.go
+++ b/duplocloud/resource_duplo_aws_lambda_function.go
@@ -97,7 +97,7 @@ func awsLambdaFunctionSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringLenBetween(1, 1024),
 		},
 		"image_uri": {
-			Description:  "The docker image that holds the lambda function's code. Used (and required) only when `package_type` is `\"Image\"`.",
+			Description:  "The docker image that holds the lambda function's code. Used (and required) only when `package_type` is `\"Image\"`. The image must be in a private ECR.",
 			Type:         schema.TypeString,
 			Optional:     true,
 			ValidateFunc: validation.StringLenBetween(1, 1024),


### PR DESCRIPTION
## Change description

make `ephemeral_storage` Default to 512 if not provided

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Checklists

### Development

- [x] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
