### PR TITLE
DUPLO-14859: add duplocloud client unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## 2024-02-06
 
 ### Added
+- Introduced comprehensive unit tests for the `getAPI`, `putAPI`, and `deleteAPI` methods in the DuploCloud SDK client, enhancing the test coverage for various scenarios including successful API calls, error handling, and response parsing.
+
+## 2024-02-06
+
+### Added
 - Introduced comprehensive unit tests for the `postAPI` method in the DuploCloud SDK client, covering various scenarios including successful API calls, error handling, and response parsing.
 - Added utility functions for creating and tearing down HTTP test servers, facilitating the simulation of API responses.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,6 @@
 ### Added
 - Introduced comprehensive unit tests for the `getAPI`, `putAPI`, and `deleteAPI` methods in the DuploCloud SDK client, enhancing the test coverage for various scenarios including successful API calls, error handling, and response parsing.
 
-## 2024-02-06
-
-### Added
-- Introduced comprehensive unit tests for the `postAPI` method in the DuploCloud SDK client, covering various scenarios including successful API calls, error handling, and response parsing.
-- Added utility functions for creating and tearing down HTTP test servers, facilitating the simulation of API responses.
-
-
 ## 2024-02-03
 
 ### Fixed
@@ -19,8 +12,6 @@
 
 ### Added
 - Introduced a new optional field `is_any_host_allowed` to the CronJob and Job resources, enhancing the control over host selection.
-
-
 
 ## 2024-01-29
 

--- a/duplosdk/client_test.go
+++ b/duplosdk/client_test.go
@@ -9,8 +9,83 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// Should call doAPIWithRequestBody with "POST", apiName, apiPath, rq, rp and return its result
-func TestPostAPI_CallDoAPIWithRequestBodyAndReturnResult(t *testing.T) {
+// Should collect a response body and deserialize it from JSON
+func TestGetAPI_ResponseExpected(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "{\"foo\":\"bar\"}")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rp := struct {
+		Foo string `json:"foo"`
+	}{}
+	result := c.getAPI("testAPI", "/test", &rp)
+
+	assert.Nil(t, result)
+	assert.Equal(t, "bar", rp.Foo)
+}
+
+// Should raise an error on invalid response JSON.
+func TestGetAPI_ResponseExpected_InvalidResponseJson(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "not JSON")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rp := struct{}{}
+	result := c.getAPI("testAPI", "/test", &rp)
+
+	invalidJsonMsg := "getAPI testAPI: cannot unmarshal response from JSON:"
+	assert.NotNil(t, result)
+	assert.True(t, strings.HasPrefix(result.Error(), invalidJsonMsg))
+}
+
+// Should support eliding a response for blank response bodies
+func TestGetAPI_ResponseElided_NoContent(t *testing.T) {
+	srv, c, err := setupClientOneshot(204, "")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	result := c.getAPI("testAPI", "/test", nil)
+
+	assert.Nil(t, result)
+}
+
+// Should support eliding a response for blank response bodies
+func TestGetAPI_ResponseElided_Null(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "null")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	result := c.getAPI("testAPI", "/test", nil)
+
+	assert.Nil(t, result)
+}
+
+// Should support eliding a response for blank response bodies
+func TestGetAPI_ResponseElided_Blank(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	result := c.getAPI("testAPI", "/test", nil)
+
+	assert.Nil(t, result)
+}
+
+// Should raise an error on invalid response JSON.
+func TestGetAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "not JSON")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	result := c.getAPI("testAPI", "/test", nil)
+
+	invalidJsonMsg := "getAPI testAPI: received unexpected response: not JSON"
+	assert.NotNil(t, result)
+	assert.True(t, strings.HasPrefix(result.Error(), invalidJsonMsg))
+}
+
+// Should collect a response body and deserialize it from JSON
+func TestPostAPI_ResponseExpected(t *testing.T) {
 	srv, c, err := setupClientOneshot(200, "{\"foo\":\"bar\"}")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
@@ -90,8 +165,8 @@ func TestPostAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
 	assert.True(t, strings.HasPrefix(result.Error(), invalidJsonMsg))
 }
 
