### PR TITLE
DUPLO-11674: Fix linting errors

### DIFF
--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
@@ -352,7 +352,7 @@ func expandAsgProfile(d *schema.ResourceData) *duplosdk.DuploAsgProfile {
 }
 
 func asgtWaitUntilCapacityReady(ctx context.Context, c *duplosdk.Client, tenantID string, minInstanceCount int, asgFriendlyName string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_aws_batch_compute_environment.go
+++ b/duplocloud/resource_duplo_aws_batch_compute_environment.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -820,7 +820,7 @@ func expandLaunchTemplateSpecification(tfMap map[string]interface{}) *duplosdk.D
 }
 
 func batchComputeEnvironmentUntilDisabled(ctx context.Context, c *duplosdk.Client, tenantID string, fullname string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {
@@ -847,7 +847,7 @@ func batchComputeEnvironmentUntilDisabled(ctx context.Context, c *duplosdk.Clien
 }
 
 func batchComputeEnvironmentUntilValid(ctx context.Context, c *duplosdk.Client, tenantID string, fullname string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_aws_batch_job_queue.go
+++ b/duplocloud/resource_duplo_aws_batch_job_queue.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -338,7 +338,7 @@ func flattenBatchJobQueue(d *schema.ResourceData, c *duplosdk.Client, duplo *dup
 }
 
 func batchJobQueueUntilDisabled(ctx context.Context, c *duplosdk.Client, tenantID string, fullname string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {
@@ -365,7 +365,7 @@ func batchJobQueueUntilDisabled(ctx context.Context, c *duplosdk.Client, tenantI
 }
 
 func batchJobQueueUntilValid(ctx context.Context, c *duplosdk.Client, tenantID string, fullname string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -2026,7 +2026,7 @@ func flattenOriginShield(o *duplosdk.DuploAwsCloudfrontOriginShield) map[string]
 }
 
 func cloudfrontDistributionWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, cfdId string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {
@@ -2053,7 +2053,7 @@ func cloudfrontDistributionWaitUntilReady(ctx context.Context, c *duplosdk.Clien
 }
 
 func cloudfrontDistributionWaitUntilDisabled(ctx context.Context, c *duplosdk.Client, tenantID string, cfdId string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
+++ b/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -755,7 +755,7 @@ func validateGSIProvisionedThroughput(data map[string]interface{}, billingMode s
 }
 
 func dynamodbWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_aws_efs_file_system.go
+++ b/duplocloud/resource_duplo_aws_efs_file_system.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -323,7 +323,7 @@ func parseAwsEFSIdParts(id string) (tenantID, efsId string, err error) {
 }
 
 func efsWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, efsId string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -622,7 +622,7 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 //
 // It should be usable both post-creation and post-modification.
 func awsElasticSearchDomainWaitUntilAvailable(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:      []string{"new", "processing", "upgrade-processing", "created"},
 		Target:       []string{"available"},
 		MinTimeout:   10 * time.Second,
@@ -661,7 +661,7 @@ func awsElasticSearchDomainWaitUntilAvailable(ctx context.Context, c *duplosdk.C
 //
 // It should be usable post-modification.
 func awsElasticSearchDomainWaitUntilUnavailable(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:      []string{"created"},
 		Target:       []string{"processing", "upgrade-processing"},
 		MinTimeout:   10 * time.Second,
@@ -696,7 +696,7 @@ func awsElasticSearchDomainWaitUntilUnavailable(ctx context.Context, c *duplosdk
 //
 // It should be usable both post-creation and post-modification.
 func awsElasticSearchDomainWaitUntilDeleted(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:      []string{"waiting", "processing", "upgrade-processing"},
 		Target:       []string{"deleted"},
 		MinTimeout:   10 * time.Second,

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -590,7 +590,7 @@ func nativeHostIdParts(id string) (string, string, error) {
 
 // NativeHostWaitForCreation waits for creation of an AWS Host by the Duplo API
 func nativeHostWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID, instanceID string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_aws_mwaa_environment.go
+++ b/duplocloud/resource_duplo_aws_mwaa_environment.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -794,7 +794,7 @@ func expandAirflowConfigurationOptions(m map[string]interface{}) map[string]stri
 }
 
 func mwaaWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, mwaaFullname string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_aws_timestreamwrite_table.go
+++ b/duplocloud/resource_duplo_aws_timestreamwrite_table.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -516,7 +516,7 @@ func expandS3Configuration(l []interface{}) *duplosdk.MagneticStoreRejectedDataS
 }
 
 func timestreamTableWaitUntilActive(ctx context.Context, c *duplosdk.Client, tenantID string, name string, dbName string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_k8_node_pool.go
+++ b/duplocloud/resource_duplo_azure_k8_node_pool.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -251,7 +251,7 @@ func flattenAgentK8NodePool(d *schema.ResourceData, duplo *duplosdk.DuploAzureK8
 }
 
 func azureK8NodePoolWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_log_analytics_workspace.go
+++ b/duplocloud/resource_duplo_azure_log_analytics_workspace.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -179,7 +179,7 @@ func parseAzureLogAnalyticsWorkspaceIdParts(id string) (infraName, name string, 
 }
 
 func logAnalyticsWorkspaceWaitUntilReady(ctx context.Context, c *duplosdk.Client, infraName string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_mssql_database.go
+++ b/duplocloud/resource_duplo_azure_mssql_database.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -262,7 +262,7 @@ func flattenAzureMssqlDatabaseSku(sku *duplosdk.DuploAzureMsSqlDatabaseSku) []in
 }
 
 func mssqlDatabaseWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, serverName string, dbName string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_mssql_elasticpool.go
+++ b/duplocloud/resource_duplo_azure_mssql_elasticpool.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -244,7 +244,7 @@ func flattenAzureMssqlElasticPoolSku(sku *duplosdk.DuploAzureMsSqlDatabaseSku) [
 }
 
 func mssqlElasticPoolWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, serverName string, epName string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_mssql_server.go
+++ b/duplocloud/resource_duplo_azure_mssql_server.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -241,7 +241,7 @@ func flattenAzureMssqlServer(d *schema.ResourceData, duplo *duplosdk.DuploAzureM
 }
 
 func mssqlSeverWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_mysql_database.go
+++ b/duplocloud/resource_duplo_azure_mysql_database.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -291,7 +291,7 @@ func flattenAzureMysqlDatabase(d *schema.ResourceData, duplo *duplosdk.DuploAzur
 }
 
 func mysqlSeverWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_postgresql_database.go
+++ b/duplocloud/resource_duplo_azure_postgresql_database.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -297,7 +297,7 @@ func flattenAzurePostgresqlDatabase(d *schema.ResourceData, duplo *duplosdk.Dupl
 }
 
 func postgresqlSeverWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_recovery_services_vault.go
+++ b/duplocloud/resource_duplo_azure_recovery_services_vault.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -164,7 +164,7 @@ func parseAzureRecoveryServicesVaultIdParts(id string) (infraName, name string, 
 }
 
 func recoveryServicesVaultWaitUntilReady(ctx context.Context, c *duplosdk.Client, infraName string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_redis_cache.go
+++ b/duplocloud/resource_duplo_azure_redis_cache.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -275,7 +275,7 @@ func flattenAzureRedisCache(d *schema.ResourceData, duplo *duplosdk.DuploAzureRe
 }
 
 func redisCacheWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_sql_managed_database.go
+++ b/duplocloud/resource_duplo_azure_sql_managed_database.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -272,7 +272,7 @@ func flattenAzureSqlManagedDatabase(d *schema.ResourceData, duplo *duplosdk.Dupl
 }
 
 func sqlManagedDatabaseWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_sql_virtual_network_rule.go
+++ b/duplocloud/resource_duplo_azure_sql_virtual_network_rule.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -205,7 +205,7 @@ func flattenAzureSqlServerVnetRule(d *schema.ResourceData, duplo *duplosdk.Azure
 }
 
 func sqlServerVnetRuleeWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, serverName string, ruleName string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_storage_account.go
+++ b/duplocloud/resource_duplo_azure_storage_account.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -204,7 +204,7 @@ func flattenAzureStorageAccount(d *schema.ResourceData, duplo *duplosdk.DuploAzu
 }
 
 func storageAccountWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_virtual_machine.go
+++ b/duplocloud/resource_duplo_azure_virtual_machine.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -541,7 +541,7 @@ func flattenTags(tags *[]duplosdk.DuploKeyStringValue) []interface{} {
 }
 
 func virtualMachineWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_azure_virtual_machine_scale_set.go
+++ b/duplocloud/resource_duplo_azure_virtual_machine_scale_set.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -2428,7 +2428,7 @@ func flattenAzureRmVirtualMachineScaleSetPlan(plan *duplosdk.DuploAzureVirtualMa
 }
 
 func virtualMachineScaleSetWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_byoh.go
+++ b/duplocloud/resource_duplo_byoh.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -354,7 +354,7 @@ func flattenByohAllocationTag(d *schema.ResourceData, duploObjects *[]duplosdk.D
 }
 
 func byohWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -331,7 +331,7 @@ func flattenEcacheInstance(duplo *duplosdk.DuploEcacheInstance, d *schema.Resour
 //
 // It should be usable both post-creation and post-modification.
 func ecacheInstanceWaitUntilAvailable(ctx context.Context, c *duplosdk.Client, tenantID, name string) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending:      []string{"processing", "creating", "modifying", "rebooting cluster nodes", "snapshotting"},
 		Target:       []string{"available"},
 		MinTimeout:   10 * time.Second,

--- a/duplocloud/resource_duplo_ecs_service.go
+++ b/duplocloud/resource_duplo_ecs_service.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -728,7 +728,7 @@ func updateEcsServiceAwsLbSettings(tenantID string, name string, d *schema.Resou
 }
 
 func ecsServiceWaitUntilTargetGroupsReady(d *schema.ResourceData, ctx context.Context, c *duplosdk.Client, tenantId string, ecs *duplosdk.DuploEcsService, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -509,7 +509,7 @@ func duploInfrastructureConfigFromState(d *schema.ResourceData) duplosdk.DuploIn
 }
 
 func duploInfrastructureWaitUntilReady(ctx context.Context, c *duplosdk.Client, name string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_kafka_cluster.go
+++ b/duplocloud/resource_duplo_kafka_cluster.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -358,7 +358,7 @@ func resourceKafkaClusterDelete(ctx context.Context, d *schema.ResourceData, m i
 }
 
 func duploKafkaClusterWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID, arn string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -416,7 +416,7 @@ func parseDuploServiceLbConfigsIdParts(id string) (tenantID, name string) {
 
 // DuploServiceLBConfigsWaitForCreation waits for creation of an service's load balancer by the Duplo API
 func duploServiceLbConfigsWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID, name string) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"missing", "pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_oci_containerengine_node_pool.go
+++ b/duplocloud/resource_duplo_oci_containerengine_node_pool.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -1017,7 +1017,7 @@ func nodeToMap(duplo duplosdk.Node) map[string]interface{} {
 }
 
 func nodePoolWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, ociId string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -15,7 +15,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -505,7 +505,7 @@ func resourceDuploRdsInstanceDelete(ctx context.Context, d *schema.ResourceData,
 //
 // It should be usable both post-creation and post-modification.
 func rdsInstanceWaitUntilAvailable(ctx context.Context, c *duplosdk.Client, id string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			"processing", "backing-up", "backtracking", "configuring-enhanced-monitoring", "configuring-iam-database-auth", "configuring-log-exports", "creating",
 			"maintenance", "modifying", "moving-to-vpc", "rebooting", "renaming",
@@ -535,7 +535,7 @@ func rdsInstanceWaitUntilAvailable(ctx context.Context, c *duplosdk.Client, id s
 //
 // It should be usable post-modification.
 func rdsInstanceWaitUntilUnavailable(ctx context.Context, c *duplosdk.Client, id string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Target: []string{
 			"processing", "backing-up", "backtracking", "configuring-enhanced-monitoring", "configuring-iam-database-auth", "configuring-log-exports", "creating",
 			"maintenance", "modifying", "moving-to-vpc", "rebooting", "renaming",

--- a/duplocloud/resource_duplo_rds_read_replica.go
+++ b/duplocloud/resource_duplo_rds_read_replica.go
@@ -12,7 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -269,7 +269,7 @@ func resourceDuploRdsReadReplicaDelete(ctx context.Context, d *schema.ResourceDa
 //
 // It should be usable both post-creation and post-modification.
 func rdsReadReplicaWaitUntilAvailable(ctx context.Context, c *duplosdk.Client, id string, timeout time.Duration) error {
-	stateConf := &resource.StateChangeConf{
+	stateConf := &retry.StateChangeConf{
 		Pending: []string{
 			"processing", "backing-up", "backtracking", "configuring-enhanced-monitoring", "configuring-iam-database-auth", "configuring-log-exports", "creating",
 			"maintenance", "modifying", "moving-to-vpc", "rebooting", "renaming",

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -514,7 +515,7 @@ func getStringArray(data map[string]interface{}, key string) (*[]string, bool) {
 }
 
 func waitForResourceToBeMissingAfterDelete(ctx context.Context, d *schema.ResourceData, kind string, id string, get func() (interface{}, duplosdk.ClientError)) diag.Diagnostics {
-	err := resource.RetryContext(ctx, d.Timeout("delete"), func() *resource.RetryError {
+	err := retry.RetryContext(ctx, d.Timeout("delete"), func() *retry.RetryError {
 		resp, errget := get()
 
 		if errget != nil {
@@ -522,11 +523,11 @@ func waitForResourceToBeMissingAfterDelete(ctx context.Context, d *schema.Resour
 				return nil
 			}
 
-			return resource.NonRetryableError(fmt.Errorf("error getting %s '%s': %s", kind, id, errget))
+			return retry.NonRetryableError(fmt.Errorf("error getting %s '%s': %s", kind, id, errget))
 		}
 
 		if !isInterfaceNil(resp) {
-			return resource.RetryableError(fmt.Errorf("expected %s '%s' to be missing, but it still exists", kind, id))
+			return retry.RetryableError(fmt.Errorf("expected %s '%s' to be missing, but it still exists", kind, id))
 		}
 
 		return nil
@@ -538,19 +539,19 @@ func waitForResourceToBeMissingAfterDelete(ctx context.Context, d *schema.Resour
 }
 
 func waitForResourceToBePresentAfterCreate(ctx context.Context, d *schema.ResourceData, kind string, id string, get func() (interface{}, duplosdk.ClientError)) diag.Diagnostics {
-	err := resource.RetryContext(ctx, d.Timeout("create"), func() *resource.RetryError {
+	err := retry.RetryContext(ctx, d.Timeout("create"), func() *retry.RetryError {
 		resp, errget := get()
 
 		if errget != nil {
 			if errget.Status() == 404 {
-				return resource.RetryableError(fmt.Errorf("expected %s '%s' to be retrieved, but got a 404", kind, id))
+				return retry.RetryableError(fmt.Errorf("expected %s '%s' to be retrieved, but got a 404", kind, id))
 			}
 
-			return resource.NonRetryableError(fmt.Errorf("error getting %s '%s': %s", kind, id, errget))
+			return retry.NonRetryableError(fmt.Errorf("error getting %s '%s': %s", kind, id, errget))
 		}
 
 		if isInterfaceNil(resp) {
-			return resource.RetryableError(fmt.Errorf("expected %s '%s' to be retrieved, but got: nil", kind, id))
+			return retry.RetryableError(fmt.Errorf("expected %s '%s' to be retrieved, but got: nil", kind, id))
 		}
 
 		return nil

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -14,7 +14,6 @@ import (
 	"unicode"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/structure"
@@ -638,7 +637,7 @@ func reduceNilOrEmptyMapEntries(m map[string]interface{}) {
 }
 
 func waitForResourceWithStatusDone(ctx context.Context, d *schema.ResourceData, kind string, id string, get func() (bool, duplosdk.ClientError)) diag.Diagnostics {
-	err := resource.RetryContext(ctx, d.Timeout(kind), func() *resource.RetryError {
+	err := retry.RetryContext(ctx, d.Timeout(kind), func() *retry.RetryError {
 		status, errget := get()
 
 		if errget != nil {
@@ -646,11 +645,11 @@ func waitForResourceWithStatusDone(ctx context.Context, d *schema.ResourceData, 
 				return nil
 			}
 
-			return resource.NonRetryableError(fmt.Errorf("error getting %s '%s': %s", kind, id, errget))
+			return retry.NonRetryableError(fmt.Errorf("error getting %s '%s': %s", kind, id, errget))
 		}
-		// return nil if want to complete wait
+		// return nil if we want to complete wait
 		if !status {
-			return resource.RetryableError(fmt.Errorf("expected %s '%s' to be missing, but it still exists", kind, id))
+			return retry.RetryableError(fmt.Errorf("expected %s '%s' to be missing, but it still exists", kind, id))
 		}
 
 		return nil


### PR DESCRIPTION
## Change description

`resource.StateChangeConf` deprecated
`resource.NonRetryableError` deprecated
`resource.RetryableError` deprecated

https://github.com/duplocloud/terraform-provider-duplocloud/actions/runs/6354751035

resource package has an `aliases.go` file that calls the function from the retry package

```go
package resource

import (
	"context"
	"time"

	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/id"
	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
)

// Deprecated: Use helper/id package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
const UniqueIdPrefix = id.UniqueIdPrefix

// Helper for a resource to generate a unique identifier w/ default prefix
//
// Deprecated: Use helper/id package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
func UniqueId() string {
	return id.UniqueId()
}

// Deprecated: Use helper/id package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
const UniqueIDSuffixLength = id.UniqueIDSuffixLength

// Helper for a resource to generate a unique identifier w/ given prefix
//
// After the prefix, the ID consists of an incrementing 26 digit value (to match
// previous timestamp output).  After the prefix, the ID consists of a timestamp
// and an incrementing 8 hex digit value The timestamp means that multiple IDs
// created with the same prefix will sort in the order of their creation, even
// across multiple terraform executions, as long as the clock is not turned back
// between calls, and as long as any given terraform execution generates fewer
// than 4 billion IDs.
//
// Deprecated: Use helper/id package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
func PrefixedUniqueId(prefix string) string {
	return id.PrefixedUniqueId(prefix)
}

// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
type NotFoundError = retry.NotFoundError

// UnexpectedStateError is returned when Refresh returns a state that's neither in Target nor Pending
//
// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
type UnexpectedStateError = retry.UnexpectedStateError

// TimeoutError is returned when WaitForState times out
//
// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
type TimeoutError = retry.TimeoutError

// StateRefreshFunc is a function type used for StateChangeConf that is
// responsible for refreshing the item being watched for a state change.
//
// It returns three results. `result` is any object that will be returned
// as the final object after waiting for state change. This allows you to
// return the final updated object, for example an EC2 instance after refreshing
// it. A nil result represents not found.
//
// `state` is the latest state of that object. And `err` is any error that
// may have happened while refreshing the state.
//
// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
type StateRefreshFunc = retry.StateRefreshFunc

// StateChangeConf is the configuration struct used for `WaitForState`.
//
// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
type StateChangeConf = retry.StateChangeConf

// RetryFunc is the function retried until it succeeds.
//
// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
type RetryFunc = retry.RetryFunc

// RetryContext is a basic wrapper around StateChangeConf that will just retry
// a function until it no longer returns an error.
//
// Cancellation from the passed in context will propagate through to the
// underlying StateChangeConf
//
// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
func RetryContext(ctx context.Context, timeout time.Duration, f RetryFunc) error {
	return retry.RetryContext(ctx, timeout, f)
}

// Retry is a basic wrapper around StateChangeConf that will just retry
// a function until it no longer returns an error.
//
// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
func Retry(timeout time.Duration, f RetryFunc) error {
	return retry.Retry(timeout, f)
}

// RetryError is the required return type of RetryFunc. It forces client code
// to choose whether or not a given error is retryable.
//
// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
type RetryError = retry.RetryError

// RetryableError is a helper to create a RetryError that's retryable from a
// given error. To prevent logic errors, will return an error when passed a
// nil error.
//
// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
func RetryableError(err error) *RetryError {
	r := retry.RetryableError(err)

	return &RetryError{
		Err:       r.Err,
		Retryable: r.Retryable,
	}
}

// NonRetryableError is a helper to create a RetryError that's _not_ retryable
// from a given error. To prevent logic errors, will return an error when
// passed a nil error.
//
// Deprecated: Use helper/retry package instead. This is required for migrating acceptance
// testing to terraform-plugin-testing.
func NonRetryableError(err error) *RetryError {
	r := retry.NonRetryableError(err)

	return &RetryError{
		Err:       r.Err,
		Retryable: r.Retryable,
	}
}

```

## Checklists

### Development

- [x] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [x] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [x] Automated tests covering modified code pass

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
