### PR TITLE
[DUPLO-14321] : TF: Doc: duplocloud_duplo_service, cloud parameter value for gcp missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-01-24
+
+### Updated
+- Enhanced the documentation for `cloud` and `agent_platform` fields in the `duplocloud_duplo_service` resource. The description now includes a list of numeric IDs representing different cloud providers and container agents respectively.
+
 ## 2024-01-23
 
 ### Updated

--- a/docs/data-sources/asg_profiles.md
+++ b/docs/data-sources/asg_profiles.md
@@ -32,6 +32,7 @@ Read-Only:
 - `agent_platform` (Number)
 - `allocated_public_ip` (Boolean)
 - `base64_user_data` (String)
+- `can_scale_from_zero` (Boolean)
 - `capacity` (String)
 - `cloud` (Number)
 - `encrypt_disk` (Boolean)

--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -54,6 +54,7 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 - `agent_platform` (Number) The numeric ID of the container agent pool that this host is added to. Defaults to `0`.
 - `allocated_public_ip` (Boolean) Whether or not to allocate a public IP. Defaults to `false`.
 - `base64_user_data` (String) Base64 encoded EC2 user data to associated with the host.
+- `can_scale_from_zero` (Boolean) Whether or not ASG should leverage duplocloud's scale from 0 feature
 - `cloud` (Number) The numeric ID of the cloud provider to launch the host in. Defaults to `0`.
 - `encrypt_disk` (Boolean) Defaults to `false`.
 - `instance_count` (Number) The number of instances that should be running in the group.

--- a/docs/resources/duplo_service.md
+++ b/docs/resources/duplo_service.md
@@ -99,7 +99,18 @@ Should be one of:
  Defaults to `0`.
 - `allocation_tags` (String)
 - `any_host_allowed` (Boolean) Whether or not the service can run on hosts in other tenants (within the the same plan as the current tenant). Defaults to `false`.
-- `cloud` (Number) The numeric ID of the cloud provider to launch the service in. Defaults to `0`.
+- `cloud` (Number) The numeric ID of the cloud provider to launch the service in.
+Should be one of:
+
+   - `0` : AWS (Default)
+   - `1` : Oracle
+   - `2` : Azure
+   - `3` : Google
+   - `4` : Byoh
+   - `5` : Unknown
+   - `6` : DigitalOcean
+   - `10` : OnPrem
+ Defaults to `0`.
 - `cloud_creds_from_k8s_service_account` (Boolean) Whether or not the service gets it's cloud credentials from Kubernetes service account. Defaults to `false`.
 - `commands` (String)
 - `extra_config` (String)

--- a/docs/resources/infrastructure.md
+++ b/docs/resources/infrastructure.md
@@ -49,6 +49,7 @@ Should be one of:
 - `delete_unspecified_settings` (Boolean) Whether or not this resource should delete any settings not specified by this resource. **WARNING:**  It is not recommended to change the default value of `false`. Defaults to `false`.
 - `enable_container_insights` (Boolean) Whether or not to enable container insights for an ECS cluster.
 - `enable_ecs_cluster` (Boolean) Whether or not to provision an ECS cluster.
+- `is_serverless_kubernetes` (Boolean) Whether or not to make GKE with autopilot.
 - `setting` (Block List) A list of configuration settings to manage, expressed as key / value pairs. (see [below for nested schema](#nestedblock--setting))
 - `subnet_address_prefix` (String) The address prefixe to use for the subnet. This is applicable only for Azure
 - `subnet_cidr` (Number) The CIDR subnet size (in bits) for the automatically created subnets. This is applicable only for AWS.

--- a/duplocloud/resource_duplo_service.go
+++ b/duplocloud/resource_duplo_service.go
@@ -87,11 +87,20 @@ func duploServiceSchema() map[string]*schema.Schema {
 			Required: false,
 		},
 		"cloud": {
-			Description: "The numeric ID of the cloud provider to launch the service in.",
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Required:    false,
-			Default:     0,
+			Description: "The numeric ID of the cloud provider to launch the service in.\n" +
+				"Should be one of:\n\n" +
+				"   - `0` : AWS (Default)\n" +
+				"   - `1` : Oracle\n" +
+				"   - `2` : Azure\n" +
+				"   - `3` : Google\n" +
+				"   - `4` : Byoh\n" +
+				"   - `5` : Unknown\n" +
+				"   - `6` : DigitalOcean\n" +
+				"   - `10` : OnPrem\n",
+			Type:     schema.TypeInt,
+			Optional: true,
+			Required: false,
+			Default:  0,
 		},
 		"agent_platform": {
 			Description: "The numeric ID of the container agent to use for deployment.\n" +


### PR DESCRIPTION
## **User description**
## Change description
[DUPLO-14321] : TF: Doc: duplocloud_duplo_service, cloud parameter value for gcp missing
> Description here

## Type of change
- [ ] Added options for cloud

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


___

## **Type**
Documentation, Enhancement


___

## **Description**
- The `cloud` field in the `duploServiceSchema` function has been updated to include a more detailed description. The description now includes a list of numeric IDs representing different cloud providers (AWS, Oracle, Azure, Google, Byoh, Unknown, DigitalOcean, OnPrem).
- Similarly, the `agent_platform` field description has been updated to include numeric IDs for different container agents (Duplo Native container agent, EKS linux container agent).
- These changes enhance the documentation within the code, making it easier for developers to understand the purpose and usage of these fields.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_service.go</strong><dd><code>Enhanced Documentation for Cloud Provider and Container Agent Fields</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_service.go

- Updated the description of the `cloud` field to include the possible <br>  numeric IDs for different cloud providers.
- Updated the description of the `agent_platform` field to include the <br>  possible numeric IDs for different container agents.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/378/files#diff-8b0e85ea6e8f55632c28e6a26c555eac68afc7f03744e8e27d727cb066618098">+14/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
