### PR TITLE
DUPLO-13203 support for duplocloud_aws_host.allocated_public_ip

### DIFF
--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -366,12 +366,12 @@ func setNetworkInterfaces(rq *duplosdk.DuploNativeHost, c *duplosdk.Client) diag
 	}
 
 	if err != nil {
-		return diag.Errorf("Error creating AWS host '%s': failed to get %s subnets for tenant '%s'"+
+		return diag.Errorf("Error creating AWS host '%s': failed to get %s subnets for tenant '%s' "+
 			"Internal error: %s", rq.FriendlyName, orientation, rq.TenantID, err)
 	}
 
 	if len(subnetIds) == 0 {
-		return diag.Errorf("Error creating AWS host '%s': no %s subnets were found for tenant '%s'"+
+		return diag.Errorf("Error creating AWS host '%s': no %s subnets were found for tenant '%s' "+
 			rq.FriendlyName, orientation, rq.TenantID)
 	}
 

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -310,8 +310,15 @@ func resourceAwsHostCreate(ctx context.Context, d *schema.ResourceData, m interf
 	rq := expandNativeHost(d)
 	log.Printf("[TRACE] resourceAwsHostCreate(%s, %s): start", rq.TenantID, rq.FriendlyName)
 
-	// Create the host in Duplo.
 	c := m.(*duplosdk.Client)
+
+	// Set the NetworkInterfaces property as needed.
+	diags := setNetworkInterfaces(rq, c)
+	if diags != nil {
+		return diags
+	}
+
+	// Create the host in Duplo.
 	rp, err := c.NativeHostCreate(rq)
 	if err != nil {
 		return diag.Errorf("Error creating AWS host '%s': %s", rq.FriendlyName, err)
@@ -322,7 +329,7 @@ func resourceAwsHostCreate(ctx context.Context, d *schema.ResourceData, m interf
 
 	// Wait up to 60 seconds for Duplo to be able to return the host details.
 	id := fmt.Sprintf("v2/subscriptions/%s/NativeHostV2/%s", rp.TenantID, rp.InstanceID)
-	diags := waitForResourceToBePresentAfterCreate(ctx, d, "AWS host", id, func() (interface{}, duplosdk.ClientError) {
+	diags = waitForResourceToBePresentAfterCreate(ctx, d, "AWS host", id, func() (interface{}, duplosdk.ClientError) {
 		return c.NativeHostGet(rp.TenantID, rp.InstanceID)
 	})
 	if diags != nil {
@@ -342,6 +349,69 @@ func resourceAwsHostCreate(ctx context.Context, d *schema.ResourceData, m interf
 	diags = resourceAwsHostRead(ctx, d, m)
 	log.Printf("[TRACE] resourceAwsHostCreate(%s, %s): end", rq.TenantID, rq.FriendlyName)
 	return diags
+}
+
+func setNetworkInterfaces(rq *duplosdk.DuploNativeHost, c *duplosdk.Client) diag.Diagnostics {
+	// Handle subnet selection for hosts
+	var subnetIds []string
+	var err duplosdk.ClientError
+	var orientation string
+
+	if rq.AllocatedPublicIP {
+		orientation = "external"
+		subnetIds, err = c.TenantGetExternalSubnets(rq.TenantID)
+	} else {
+		orientation = "internal"
+		subnetIds, err = c.TenantGetInternalSubnets(rq.TenantID)
+	}
+
+	if err != nil {
+		return diag.Errorf("Error creating AWS host '%s': failed to get %s subnets for tenant '%s'"+
+			"Internal error: %s", rq.FriendlyName, orientation, rq.TenantID, err)
+	}
+
+	if len(subnetIds) == 0 {
+		return diag.Errorf("Error creating AWS host '%s': no %s subnets were found for tenant '%s'"+
+			rq.FriendlyName, orientation, rq.TenantID)
+	}
+
+	if rq.Zone < 0 || rq.Zone >= len(subnetIds) {
+		return diag.Errorf("Error creating AWS host '%s': zone %d is invalid. zone must be between 0 and %d.",
+			rq.FriendlyName, rq.Zone, len(subnetIds))
+	}
+
+	subnetId := subnetIds[rq.Zone]
+
+	// When AllocatedPublicIP is true, ensure there is at least one network interface
+	if rq.AllocatedPublicIP && (rq.NetworkInterfaces == nil || len(*rq.NetworkInterfaces) == 0) {
+		// No network interfaces, create a new one on the external subnet for the given zone.
+		rq.NetworkInterfaces = &[]duplosdk.DuploNativeHostNetworkInterface{{
+			SubnetID: subnetId,
+		}}
+	}
+
+	if rq.NetworkInterfaces == nil {
+		return nil
+	}
+
+	// Ensure all network interfaces without an ID are using the correct subnet
+	for idx, niConfig := range *rq.NetworkInterfaces {
+		if niConfig.NetworkInterfaceID != "" && niConfig.SubnetID != "" {
+			return diag.Errorf("Error creating AWS host '%s': a subnetId on network interface %d cannot be specified since network_interface_id '%s' is provided",
+				rq.FriendlyName, idx, niConfig.NetworkInterfaceID)
+		}
+
+		if niConfig.NetworkInterfaceID == "" {
+			if niConfig.SubnetID == "" {
+				niConfig.SubnetID = subnetId
+			} else if niConfig.SubnetID != subnetId {
+				return diag.Errorf("Error creating AWS host '%s': %s subnetId on network interface %d for zone %d must be '%s' instead of '%s'",
+					rq.FriendlyName, orientation, idx, rq.Zone, subnetId, niConfig.SubnetID)
+			}
+		}
+	}
+
+	return nil
 }
 
 // UPDATE resource


### PR DESCRIPTION
## Change description

Adds support for the `allocated_public_ip` attribute on the `duplocloud_aws_host`. Previously, this attribute was only a passthrough value for the resource to the Duplo API. However, the Duplo API does not rely on this flag when determining the configuration of the network interface controller.

### New Features

1. If the `allocated_public_ip` property is set to true (default is false) and there is no `NetworkInterface` config provided in the `NetworkInterfaces` attribute, then a `NetworkInterface` config is created for it with the `subnet_id` attribute set to be the tenant's external subnet assigned to the provided `zone` (default zone is 0).
2. For all existing `NetworkInterface` configs, if the `network_interface_id` was left blank, the `subnet_id` attribute is set to be the tenant's subnet assigned to the provided `zone` (default zone is 0). If the `allocated_public_ip` attribute was true, the external subnet ID for the zone is used and if it is false, the internal subnet ID for the zone is used.

### New Validation

1. If a subnet ID is provided for a `NetworkInterface` config by the user and it conflicts with either the `zone` attribute or the `allocated_public_ip` attribute, an error is returned.  In detail, this means that either the subnet is not in that `zone`, it is an external subnet when the `allocated_public_ip` attribute is true, or it is an internal subnet when the `allocated_public_ip` attribute is false.
2. If the tenant ID seems to be invalid when retrieving subnets or no subnets were found, an error is returned.
3. If the zone is out-of-range, an error is returned.

### Edge Cases

1. If there are one more more `NetworkInterface` configs provided by the user and all of them have the `network_interface_id` attribute set, then the `allocated_public_ip` attribute will have no effect.
2. If the `network_interface_id` attribute is not set, the subnet ID will be set according to the discovery logic outlined above. If there is another `NetworkInterface` config that has the `network_interface_id` attribute set alongside a config that does not (e.g. multiple `NetworkInterface` configs, mixed), the subnet ID of the interface without a `network_interface_id` will still be set according to the discovery logic outlined above without regard to how the interface referenced by ID is configured.


## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [DUPLO-13203](https://app.clickup.com/t/8655600/DUPLO-13203) TF: duplocloud_aws_host: allocated_public_ip
