### PR TITLE
[DUPLO-13533] : [TF] ElasticSearch storage options support

### DIFF
--- a/duplosdk/aws_elasticsearch.go
+++ b/duplosdk/aws_elasticsearch.go
@@ -70,7 +70,7 @@ type DuploElasticSearchDomain struct {
 	CognitoOptions              DuploEnabled                                 `json:"CognitoOptions,omitempty"`
 	DomainEndpointOptions       DuploElasticSearchDomainEndpointOptions      `json:"DomainEndpointOptions,omitempty"`
 	EBSOptions                  DuploElasticSearchDomainEBSOptions           `json:"EBSOptions,omitempty"`
-	ClusterConfig               DuploElasticSearchDomainClusterConfig        `json:"ElasticsearchClusterConfig,omitempty"`
+	ClusterConfig               DuploElasticSearchDomainClusterConfig        `json:"ClusterConfig,omitempty"`
 	NodeToNodeEncryptionOptions DuploEnabled                                 `json:"NodeToNodeEncryptionOptions,omitempty"`
 	ElasticSearchVersion        string                                       `json:"ElasticsearchVersion,omitempty"`
 	EncryptionAtRestOptions     DuploElasticSearchDomainEncryptAtRestOptions `json:"EncryptionAtRestOptions,omitempty"`

--- a/duplosdk/aws_elasticsearch.go
+++ b/duplosdk/aws_elasticsearch.go
@@ -35,11 +35,19 @@ type DuploElasticSearchDomainEndpointOptions struct {
 
 // DuploElasticSearchDomainClusterConfig represents an AWS ElasticSearch domain's endpoint options for a Duplo tenant
 type DuploElasticSearchDomainClusterConfig struct {
-	DedicatedMasterCount   int               `json:"DedicatedMasterCount,omitempty"`
-	DedicatedMasterEnabled bool              `json:"DedicatedMasterEnabled,omitempty"`
-	DedicatedMasterType    *DuploStringValue `json:"DedicatedMasterType,omitempty"`
-	InstanceCount          int               `json:"InstanceCount,omitempty"`
-	InstanceType           DuploStringValue  `json:"InstanceType,omitempty"`
+	DedicatedMasterCount   int                                        `json:"DedicatedMasterCount,omitempty"`
+	DedicatedMasterEnabled bool                                       `json:"DedicatedMasterEnabled,omitempty"`
+	DedicatedMasterType    DuploStringValue                           `json:"DedicatedMasterType,omitempty"`
+	InstanceCount          int                                        `json:"InstanceCount,omitempty"`
+	InstanceType           DuploStringValue                           `json:"InstanceType,omitempty"`
+	WarmCount              int                                        `json:"WarmCount,omitempty"`
+	WarmEnabled            bool                                       `json:"WarmEnabled,omitempty"`
+	WarmType               DuploStringValue                           `json:"WarmType,omitempty"`
+	ColdStorageOptions     DuploElasticSearchDomainColdStorageOptions `json:"ColdStorageOptions,omitempty"`
+}
+
+type DuploElasticSearchDomainColdStorageOptions struct {
+	Enabled bool `json:"Enabled,omitempty"`
 }
 
 // DuploElasticSearchDomainSnapshotOptions represents an AWS ElasticSearch domain's endpoint options for a Duplo tenant


### PR DESCRIPTION
## Change description

[DUPLO-13533] : [TF] ElasticSearch storage options support

## Type of change
- [ ] Added support for ElasticSearch storage options support
- [ ] Fixed existing bug

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable

### Testing
```resource "duplocloud_aws_elasticsearch" "example" {
  name      = "kk7"
  tenant_id = var.tenant_id
  elasticsearch_version = "OpenSearch_2.11"
  selected_zone=1

  cluster_config {
    instance_type = "c5.large.search"
    dedicated_master_count = 3
    dedicated_master_enabled = true
    dedicated_master_type = "c5.large.search"
    cold_storage_options {
      enabled = true
    }
    warm_type = "ultrawarm1.medium.search"
    warm_enabled = true
    warm_count = 2

  }

}```