-// Should call doAPIWithRequestBody with "PUT", apiName, apiPath, rq, rp and return its result
-func TestPutAPI_CallDoAPIWithRequestBodyAndReturnResult(t *testing.T) {
+// Should collect a response body and deserialize it from JSON
+func TestPutAPI_ResponseExpected(t *testing.T) {
 	srv, c, err := setupClientOneshot(200, "{\"foo\":\"bar\"}")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)

--- a/duplosdk/client_test.go
+++ b/duplosdk/client_test.go
@@ -97,7 +97,7 @@ func setupClientOneshot(status int, body string) (srv *httptest.Server, c *Clien
 }
 
 func teardownClient(srv *httptest.Server, c *Client) {
-	srv.Close()
+	teardownHttptest(srv)
 }
 
 /*

--- a/duplosdk/client_test.go
+++ b/duplosdk/client_test.go
@@ -1,0 +1,160 @@
+package duplosdk
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Should call doAPIWithRequestBody with "POST", apiName, apiPath, rq, rp and return its result
+func TestPostAPI_CallDoAPIWithRequestBodyAndReturnResult(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "{\"foo\":\"bar\"}")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	rp := struct {
+		Foo string `json:"foo"`
+	}{}
+	result := c.postAPI("testAPI", "/test", &rq, &rp)
+
+	assert.Nil(t, result)
+	assert.Equal(t, "bar", rp.Foo)
+}
+
+// Should raise an error on invalid response JSON.
+func TestPostAPI_ResponseExpected_InvalidResponseJson(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "not JSON")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	rp := struct{}{}
+	result := c.postAPI("testAPI", "/test", &rq, &rp)
+
+	invalidJsonMsg := "postAPI testAPI: cannot unmarshal response from JSON:"
+	assert.NotNil(t, result)
+	assert.True(t, strings.HasPrefix(result.Error(), invalidJsonMsg))
+}
+
+// Should support eliding a response for blank response bodies
+func TestPostAPI_ResponseElided_NoContent(t *testing.T) {
+	srv, c, err := setupClientOneshot(204, "")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	result := c.postAPI("testAPI", "/test", &rq, nil)
+
+	assert.Nil(t, result)
+}
+
+// Should support eliding a response for blank response bodies
+func TestPostAPI_ResponseElided_Null(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "null")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	result := c.postAPI("testAPI", "/test", &rq, nil)
+
+	assert.Nil(t, result)
+}
+
+// Should support eliding a response for blank response bodies
+func TestPostAPI_ResponseElided_Blank(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	result := c.postAPI("testAPI", "/test", &rq, nil)
+
+	assert.Nil(t, result)
+}
+
+// Should raise an error on invalid response JSON.
+func TestPostAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "not JSON")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	result := c.postAPI("testAPI", "/test", &rq, nil)
+
+	invalidJsonMsg := "postAPI testAPI: received unexpected response: not JSON"
+	assert.NotNil(t, result)
+	assert.True(t, strings.HasPrefix(result.Error(), invalidJsonMsg))
+}
+
+func setupClientOneshot(status int, body string) (srv *httptest.Server, c *Client, err error) {
+	srv = setupHttptestOneshot(status, body)
+	c, err = NewClient(srv.URL, "none")
+	return
+}
+
+func teardownClient(srv *httptest.Server, c *Client) {
+	srv.Close()
+}
+
+/*
+setupHttptestOneshot is a function that sets up a one-shot httptest server with the given status code and response body.
+
+Parameters:
+- status (int): The HTTP status code to be returned by the server.
+- body (string): The response body to be returned by the server.
+
+Returns:
+- *httptest.Server: The one-shot httptest server.
+
+Example:
+
+	server := setupHttptestOneshot(200, "Hello, World!")
+	defer teardownHttptest(server)
+*/
+func setupHttptestOneshot(status int, body string) *httptest.Server {
+	return setupHttptest(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(200)
+		res.Write([]byte(body)) // nolint
+	}))
+}
+
+/*
+setupHttptest is a function that sets up a one-shot httptest server with the given handler.
+
+Parameters:
+- handler (http.Handler): The handler to be used by the server.
+
+Returns:
+- *httptest.Server: The one-shot httptest server.
+
+Example:
+
+	server := setupHttptest(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		// handler logic
+	}))
+	defer teardownHttptest(server)
+*/
+func setupHttptest(handler http.Handler) *httptest.Server {
+	return httptest.NewServer(handler)
+}
+
+/*
+teardownHttptest is a function that closes the given httptest server.
+
+Parameters:
+- server (*httptest.Server): The httptest server to be closed.
+
+Example:
+
+	server := setupHttptest(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		// handler logic
+	}))
+	teardownHttptest(server)
+*/
+func teardownHttptest(server *httptest.Server) {
+	server.Close()
+}

