### PR TITLE
DUPLO-13555: Added `is any host allowed`  functionality to Job and CronJob

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-02-01
+
+### Added
+- Introduced a new optional field `is_any_host_allowed` to the CronJob and Job resources, enhancing the control over host selection.
+
 
 ## 2024-01-29
 

--- a/duplocloud/resource_duplo_k8s_cron_job.go
+++ b/duplocloud/resource_duplo_k8s_cron_job.go
@@ -150,11 +150,7 @@ func resourceKubernetesCronJobV1Beta1Read(ctx context.Context, d *schema.Resourc
 	}
 	log.Printf("[INFO] Received CronJob: %#v", job)
 
-	isAnyHostAllowed, err := GetIsAnyHostAllowed(job.Metadata.Annotations)
-	if err != nil {
-		log.Printf("[DEBUG] Received error: %#v", err)
-		return diag.Errorf("Failed to read IsAnyHostAllowed on CronJob. error: %s", err)
-	}
+	isAnyHostAllowed := GetIsAnyHostAllowed(job.Metadata.Annotations)
 	job.IsAnyHostAllowed = isAnyHostAllowed
 
 	// Remove server-generated labels unless using manual selector
@@ -189,15 +185,16 @@ func resourceKubernetesCronJobV1Beta1Read(ctx context.Context, d *schema.Resourc
 	return diag.Diagnostics{}
 }
 
-func GetIsAnyHostAllowed(annotations map[string]string) (bool, error) {
+func GetIsAnyHostAllowed(annotations map[string]string) bool {
 	if val, ok := annotations["duplocloud.net/is-any-host-allowed"]; ok {
 		boolValue, err := strconv.ParseBool(val)
 		if err != nil {
-			log.Fatal(err)
+			log.Printf("[DEBUG] Received error: %#v", err)
+			boolValue = false
 		}
-		return boolValue, err
+		return boolValue
 	}
-	return false, nil
+	return false
 }
 
 func resourceKubernetesCronJobV1Beta1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/duplocloud/resource_duplo_k8s_cron_job.go
+++ b/duplocloud/resource_duplo_k8s_cron_job.go
@@ -3,11 +3,13 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"log"
 	"regexp"
+	"strconv"
 	"terraform-provider-duplocloud/duplosdk"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
@@ -50,11 +52,17 @@ func resourceKubernetesCronJobSchemaV1Beta1(readonly bool) map[string]*schema.Sc
 				Schema: cronJobSpecFieldsV1Beta1(),
 			},
 		},
+		"is_any_host_allowed": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 	}
 }
 
 func resourceKubernetesCronJobV1Beta1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	tenantId := d.Get("tenant_id").(string)
+	isAnyHostAllowed := d.Get("is_any_host_allowed").(bool)
 	log.Printf("[TRACE] resourceKubernetesJobV1Create(%s): start", tenantId)
 
 	name, err := getK8sJobName(d)
