### PR TITLE
DUPLO-14602 fix: get ASG allocation tags from CustomDataTags instead of MinionTags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2024-02-06
+
+### Fixed
+- Resolved an issue where `minion_tags` in ASG profile were incorrectly fetched from `MinionTags` instead of `CustomDataTags`.
+- Reordered fields in the `DuploAsgProfile` struct for better clarity and included `CustomDataTags` and `MaxSpotPrice`.
+
 
 ## 2024-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,8 @@
 ## 2024-02-06
 
 ### Fixed
-- Resolved an issue where `minion_tags` in ASG profile were incorrectly fetched from `MinionTags` instead of `CustomDataTags`.
-- Reordered fields in the `DuploAsgProfile` struct for better clarity and included `CustomDataTags` and `MaxSpotPrice`.
-
-
-## 2024-02-06
-
-### Fixed
 - Fixed an issue where changes to allocation tags in the ASG profile were not being detected and updated correctly.
+- assigns `CustomDataTags` to AsgProfile's minion_tags fields as this field receives the tag edits in the beckend
 
 ### Added
 - Introduced comprehensive unit tests for the `getAPI`, `putAPI`, and `deleteAPI` methods in the DuploCloud SDK client, enhancing the test coverage for various scenarios including successful API calls, error handling, and response parsing.

--- a/duplocloud/data_source_duplo_asg_profile.go
+++ b/duplocloud/data_source_duplo_asg_profile.go
@@ -84,7 +84,7 @@ func flattenAsgProfile(duplo *duplosdk.DuploAsgProfile) map[string]interface{} {
 		//"status":              duplo.Status,
 		"metadata":           keyValueToState("metadata", duplo.MetaData),
 		"tags":               keyValueToState("tags", duplo.Tags),
-		"minion_tags":        keyValueToState("minion_tags", duplo.MinionTags),
+		"minion_tags":        keyValueToState("minion_tags", duplo.CustomDataTags),
 		"volumes":            flattenNativeHostVolumes(duplo.Volumes),
 		"network_interfaces": flattenNativeHostNetworkInterfaces(duplo.NetworkInterfaces),
 	}

--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -369,7 +369,7 @@ func asgProfileToState(d *schema.ResourceData, duplo *duplosdk.DuploAsgProfile) 
 	d.Set("keypair_type", duplo.KeyPairType)
 	d.Set("encrypt_disk", duplo.EncryptDisk)
 	d.Set("tags", keyValueToState("tags", duplo.Tags))
