### PR TITLE
DUPLO-4661: Tag based resource handling for lambda function and S3 resource.

### DIFF
--- a/duplosdk/admin.go
+++ b/duplosdk/admin.go
@@ -17,11 +17,12 @@ type DuploSystemFeatures struct {
 		DefaultVersion    string   `json:"DefaultVersion"`
 		SupportedVersions []string `json:"SupportedVersions"`
 	} `json:"EksVersions"`
-	IsOtpNeeded           bool   `json:"IsOtpNeeded"`
-	IsAwsAdminJITEnabled  bool   `json:"IsAwsAdminJITEnabled"`
-	IsDuploOpsEnabled     bool   `json:"IsDuploOpsEnabled"`
-	DevopsManagerHostname string `json:"DevopsManagerHostname"`
-	TenantNameMaxLength   int    `json:"TenantNameMaxLength"`
+	IsOtpNeeded                    bool   `json:"IsOtpNeeded"`
+	IsAwsAdminJITEnabled           bool   `json:"IsAwsAdminJITEnabled"`
+	IsDuploOpsEnabled              bool   `json:"IsDuploOpsEnabled"`
+	IsTagsBasedResourceMgmtEnabled bool   `json:"IsTagsBasedResourceMgmtEnabled"`
+	DevopsManagerHostname          string `json:"DevopsManagerHostname"`
+	TenantNameMaxLength            int    `json:"TenantNameMaxLength"`
 }
 
 // DuploAdminAwsCredentials represents just-in-time admin AWS credentials from Duplo

--- a/duplosdk/tenant_aws_cloud_resources.go
+++ b/duplosdk/tenant_aws_cloud_resources.go
@@ -434,7 +434,11 @@ func (c *Client) TenantGetApplicationLbFullName(tenantID string, name string) (s
 // TenantGetS3Bucket retrieves a managed S3 bucket via the Duplo API
 func (c *Client) TenantGetS3Bucket(tenantID string, name string) (*DuploS3Bucket, ClientError) {
 	// Figure out the full resource name.
+	features, _ := c.AdminGetSystemFeatures()
 	fullName, err := c.GetDuploServicesNameWithAws(tenantID, name)
+	if features.IsTagsBasedResourceMgmtEnabled {
+		fullName = name
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -522,6 +526,10 @@ func (c *Client) TenantDeleteS3Bucket(tenantID string, name string) ClientError 
 
 	// Get the full name of the S3 bucket
 	fullName, err := c.GetDuploServicesNameWithAws(tenantID, name)
+	features, _ := c.AdminGetSystemFeatures()
+	if features.IsTagsBasedResourceMgmtEnabled {
+		fullName = name
+	}
 	if err != nil {
 		return err
 	}
@@ -552,7 +560,11 @@ func (c *Client) TenantApplyS3BucketSettings(tenantID string, duplo DuploS3Bucke
 	apiName := fmt.Sprintf("TenantApplyS3BucketSettings(%s, %s)", tenantID, duplo.Name)
 
 	// Figure out the full resource name.
+	features, _ := c.AdminGetSystemFeatures()
 	fullName, err := c.GetDuploServicesNameWithAws(tenantID, duplo.Name)
+	if features.IsTagsBasedResourceMgmtEnabled {
+		fullName = duplo.Name
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## **User description**
## Change description

Lambda function name validation based on Tag-based resource handling is enabled or not.
S3 bucket name validation based on Tag-based resource handling is enabled or not.

## Type of change
- New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


___

## **Type**
Enhancement


___

## **Description**
- Added validation for the length of the lambda function name and S3 bucket name based on whether tag-based resource management is enabled or not in `duplocloud/resource_duplo_aws_lambda_function.go` and `duplocloud/resource_duplo_s3_bucket.go` respectively.
- Added a new field `IsTagsBasedResourceMgmtEnabled` to the `DuploSystemFeatures` struct in `duplosdk/admin.go`.
- Updated several functions in `duplosdk/tenant_aws_cloud_resources.go` to consider the `IsTagsBasedResourceMgmtEnabled` feature for resource name handling.
- Updated the changelog in `CHANGELOG.md` to reflect the new enhancements.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_lambda_function.go</strong><dd><code>Added tag-based resource management validation for lambda function name 

 length</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_aws_lambda_function.go

- Added validation for the length of the lambda function name based on <br>  whether tag-based resource management is enabled or not.
- Removed the previous validation function for the lambda function name <br>  length.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/379/files#diff-c13f14fb2a32c7d12b7beb43bd7a8d80d643b446a7def447c9774e170bb9e9e2">+11/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_s3_bucket.go</strong><dd><code>Added tag-based resource management validation for S3 bucket name length</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_s3_bucket.go

- Added validation for the length of the S3 bucket name based on whether <br>  tag-based resource management is enabled or not.
- Removed the previous validation function for the S3 bucket name <br>  length.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/379/files#diff-33c4307f72e0007e5c807624c3d14a7498e643ebb8d5d384cf357517b6f105f0">+10/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>admin.go</strong><dd><code>Added new field to DuploSystemFeatures struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/admin.go

- Added a new field `IsTagsBasedResourceMgmtEnabled` to the <br>  `DuploSystemFeatures` struct.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/379/files#diff-55491ea7dad59df933c376b35936ca5825ca6ae1c5cd3aff784a80d54dc7425e">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tenant_aws_cloud_resources.go</strong><dd><code>Updated resource name handling based on tag-based resource management 

 feature</code></dd></summary>
<hr>
      
duplosdk/tenant_aws_cloud_resources.go

- Updated several functions to consider the <br>  `IsTagsBasedResourceMgmtEnabled` feature for resource name handling.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/379/files#diff-92155358c5460b82348654a065ca4a047d7e3926595f74647c8786b1f7f02387">+12/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Updated CHANGELOG.md</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
CHANGELOG.md

- Updated the changelog to reflect the new enhancements.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/379/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+10/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