@@ -72,6 +80,7 @@ func resourceKubernetesCronJobV1Beta1Create(ctx context.Context, d *schema.Resou
 	rq.Metadata = metadata
 	rq.Spec = spec
 	rq.TenantId = tenantId
+	rq.IsAnyHostAllowed = isAnyHostAllowed
 
 	c := meta.(*duplosdk.Client)
 	err = c.K8sCronJobCreate(&rq)
@@ -88,6 +97,7 @@ func resourceKubernetesCronJobV1Beta1Create(ctx context.Context, d *schema.Resou
 
 func resourceKubernetesCronJobV1Beta1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	tenantId := d.Get("tenant_id").(string)
+	isAnyHostAllowed := d.Get("is_any_host_allowed").(bool)
 	log.Printf("[TRACE] resourceKubernetesCronJobV1Update(%s): end", tenantId)
 
 	name, err := getK8sJobName(d)
@@ -103,8 +113,9 @@ func resourceKubernetesCronJobV1Beta1Update(ctx context.Context, d *schema.Resou
 	spec.JobTemplate.ObjectMeta.Annotations = metadata.Annotations
 
 	rq := duplosdk.DuploK8sCronJob{
-		Metadata: metadata,
-		Spec:     spec,
+		Metadata:         metadata,
+		Spec:             spec,
+		IsAnyHostAllowed: isAnyHostAllowed,
 	}
 
 	// initiate update Job
@@ -139,6 +150,13 @@ func resourceKubernetesCronJobV1Beta1Read(ctx context.Context, d *schema.Resourc
 	}
 	log.Printf("[INFO] Received CronJob: %#v", job)
 
+	isAnyHostAllowed, err := GetIsAnyHostAllowed(job.Metadata.Annotations)
+	if err != nil {
+		log.Printf("[DEBUG] Received error: %#v", err)
+		return diag.Errorf("Failed to read IsAnyHostAllowed on CronJob. error: %s", err)
+	}
+	job.IsAnyHostAllowed = isAnyHostAllowed
+
 	// Remove server-generated labels unless using manual selector
 	if _, ok := d.GetOk("spec.0.manual_selector"); !ok {
 		labels := job.Metadata.Labels
@@ -169,6 +187,17 @@ func resourceKubernetesCronJobV1Beta1Read(ctx context.Context, d *schema.Resourc
 	}
 
 	return diag.Diagnostics{}
+}
+
+func GetIsAnyHostAllowed(annotations map[string]string) (bool, error) {
+	if val, ok := annotations["duplocloud.net/is-any-host-allowed"]; ok {
+		boolValue, err := strconv.ParseBool(val)
+		if err != nil {
+			log.Fatal(err)
+		}
+		return boolValue, err
+	}
+	return false, nil
 }
 
 func resourceKubernetesCronJobV1Beta1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/duplocloud/resource_duplo_k8s_job.go
+++ b/duplocloud/resource_duplo_k8s_job.go
@@ -142,11 +142,7 @@ func resourceKubernetesJobV1Read(ctx context.Context, d *schema.ResourceData, me
 	}
 	log.Printf("[INFO] Received Job: %#v", job)
 
-	isAnyHostAllowed, err := GetIsAnyHostAllowed(job.Metadata.Annotations)
-	if err != nil {
-		log.Printf("[DEBUG] Received error: %#v", err)
-		return diag.Errorf("Failed to read IsAnyHostAllowed on Job. error: %s", err)
-	}
+	isAnyHostAllowed := GetIsAnyHostAllowed(job.Metadata.Annotations)
 	job.IsAnyHostAllowed = isAnyHostAllowed
 
 	// Remove server-generated labels unless using manual selector

--- a/duplosdk/k8s_cron_job.go
+++ b/duplosdk/k8s_cron_job.go
@@ -2,6 +2,7 @@ package duplosdk
 
 import (
 	"fmt"
+
 	"k8s.io/api/batch/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -9,10 +10,11 @@ import (
 // DuploK8sCronJob represents a kubernetes job in a Duplo tenant
 type DuploK8sCronJob struct {
 	// NOTE: The TenantId field does not come from the backend - we synthesize it
-	TenantId string                `json:"-"` //nolint:govet
-	Metadata metav1.ObjectMeta     `json:"metadata"`
-	Spec     v1beta1.CronJobSpec   `json:"spec"`
-	Status   v1beta1.CronJobStatus `json:"status"`
+	TenantId         string                `json:"-"` //nolint:govet
+	Metadata         metav1.ObjectMeta     `json:"metadata"`
+	Spec             v1beta1.CronJobSpec   `json:"spec"`
+	Status           v1beta1.CronJobStatus `json:"status"`
+	IsAnyHostAllowed bool                  `json:"IsAnyHostAllowed"`
 }
 
 // K8sCronJobGetList retrieves a list of k8s jobs via the Duplo API.

--- a/duplosdk/k8s_job.go
+++ b/duplosdk/k8s_job.go
@@ -2,6 +2,7 @@ package duplosdk
 
 import (
 	"fmt"
+
 	batchv1 "k8s.io/api/batch/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -9,10 +10,11 @@ import (
 // DuploK8sJob represents a kubernetes job in a Duplo tenant
 type DuploK8sJob struct {
 	// NOTE: The TenantId field does not come from the backend - we synthesize it
-	TenantId string            `json:"-"` //nolint:govet
-	Metadata metav1.ObjectMeta `json:"metadata"`
-	Spec     batchv1.JobSpec   `json:"spec"`
-	Status   batchv1.JobStatus `json:"status"`
+	TenantId         string            `json:"-"` //nolint:govet
+	Metadata         metav1.ObjectMeta `json:"metadata"`
+	Spec             batchv1.JobSpec   `json:"spec"`
+	Status           batchv1.JobStatus `json:"status"`
+	IsAnyHostAllowed bool              `json:"IsAnyHostAllowed"`
 }
 
 // K8sJobGetList retrieves a list of k8s jobs via the Duplo API.


### PR DESCRIPTION
## **User description**
## Change description

> Added field is any host allowed to K8s Job and CronJob

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


___

## **Type**
Enhancement


___

## **Description**
- Added a new optional field `is_any_host_allowed` of type boolean to the CronJob and Job resources in the `duplocloud` package.
- The `is_any_host_allowed` field is included in the create, update and read operations of the CronJob and Job resources.
- Added a new function `GetIsAnyHostAllowed` to read the `is_any_host_allowed` value from the CronJob's and Job's metadata annotations.
- Added a new field `IsAnyHostAllowed` of type boolean to the `DuploK8sCronJob` and `DuploK8sJob` structs in the `duplosdk` package.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_k8s_cron_job.go</strong><dd><code>Added `is_any_host_allowed` field to CronJob resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_k8s_cron_job.go

- Added a new optional field `is_any_host_allowed` of type boolean to <br>  the CronJob resource.<br> - The `is_any_host_allowed` field is included in the create, update and <br>  read operations of the CronJob resource.<br> - Added a new function `GetIsAnyHostAllowed` to read the <br>  `is_any_host_allowed` value from the CronJob's metadata annotations.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/384/files#diff-1df74c0d3378c45c99ce30b338bebd4a0504ba9e2e9a7144205c3e9ada8fcdbc">+32/-3</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_k8s_job.go</strong><dd><code>Added `is_any_host_allowed` field to Job resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_k8s_job.go

- Added a new optional field `is_any_host_allowed` of type boolean to <br>  the Job resource.<br> - The `is_any_host_allowed` field is included in the create, update and <br>  read operations of the Job resource.<br> - Added a new function `GetIsAnyHostAllowed` to read the <br>  `is_any_host_allowed` value from the Job's metadata annotations.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/384/files#diff-e48a7393373ee0d9192a61abb05faeb097eac8734b334b735d07217bd62dba46">+19/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>k8s_cron_job.go</strong><dd><code>Added `IsAnyHostAllowed` field to `DuploK8sCronJob` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/k8s_cron_job.go

- Added a new field `IsAnyHostAllowed` of type boolean to the <br>  `DuploK8sCronJob` struct.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/384/files#diff-7e0d3f1695a9e33f4fecde85f6b7cb48e5a3622e93d42caa2c480de0f6513d55">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>k8s_job.go</strong><dd><code>Added `IsAnyHostAllowed` field to `DuploK8sJob` struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/k8s_job.go

- Added a new field `IsAnyHostAllowed` of type boolean to the <br>  `DuploK8sJob` struct.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/384/files#diff-1a33adcc201b24d17e117f942d74368958c89658ba6e1ee18535d2e80c9d3e91">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
