### PR TITLE
DUPLO-13535 fix: remove MaxItems which errors out for computed fields

### DIFF
--- a/duplocloud/data_source_duplo_plan_settings.go
+++ b/duplocloud/data_source_duplo_plan_settings.go
@@ -22,7 +22,6 @@ func duploComputedPlanSettingsSchema() map[string]*schema.Schema {
 		"dns_setting": {
 			Type:     schema.TypeList,
 			Computed: true,
-			MaxItems: 1,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"domain_id": {


### PR DESCRIPTION
* data source duplocloud_plan_settings: dns_setting: MaxItems is for configurable attributes,there's nothing to configure on computed-only field

## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
