### PR TITLE
set id for state

### DIFF
--- a/duplocloud/data_source_duplo_tenant_config.go
+++ b/duplocloud/data_source_duplo_tenant_config.go
@@ -51,7 +51,7 @@ func dataSourceTenantConfigRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	// Set the fields
-	d.Set("tenant_id", duplo.TenantID)
+	d.SetId(duplo.TenantID)
 	d.Set("metadata", keyValueToState("metadata", duplo.Metadata))
 
 	log.Printf("[TRACE] dataSourceTenantConfigRead(%s): end", tenantID)


### PR DESCRIPTION
## Change description

Fix terraform state showing null fields.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Testing

1. Run `terraform apply` on the following data source

```
data "duplocloud_tenant_config" "config" {
  tenant_id     = "64813f67-7df1-438d-95ea-c3cc2b151717"
}
```

2. Run `terraform state show data.duplocloud_tenant_config.config`

```
# data.duplocloud_tenant_config.config:
data "duplocloud_tenant_config" "config" {
    id        = "64813f67-7df1-438d-95ea-c3cc2b151717"
    metadata  = [
        {
            key   = "delete_protection"
            value = "true"
        },
        {
            key   = "kms_key_rotation_enabled"
            value = "true"
        },
        {
            key   = "enable_node_to_node_encryption_for_es"
            value = "true"
        },
        {
            key   = "enforce_ssl_for_es"
            value = "true"
        },
        {
            key   = "use_latest_tls_cipher_for_es"
            value = "true"
        },
        {
            key   = "enable_ecs_cloud_watch_logging"
            value = "true"
        },
        {
            key   = "enable_alerting"
            value = "true"
        },
    ]
    tenant_id = "64813f67-7df1-438d-95ea-c3cc2b151717"
}
```

## Checklists

### Development

- [x] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
