### PR TITLE
fixing bug : DUPLO-11835 -> now adds subnet only when needed (in Azure)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-02-03
+
+### Fixed
+- Resolved a bug where an empty subnet was being created in all infrastructures, which could lead to errors. Now, a subnet is only created when the infrastructure is Azure, where it is needed.
+
 
 ## 2024-01-29
 

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -478,8 +478,6 @@ func parseInfrastructureId(d *schema.ResourceData) (string, diag.Diagnostics) {
 }
 
 func duploInfrastructureConfigFromState(d *schema.ResourceData) duplosdk.DuploInfrastructureConfig {
-	subnet := duplosdk.DuploInfrastructureVnetSubnet{}
-
 	var IsServerlessKubernetes bool
 
 	// to check if boolean which is optional and doesn't have a default value there is no replacement for GetOkExist
@@ -493,12 +491,6 @@ func duploInfrastructureConfigFromState(d *schema.ResourceData) duplosdk.DuploIn
 		}
 	}
 
-	if v, ok := d.GetOk("subnet_name"); ok {
-		subnet.Name = v.(string)
-	}
-	if v, ok := d.GetOk("subnet_address_prefix"); ok {
-		subnet.AddressPrefix = v.(string)
-	}
 	config := duplosdk.DuploInfrastructureConfig{
 		Name:                    d.Get("infra_name").(string),
 		AccountId:               d.Get("account_id").(string),
@@ -518,6 +510,13 @@ func duploInfrastructureConfigFromState(d *schema.ResourceData) duplosdk.DuploIn
 
 	//Azure -> if needed only there, this subnet should be added only in Azure
 	if config.Cloud == 2 {
+		subnet := duplosdk.DuploInfrastructureVnetSubnet{}
+		if v, ok := d.GetOk("subnet_name"); ok {
+			subnet.Name = v.(string)
+		}
+		if v, ok := d.GetOk("subnet_address_prefix"); ok {
+			subnet.AddressPrefix = v.(string)
+		}
 		config.Vnet.Subnets = &[]duplosdk.DuploInfrastructureVnetSubnet{
 			subnet,
 		}

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -512,10 +512,15 @@ func duploInfrastructureConfigFromState(d *schema.ResourceData) duplosdk.DuploIn
 		Vnet: &duplosdk.DuploInfrastructureVnet{
 			AddressPrefix: d.Get("address_prefix").(string),
 			SubnetCidr:    d.Get("subnet_cidr").(int),
-			Subnets: &[]duplosdk.DuploInfrastructureVnetSubnet{
-				subnet,
-			},
+			Subnets:       &[]duplosdk.DuploInfrastructureVnetSubnet{},
 		},
+	}
+
+	//Azure -> if needed only there, this subnet should be added only in Azure
+	if config.Cloud == 2 {
+		config.Vnet.Subnets = &[]duplosdk.DuploInfrastructureVnetSubnet{
+			subnet,
+		}
 	}
 
 	if d.HasChange("setting") {


### PR DESCRIPTION
## **User description**
## Change description

> This PR prevents setting subnet in any infrastructure except Azure where it is needed. Creating an empty subnet in some infrastructures can create errors

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> DUPLO-11835

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


___

## **Type**
Bug fix


___

## **Description**
This PR addresses a bug where an empty subnet was being created in all infrastructures, which could lead to errors. The changes ensure that a subnet is only created when the infrastructure is Azure, where it is needed. This is achieved by moving the subnet creation code into an if statement that checks if the cloud is Azure.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_infrastructure.go</strong><dd><code>Restrict subnet creation to Azure infrastructure only</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_infrastructure.go

- Moved the creation of the subnet in infrastructure to an if statement, <br>  which only executes for Azure.<br> - Removed the unconditional creation of an empty subnet.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/385/files#diff-363fcab55dc64ace151151219266787d205e8ebc7656975a5909caf7a86b987f">+15/-11</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
