### PR TITLE
DUPLO feat: allow provider development with debuggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ backend.tf
 .terraform.lock.hcl  # <== normally do NOT ignore this - but we are testing the provider
 dist/
 my-testing/**
+
+main.tf
+__debug_bin*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Debug Terraform Provider",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            // this assumes your workspace is the root of the repo
+            "program": "${workspaceFolder}",
+            "env": {},
+            "args": [
+                "-debug",
+            ]
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,6 @@
             "type": "go",
             "request": "launch",
             "mode": "debug",
-            // this assumes your workspace is the root of the repo
             "program": "${workspaceFolder}",
             "env": {},
             "args": [

--- a/README.md
+++ b/README.md
@@ -20,13 +20,36 @@ cd examples/service
 terraform init && terraform apply
 ```
 
-### Using debug output during execution.
+### Debugging
+
+#### Using debug output during execution
 
 ``` shell
 export TF_LOG_PATH=duplo.log
 export TF_LOG=TRACE
 terraform init && terraform apply
 ```
+
+#### Using a debugger on VS code
+
+Reference documentation [here](https://developer.hashicorp.com/terraform/plugin/debugging#debugger-based-debugging)
+
+1. Install the VS code [GO extension](https://marketplace.visualstudio.com/items?itemName=golang.go)
+2. Go to VS code debug tab and start a new debug session for the terraform provider. You should see something similar to the output below in the console:
+```
+Starting: /Users/matheusbafutto/go/bin/dlv dap --listen=127.0.0.1:55046 --log-dest=3 from /Users/matheusbafutto/Desktop/duplocloud/terraform-provider-duplocloud
+DAP server listening at: 127.0.0.1:55046
+Type 'dlv help' for list of commands.
+Provider started. To attach Terraform CLI, set the TF_REATTACH_PROVIDERS environment variable with the following:
+
+	TF_REATTACH_PROVIDERS='{"registry.terraform.io/duplocloud/duplocloud":{"Protocol":"grpc","ProtocolVersion":5,"Pid":79817,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/32/bgvj1ynd6p16109l4t7sx4jm0000gn/T/plugin2604224326"}}}'
+```
+3. Copy `TF_REATTACH_PROVIDERS` to your clipboard and a terminal session to run the terraform commands
+4. Run the terraform apply command like the following:
+```
+TF_REATTACH_PROVIDERS='{"registry.terraform.io/duplocloud/duplocloud":{"Protocol":"grpc","ProtocolVersion":5,"Pid":79817,"Test":true,"Addr":{"Network":"unix","String":"/var/folders/32/bgvj1ynd6p16109l4t7sx4jm0000gn/T/plugin2604224326"}}}' terraform apply
+```
+5. Happy debugging!
 
 ## Installing and running project on WSL2
 *Assumptions*

--- a/main.go
+++ b/main.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"flag"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
@@ -18,9 +20,18 @@ import (
 //go:generate go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs
 
 func main() {
-	plugin.Serve(&plugin.ServeOpts{
+	var debug bool
+
+	flag.BoolVar(&debug, "debug", false, "set to true to run the provider with support for debuggers like delve")
+	flag.Parse()
+
+	opts := &plugin.ServeOpts{
+		Debug:        debug,
+		ProviderAddr: "registry.terraform.io/duplocloud/duplocloud",
 		ProviderFunc: func() *schema.Provider {
 			return duplocloud.Provider()
 		},
-	})
+	}
+
+	plugin.Serve(opts)
 }


### PR DESCRIPTION
## Change description

We currently debug this provider using a log strategy which I think presents several drawbacks like the following:

1. Relevant logs in the output file are usually mixed with a lot of noise logs we are not really interested in
2. Rerunning the provider after changes requires running a bunch of commands to removing tf lock files, existing plugins and make a new local installation of the provider.

The debugger setup allow us to define breakpoints and get laser focused information in regards to what we want to inspect. Debugger development helps avoid having to remove and re-install the provider locally after every code change.

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

## Checklists

### Development

- [x] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [x] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
