### PR TITLE
make `storage_type` Computed = true

### DIFF
--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -162,6 +162,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			Description: "Valid values: gp2 | gp3 | io1 | standard. Storage type to be used for RDS instance storage.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 			ValidateFunc: validation.StringInSlice(
 				[]string{"gp2", "gp3", "io1", "standard"},
 				false,


### PR DESCRIPTION
## Testing

### Before change
```
  # duplocloud_rds_instance.theirdb will be updated in-place
  ~ resource "duplocloud_rds_instance" "theirdb" {
        id                  = "v2/subscriptions/09da93de-cfc0-42bc-9cc5-5f11de485cd2/RDSDBInstance/retestbug1"
        name                = "retestbug1"
      - storage_type        = "aurora" -> null
        # (19 unchanged attributes hidden)
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

### After change
```
╰─ terraform apply              
random_password.mypassword: Refreshing state... [id=none]
duplocloud_rds_instance.theirdb: Refreshing state... [id=v2/subscriptions/09da93de-cfc0-42bc-9cc5-5f11de485cd2/RDSDBInstance/retestbug1]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```