### PR TITLE
DUPLO-14597: forces recreation on changes to is_cluster_autoscaled and can_scale_from_zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,8 @@
 ## 2024-01-23
 
 ### Fixed
-- Corrected a typo in the tenant data source read function in `duplocloud/data_source_duplo_tenant.go`.
-- Enhanced the autoscaling group schema by forcing a new resource to be created when `is_cluster_autoscaled` and `can_scale_from_zero` attributes are changed.
-
-## 2024-01-23
+- Corrected a typo in `duplocloud_tenant` data source read function (tenant_id is the id naming for the resource but datasource calls it "id").
+- Enhanced schema for `duplocloud_asg_profile` resource by forcing recreation when `is_cluster_autoscaled` and `can_scale_from_zero` attributes are changed.
 
 ### Added
 - Introduced a new attribute `can_scale_from_zero` to the `duplocloud_asg_profile` resource, allowing an AWS Autoscaling Group to leverage DuploCloud's scale from zero feature on Amazon EKS.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 2024-01-23
 
+### Fixed
+- Corrected a typo in the tenant data source read function in `duplocloud/data_source_duplo_tenant.go`.
+- Enhanced the autoscaling group schema by forcing a new resource to be created when `is_cluster_autoscaled` and `can_scale_from_zero` attributes are changed.
+
+## 2024-01-23
+
 ### Added
 - Introduced a new attribute `can_scale_from_zero` to the `duplocloud_asg_profile` resource, allowing an AWS Autoscaling Group to leverage DuploCloud's scale from zero feature on Amazon EKS.
 

--- a/duplocloud/data_source_duplo_tenant.go
+++ b/duplocloud/data_source_duplo_tenant.go
@@ -75,7 +75,7 @@ func dataSourceTenantRead(d *schema.ResourceData, m interface{}) error {
 	log.Printf("[TRACE] dataSourceTenantRead(): start")
 
 	var tenantID, tenantName string
-	if v, ok := d.GetOk("tenant_id"); ok && v != nil {
+	if v, ok := d.GetOk("id"); ok && v != nil {
 		tenantID = v.(string)
 	} else if v, ok := d.GetOk("name"); ok && v != nil {
 		tenantName = v.(string)

--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -79,6 +79,7 @@ func autoscalingGroupSchema() map[string]*schema.Schema {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Computed:    true,
+		ForceNew:    true,
 	}
 
 	awsASGSchema["can_scale_from_zero"] = &schema.Schema{
@@ -86,6 +87,7 @@ func autoscalingGroupSchema() map[string]*schema.Schema {
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Computed:    true,
+		ForceNew:    true,
 	}
 
 	awsASGSchema["fullname"] = &schema.Schema{


### PR DESCRIPTION
## **User description**
## Change description

- Changing the key from "tenant_id" to "id" as the field name differs between the resource schema and its datasource counterpart
- Added "ForceNew: true" to the "is_cluster_autoscaled" and "can_scale_from_zero" attributes. This forces a new resource to be created when these attributes are changed.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

No related issues

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


___

## **Type**
Bug fix, Enhancement


___

## **Description**
- This PR primarily addresses two issues. 
- First, it fixes a bug in the `dataSourceTenantRead` function in `duplocloud/data_source_duplo_tenant.go` where the key "tenant_id" was incorrectly used instead of "id". 
- Second, it enhances the `autoscalingGroupSchema` function in `duplocloud/resource_duplo_asg_profile.go` by forcing a new resource to be created when the "is_cluster_autoscaled" and "can_scale_from_zero" attributes are changed. 
- The changes have been documented in the CHANGELOG.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_source_duplo_tenant.go</strong><dd><code>Refactor tenant data source read function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/data_source_duplo_tenant.go

- Changed the key from "tenant_id" to "id" in the `dataSourceTenantRead` <br>  function.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/377/files#diff-cd8ffc174ea8062193f288dbe3f51491bac3ffde9573ea564474e13308e3539d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_asg_profile.go</strong><dd><code>Enforce resource replacement for autoscaling attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_asg_profile.go

- Added "ForceNew: true" to the "is_cluster_autoscaled" and <br>  "can_scale_from_zero" attributes in the `autoscalingGroupSchema` <br>  function.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/377/files#diff-f58c7134634373bfbd4607fa72e0d5fb28a0da60d136394bacd5671ea75c8346">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update CHANGELOG with recent fixes and enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
CHANGELOG.md

- Added entries for the changes made in <br>  `duplocloud/data_source_duplo_tenant.go` and <br>  `duplocloud/resource_duplo_asg_profile.go`.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/377/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