--- a/duplosdk/client_test.go
+++ b/duplosdk/client_test.go
@@ -11,7 +11,7 @@ import (
 
 // Should collect a response body and deserialize it from JSON
 func TestGetAPI_ResponseExpected(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "{\"foo\":\"bar\"}")
+	srv, c, err := setupClientOneshot(t, "GET", 200, "{\"foo\":\"bar\"}")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -26,7 +26,7 @@ func TestGetAPI_ResponseExpected(t *testing.T) {
 
 // Should raise an error on invalid response JSON.
 func TestGetAPI_ResponseExpected_InvalidResponseJson(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "not JSON")
+	srv, c, err := setupClientOneshot(t, "GET", 200, "not JSON")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -40,7 +40,7 @@ func TestGetAPI_ResponseExpected_InvalidResponseJson(t *testing.T) {
 
 // Should support eliding a response for blank response bodies
 func TestGetAPI_ResponseElided_NoContent(t *testing.T) {
-	srv, c, err := setupClientOneshot(204, "")
+	srv, c, err := setupClientOneshot(t, "GET", 204, "")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -51,7 +51,7 @@ func TestGetAPI_ResponseElided_NoContent(t *testing.T) {
 
 // Should support eliding a response for blank response bodies
 func TestGetAPI_ResponseElided_Null(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "null")
+	srv, c, err := setupClientOneshot(t, "GET", 200, "null")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -62,7 +62,7 @@ func TestGetAPI_ResponseElided_Null(t *testing.T) {
 
 // Should support eliding a response for blank response bodies
 func TestGetAPI_ResponseElided_Blank(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "")
+	srv, c, err := setupClientOneshot(t, "GET", 200, "")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -73,7 +73,7 @@ func TestGetAPI_ResponseElided_Blank(t *testing.T) {
 
 // Should raise an error on invalid response JSON.
 func TestGetAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "not JSON")
+	srv, c, err := setupClientOneshot(t, "GET", 200, "not JSON")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -86,7 +86,7 @@ func TestGetAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
 
 // Should collect a response body and deserialize it from JSON
 func TestPostAPI_ResponseExpected(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "{\"foo\":\"bar\"}")
+	srv, c, err := setupClientOneshot(t, "POST", 200, "{\"foo\":\"bar\"}")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -102,7 +102,7 @@ func TestPostAPI_ResponseExpected(t *testing.T) {
 
 // Should raise an error on invalid response JSON.
 func TestPostAPI_ResponseExpected_InvalidResponseJson(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "not JSON")
+	srv, c, err := setupClientOneshot(t, "POST", 200, "not JSON")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -117,7 +117,7 @@ func TestPostAPI_ResponseExpected_InvalidResponseJson(t *testing.T) {
 
 // Should support eliding a response for blank response bodies
 func TestPostAPI_ResponseElided_NoContent(t *testing.T) {
-	srv, c, err := setupClientOneshot(204, "")
+	srv, c, err := setupClientOneshot(t, "POST", 204, "")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -129,7 +129,7 @@ func TestPostAPI_ResponseElided_NoContent(t *testing.T) {
 
 // Should support eliding a response for blank response bodies
 func TestPostAPI_ResponseElided_Null(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "null")
+	srv, c, err := setupClientOneshot(t, "POST", 200, "null")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -141,7 +141,7 @@ func TestPostAPI_ResponseElided_Null(t *testing.T) {
 
 // Should support eliding a response for blank response bodies
 func TestPostAPI_ResponseElided_Blank(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "")
+	srv, c, err := setupClientOneshot(t, "POST", 200, "")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -153,7 +153,7 @@ func TestPostAPI_ResponseElided_Blank(t *testing.T) {
 
 // Should raise an error on invalid response JSON.
 func TestPostAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "not JSON")
+	srv, c, err := setupClientOneshot(t, "POST", 200, "not JSON")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -167,7 +167,7 @@ func TestPostAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
 
 // Should collect a response body and deserialize it from JSON
 func TestPutAPI_ResponseExpected(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "{\"foo\":\"bar\"}")
+	srv, c, err := setupClientOneshot(t, "PUT", 200, "{\"foo\":\"bar\"}")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -183,7 +183,7 @@ func TestPutAPI_ResponseExpected(t *testing.T) {
 
 // Should raise an error on invalid response JSON.
 func TestPutAPI_ResponseExpected_InvalidResponseJson(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "not JSON")
+	srv, c, err := setupClientOneshot(t, "PUT", 200, "not JSON")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -198,7 +198,7 @@ func TestPutAPI_ResponseExpected_InvalidResponseJson(t *testing.T) {
 
 // Should support eliding a response for blank response bodies
 func TestPutAPI_ResponseElided_NoContent(t *testing.T) {
-	srv, c, err := setupClientOneshot(204, "")
+	srv, c, err := setupClientOneshot(t, "PUT", 204, "")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -210,7 +210,7 @@ func TestPutAPI_ResponseElided_NoContent(t *testing.T) {
 
 // Should support eliding a response for blank response bodies
 func TestPutAPI_ResponseElided_Null(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "null")
+	srv, c, err := setupClientOneshot(t, "PUT", 200, "null")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -222,7 +222,7 @@ func TestPutAPI_ResponseElided_Null(t *testing.T) {
 
 // Should support eliding a response for blank response bodies
 func TestPutAPI_ResponseElided_Blank(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "")
+	srv, c, err := setupClientOneshot(t, "PUT", 200, "")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -234,7 +234,7 @@ func TestPutAPI_ResponseElided_Blank(t *testing.T) {
 
 // Should raise an error on invalid response JSON.
 func TestPutAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
-	srv, c, err := setupClientOneshot(200, "not JSON")
+	srv, c, err := setupClientOneshot(t, "PUT", 200, "not JSON")
 	defer teardownClient(srv, c)
 	assert.Nil(t, err, err)
 
@@ -246,9 +246,9 @@ func TestPutAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
 	assert.True(t, strings.HasPrefix(result.Error(), invalidJsonMsg))
 }
 
-func setupClientOneshot(status int, body string) (srv *httptest.Server, c *Client, err error) {
-	srv = setupHttptestOneshot(status, body)
-	c, err = NewClient(srv.URL, "none")
+func setupClientOneshot(t *testing.T, expectedMethod string, status int, body string) (srv *httptest.Server, c *Client, err error) {
+	srv = setupHttptestOneshot(t, expectedMethod, status, body)
+	c, err = NewClient(srv.URL, "FAKE")
 	return
 }
 
@@ -271,8 +271,14 @@ Example:
 	server := setupHttptestOneshot(200, "Hello, World!")
 	defer teardownHttptest(server)
 */
-func setupHttptestOneshot(status int, body string) *httptest.Server {
+func setupHttptestOneshot(t *testing.T, expectedMethod string, status int, body string) *httptest.Server {
 	return setupHttptest(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		m := req.Method
+		if m == "" {
+			m = "GET"
+		}
+		assert.Equal(t, expectedMethod, m)
+		assert.Equal(t, "Bearer FAKE", req.Header.Get("Authorization"))
 		res.WriteHeader(200)
 		res.Write([]byte(body)) // nolint
 	}))

--- a/duplosdk/client_test.go
+++ b/duplosdk/client_test.go
@@ -90,6 +90,87 @@ func TestPostAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
 	assert.True(t, strings.HasPrefix(result.Error(), invalidJsonMsg))
 }
 
+// Should call doAPIWithRequestBody with "PUT", apiName, apiPath, rq, rp and return its result
+func TestPutAPI_CallDoAPIWithRequestBodyAndReturnResult(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "{\"foo\":\"bar\"}")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	rp := struct {
+		Foo string `json:"foo"`
+	}{}
+	result := c.putAPI("testAPI", "/test", &rq, &rp)
+
+	assert.Nil(t, result)
+	assert.Equal(t, "bar", rp.Foo)
+}
+
+// Should raise an error on invalid response JSON.
+func TestPutAPI_ResponseExpected_InvalidResponseJson(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "not JSON")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	rp := struct{}{}
+	result := c.putAPI("testAPI", "/test", &rq, &rp)
+
+	invalidJsonMsg := "putAPI testAPI: cannot unmarshal response from JSON:"
+	assert.NotNil(t, result)
+	assert.True(t, strings.HasPrefix(result.Error(), invalidJsonMsg))
+}
+
+// Should support eliding a response for blank response bodies
+func TestPutAPI_ResponseElided_NoContent(t *testing.T) {
+	srv, c, err := setupClientOneshot(204, "")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	result := c.putAPI("testAPI", "/test", &rq, nil)
+
+	assert.Nil(t, result)
+}
+
+// Should support eliding a response for blank response bodies
+func TestPutAPI_ResponseElided_Null(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "null")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	result := c.putAPI("testAPI", "/test", &rq, nil)
+
+	assert.Nil(t, result)
+}
+
+// Should support eliding a response for blank response bodies
+func TestPutAPI_ResponseElided_Blank(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	result := c.putAPI("testAPI", "/test", &rq, nil)
+
+	assert.Nil(t, result)
+}
+
+// Should raise an error on invalid response JSON.
+func TestPutAPI_ResponseElided_InvalidResponseJson(t *testing.T) {
+	srv, c, err := setupClientOneshot(200, "not JSON")
+	defer teardownClient(srv, c)
+	assert.Nil(t, err, err)
+
+	rq := struct{}{}
+	result := c.putAPI("testAPI", "/test", &rq, nil)
+
+	invalidJsonMsg := "putAPI testAPI: received unexpected response: not JSON"
+	assert.NotNil(t, result)
+	assert.True(t, strings.HasPrefix(result.Error(), invalidJsonMsg))
+}
+
 func setupClientOneshot(status int, body string) (srv *httptest.Server, c *Client, err error) {
 	srv = setupHttptestOneshot(status, body)
 	c, err = NewClient(srv.URL, "none")


### PR DESCRIPTION
## **User description**
## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


___

## **Type**
enhancement, tests


___

## **Description**
- Introduced comprehensive unit tests for the DuploCloud SDK client, significantly enhancing test coverage.
- Tests include scenarios for successful API calls, error handling, and response parsing for `getAPI`, `postAPI`, `putAPI`, and `deleteAPI` methods.
- Utilized `httptest` server for mocking API responses, ensuring robust testing.
- Updated CHANGELOG.md to reflect the addition of these tests.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>client_test.go</strong><dd><code>Comprehensive Unit Tests for DuploCloud SDK Client API Methods</code>&nbsp; </dd></summary>
<hr>
      
duplosdk/client_test.go

<li>Added comprehensive unit tests for <code>getAPI</code>, <code>postAPI</code>, <code>putAPI</code>, and <br><code>deleteAPI</code> methods.<br> <li> Tests cover successful API calls, error handling, and response <br>parsing.<br> <li> Utilizes <code>httptest</code> server for mocking API responses.<br> <li> Asserts include checking for correct response body parsing and error <br>messages for invalid JSON.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/386/files#diff-be97e925a8ecb5db83f803a9406d5c1c48cd5dc533b84285d3e925838ac50e98">+397/-0</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Changelog Update for Added Unit Tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
CHANGELOG.md

<li>Updated with an entry under 2024-02-06 detailing the addition of <br>comprehensive unit tests for the DuploCloud SDK client.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/386/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