-	d.Set("minion_tags", keyValueToState("minion_tags", duplo.MinionTags))
+	d.Set("minion_tags", keyValueToState("minion_tags", duplo.CustomDataTags))
 
 	// If a network interface was customized, certain fields are not returned by the backend.
 	if v, ok := d.GetOk("network_interface"); !ok || v == nil || len(v.([]interface{})) == 0 {

--- a/duplosdk/asg.go
+++ b/duplosdk/asg.go
@@ -13,6 +13,7 @@ type DuploAsgProfile struct {
 	CanScaleFromZero    bool                               `json:"CanScaleFromZero,omitempty"`
 	Capacity            string                             `json:"Capacity,omitempty"`
 	Cloud               int                                `json:"Cloud"`
+	CustomDataTags      *[]DuploKeyStringValue             `json:"CustomDataTags"`
 	DesiredCapacity     int                                `json:"DesiredCapacity"`
 	EncryptDisk         bool                               `json:"EncryptDisk,omitempty"`
 	FriendlyName        string                             `json:"FriendlyName,omitempty"`

--- a/duplosdk/asg.go
+++ b/duplosdk/asg.go
@@ -6,34 +6,34 @@ import (
 )
 
 type DuploAsgProfile struct {
-	MinSize             int                                `json:"MinSize"`
-	MaxSize             int                                `json:"MaxSize"`
-	DesiredCapacity     int                                `json:"DesiredCapacity"`
 	AccountName         string                             `json:"AccountName,omitempty"`
-	TenantId            string                             `json:"TenantId,omitempty"`
-	FriendlyName        string                             `json:"FriendlyName,omitempty"`
-	Capacity            string                             `json:"Capacity,omitempty"`
-	Zone                int                                `json:"Zone"`
-	IsMinion            bool                               `json:"IsMinion"`
-	ImageID             string                             `json:"ImageId,omitempty"`
-	Base64UserData      string                             `json:"Base64UserData,omitempty"`
 	AgentPlatform       int                                `json:"AgentPlatform"`
-	IsEbsOptimized      bool                               `json:"IsEbsOptimized"`
 	AllocatedPublicIP   bool                               `json:"AllocatedPublicIp,omitempty"`
-	Cloud               int                                `json:"Cloud"`
-	KeyPairType         int                                `json:"KeyPairType,omitempty"`
-	IsClusterAutoscaled bool                               `json:"IsClusterAutoscaled,omitempty"`
+	Base64UserData      string                             `json:"Base64UserData,omitempty"`
 	CanScaleFromZero    bool                               `json:"CanScaleFromZero,omitempty"`
+	Capacity            string                             `json:"Capacity,omitempty"`
+	Cloud               int                                `json:"Cloud"`
+	DesiredCapacity     int                                `json:"DesiredCapacity"`
 	EncryptDisk         bool                               `json:"EncryptDisk,omitempty"`
-	Status              string                             `json:"Status,omitempty"`
-	NetworkInterfaces   *[]DuploNativeHostNetworkInterface `json:"NetworkInterfaces,omitempty"`
-	Volumes             *[]DuploNativeHostVolume           `json:"Volumes,omitempty"`
+	FriendlyName        string                             `json:"FriendlyName,omitempty"`
+	ImageID             string                             `json:"ImageId,omitempty"`
+	IsClusterAutoscaled bool                               `json:"IsClusterAutoscaled,omitempty"`
+	IsEbsOptimized      bool                               `json:"IsEbsOptimized"`
+	IsMinion            bool                               `json:"IsMinion"`
+	KeyPairType         int                                `json:"KeyPairType,omitempty"`
+	MaxSize             int                                `json:"MaxSize"`
+	MaxSpotPrice        string                             `json:"SpotPrice,omitempty"`
 	MetaData            *[]DuploKeyStringValue             `json:"MetaData,omitempty"`
-	Tags                *[]DuploKeyStringValue             `json:"Tags,omitempty"`
 	MinionTags          *[]DuploKeyStringValue             `json:"MinionTags,omitempty"`
+	MinSize             int                                `json:"MinSize"`
+	NetworkInterfaces   *[]DuploNativeHostNetworkInterface `json:"NetworkInterfaces,omitempty"`
+	Status              string                             `json:"Status,omitempty"`
+	Tags                *[]DuploKeyStringValue             `json:"Tags,omitempty"`
+	TenantId            string                             `json:"TenantId,omitempty"`
 	UseLaunchTemplate   bool                               `json:"UseLaunchTemplate"`
 	UseSpotInstances    bool                               `json:"UseSpotInstances,omitempty"`
-	MaxSpotPrice        string                             `json:"SpotPrice,omitempty"`
+	Volumes             *[]DuploNativeHostVolume           `json:"Volumes,omitempty"`
+	Zone                int                                `json:"Zone"`
 }
 
 type DuploAsgProfileDeleteReq struct {


### PR DESCRIPTION
## **User description**
## Change description

One way to resolve issue of minionTags and CustomDataTags on TF

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


___

## **Type**
Bug fix, Enhancement


___

## **Description**
- Changed the source of `minion_tags` in both `data_source_duplo_asg_profile.go` and `resource_duplo_asg_profile.go` to use `CustomDataTags` instead of `MinionTags`.
- Added `CustomDataTags` field to the `DuploAsgProfile` struct in `duplosdk/asg.go` and reorganized the struct fields for better clarity.
- Updated the CHANGELOG.md to include the recent changes regarding the handling of `minion_tags` and other fixes and enhancements.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_source_duplo_asg_profile.go</strong><dd><code>Update minion_tags Source to CustomDataTags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/data_source_duplo_asg_profile.go

<li>Changed the source of <code>minion_tags</code> from <code>MinionTags</code> to <code>CustomDataTags</code>.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/388/files#diff-3338765c0215fecbec2e7b62b9d3f83e83887af6db36c74d7e38d3b80670d8d6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_asg_profile.go</strong><dd><code>Align minion_tags with CustomDataTags in Resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_asg_profile.go

<li>Updated <code>minion_tags</code> to be set from <code>CustomDataTags</code> instead of <br><code>MinionTags</code>.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/388/files#diff-f58c7134634373bfbd4607fa72e0d5fb28a0da60d136394bacd5671ea75c8346">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>asg.go</strong><dd><code>Add CustomDataTags Field and Sort DuploAsgProfile Struct</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/asg.go

<li>Introduced <code>CustomDataTags</code> field in <code>DuploAsgProfile</code> struct.<br> <li> Sorted fields in <code>DuploAsgProfile</code> struct for clarity.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/388/files#diff-b9e34e160487d98157b8b887377449bc8b90d93a1d7640c770a57ab0a7ca5507">+20/-19</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update Changelog with Recent Fixes and Enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
CHANGELOG.md

<li>Added a note about assigning <code>CustomDataTags</code> to <code>minion_tags</code> in the ASG <br>profile.<br> <li> Documented fixes and enhancements in the changelog.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/388/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
