### PR TITLE
DUPLO-13535 fix: allow global DNS config to be retrieved from plan config data source

### DIFF
--- a/duplocloud/data_source_duplo_plan_settings.go
+++ b/duplocloud/data_source_duplo_plan_settings.go
@@ -19,6 +19,11 @@ func duploComputedPlanSettingsSchema() map[string]*schema.Schema {
 			Type:     schema.TypeBool,
 			Computed: true,
 		},
+		"include_global_dns": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  true,
+		},
 		"dns_setting": {
 			Type:     schema.TypeList,
 			Computed: true,
@@ -74,10 +79,11 @@ func dataSourcePlanSettingsRead(ctx context.Context, d *schema.ResourceData, m i
 
 	// Get plan DNS config.  If the config is "global", that means there is no plan DNS config.
 	dns, err := c.PlanGetDnsConfig(planID)
+	includeGlobalDns := d.Get("include_global_dns").(bool)
 	if err != nil {
 		return diag.Errorf("failed to retrieve plan DNS config for '%s': %s", planID, err)
 	}
-	if dns != nil && dns.IsGlobalDNS {
+	if dns != nil && dns.IsGlobalDNS && !includeGlobalDns {
 		dns = nil
 	}
 


### PR DESCRIPTION
## Change description

Allow global dns setting exposure conditionally based on new config flag for plan settings datasource

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
