### PR TITLE
DUPLO-14884: support ingress port_name attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,6 @@
 ### Added
 - Added support for `port_name` attribute in Kubernetes ingress rules, allowing service port specification by name.
 - Made `port` attribute optional and enforced port range validation for ingress rules.
-- Updated Go code to handle ingress rules with either `port` or `port_name` specified.
-- Provided an updated Terraform example demonstrating the use of the new `port_name` attribute in a Kubernetes ingress resource.
 
 ## 2024-02-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2024-02-08
+
+### Added
+- Added support for `port_name` attribute in Kubernetes ingress rules, allowing service port specification by name.
+- Made `port` attribute optional and enforced port range validation for ingress rules.
+- Updated Go code to handle ingress rules with either `port` or `port_name` specified.
+- Provided an updated Terraform example demonstrating the use of the new `port_name` attribute in a Kubernetes ingress resource.
+
 ## 2024-02-06
 
 ### Fixed

--- a/duplosdk/k8s_ingress.go
+++ b/duplosdk/k8s_ingress.go
@@ -33,6 +33,7 @@ type DuploK8sIngressRule struct {
 	ServiceName string `json:"serviceName,omitempty"`
 	Host        string `json:"host,omitempty"`
 	Port        int    `json:"port,omitempty"`
+	PortName    string `json:"portName,omitempty"`
 }
 
 func (c *Client) DuploK8sIngressCreate(tenantID string, rq *DuploK8sIngress) ClientError {

--- a/examples/k8/main.tf
+++ b/examples/k8/main.tf
@@ -12,96 +12,131 @@ provider "duplocloud" {
   // duplo_token = ".."                         # please *ONLY* specify using a duplo_token env var (avoid checking secrets into git)
 }
 
-resource "duplocloud_tenant" "tenant1" {
-  account_name = "tf5"
-  plan_id      = "devtest"
-}
+# resource "duplocloud_tenant" "tenant1" {
+#   account_name = "tf5"
+#   plan_id      = "devtest"
+# }
 
-resource "duplocloud_aws_host" "host1" {
-  tenant_id      = duplocloud_tenant.tenant1.tenant_id
-  user_account   = duplocloud_tenant.tenant1.account_name
-  image_id       = "ami-062e7f2xxxa"
-  capacity       = "t2.small"
-  agent_platform = 7
-  friendly_name  = "host1"
-  minion_tags {
-    key   = "AllocationTags"
-    value = "apps"
-  }
-}
+# resource "duplocloud_aws_host" "host1" {
+#   tenant_id      = duplocloud_tenant.tenant1.tenant_id
+#   user_account   = duplocloud_tenant.tenant1.account_name
+#   image_id       = "ami-062e7f2xxxa"
+#   capacity       = "t2.small"
+#   agent_platform = 7
+#   friendly_name  = "host1"
+#   minion_tags {
+#     key   = "AllocationTags"
+#     value = "apps"
+#   }
+# }
 
-resource "duplocloud_duplo_service" "website" {
-  tenant_id           = duplocloud_tenant.tenant1.tenant_id
-  name                = "website"
-  agent_platform      = 7
-  docker_image        = "nginx:latest"
-  replicas            = 1
-  other_docker_config = file("other_k8_config_website.json")
-}
+# resource "duplocloud_duplo_service" "website" {
+#   tenant_id           = duplocloud_tenant.tenant1.tenant_id
+#   name                = "website"
+#   agent_platform      = 7
+#   docker_image        = "nginx:latest"
+#   replicas            = 1
+#   other_docker_config = file("other_k8_config_website.json")
+# }
 
-resource "duplocloud_duplo_service_lbconfigs" "websitelbs" {
-  tenant_id                   = duplocloud_tenant.tenant1.tenant_id
-  replication_controller_name = duplocloud_duplo_service.website.name
-  lbconfigs {
-    certificate_arn             = "arn:aws:acm:us-east-1:9xxxxx1b"
-    external_port               = 443
-    health_check_url            = "/"
-    is_native                   = false
-    lb_type                     = 1
-    port                        = "80"
-    protocol                    = "http"
-    replication_controller_name = "website"
-  }
-}
+# resource "duplocloud_duplo_service_lbconfigs" "websitelbs" {
+#   tenant_id                   = duplocloud_tenant.tenant1.tenant_id
+#   replication_controller_name = duplocloud_duplo_service.website.name
+#   lbconfigs {
+#     certificate_arn             = "arn:aws:acm:us-east-1:9xxxxx1b"
+#     external_port               = 443
+#     health_check_url            = "/"
+#     is_native                   = false
+#     lb_type                     = 1
+#     port                        = "80"
+#     protocol                    = "http"
+#     replication_controller_name = "website"
+#   }
+# }
 
-resource "duplocloud_duplo_service" "mongodb" {
-  tenant_id           = duplocloud_tenant.tenant1.tenant_id
-  name                = "mongodb"
-  agent_platform      = 7
-  docker_image        = "docker.io/bitnami/mongodb:4.2.8-debian-10-r47"
-  replicas            = 1
-  other_docker_config = file("other_k8_config_mongodb.json")
-  volumes = jsonencode(
-    [
-      {
-        "Name" : "datadir",
-        "Path" : "/bitnami/mongodb",
-        "AccessMode" : "ReadWriteOnce",
-        "Size" : "10Gi"
+# resource "duplocloud_duplo_service" "mongodb" {
+#   tenant_id           = duplocloud_tenant.tenant1.tenant_id
+#   name                = "mongodb"
+#   agent_platform      = 7
+#   docker_image        = "docker.io/bitnami/mongodb:4.2.8-debian-10-r47"
+#   replicas            = 1
+#   other_docker_config = file("other_k8_config_mongodb.json")
+#   volumes = jsonencode(
+#     [
+#       {
+#         "Name" : "datadir",
+#         "Path" : "/bitnami/mongodb",
+#         "AccessMode" : "ReadWriteOnce",
+#         "Size" : "10Gi"
+#       }
+#     ]
+#   )
+# }
+
+# resource "duplocloud_duplo_service_lbconfigs" "mongodblbs" {
+#   tenant_id                   = duplocloud_tenant.tenant1.tenant_id
+#   replication_controller_name = duplocloud_duplo_service.mongodb.name
+#   lbconfigs {
+#     lb_type                     = 3
+#     port                        = "27017"
+#     external_port               = 27017
+#     protocol                    = "tcp"
+#     replication_controller_name = "mongodb"
+#   }
+# }
+
+
+
+# resource "duplocloud_k8_config_map" "customer-api-configs" {
+#   tenant_id = duplocloud_tenant.tenant1.tenant_id
+#   name      = "customer-api-configs"
+#   data = jsonencode(
+#     {
+#       "ABC" : "DEF",
+#       "123" : "456"
+#     }
+#   )
+# }
+
+# //secret_data  secret_name  secret_version  secret_type
+# resource "duplocloud_k8_secret" "customer-api-secrets" {
+#   tenant_id   = duplocloud_tenant.tenant1.tenant_id
+#   secret_type = "Opaque"
+#   secret_name = "customer-api-secrets"
+#   secret_data = file("customer-api-secrets.json")
+# }
+
+variable "tenant_id" { }
+
+resource "duplocloud_k8_ingress" "ingress" {
+  tenant_id          = var.tenant_id
+  name               = "joedemo"
+  ingress_class_name = "alb"
+
+  annotations = {
+    "alb.ingress.kubernetes.io/actions.redirect-to-new-domain" = jsonencode({
+      Type           = "redirect",
+      RedirectConfig = {
+        Host       = "my.example.com",
+        Path       = "/#{path}",
+        Port       = "#{port}",
+        Protocol   = "HTTPS",
+        Query      = "#{query}",
+        StatusCode = "HTTP_301"
       }
-    ]
-  )
-}
-
-resource "duplocloud_duplo_service_lbconfigs" "mongodblbs" {
-  tenant_id                   = duplocloud_tenant.tenant1.tenant_id
-  replication_controller_name = duplocloud_duplo_service.mongodb.name
-  lbconfigs {
-    lb_type                     = 3
-    port                        = "27017"
-    external_port               = 27017
-    protocol                    = "tcp"
-    replication_controller_name = "mongodb"
+    })
   }
-}
 
+  lbconfig {
+    is_internal = false
+    dns_prefix  = "joedemo-ingress"
+    http_port = 80
+  }
 
-
-resource "duplocloud_k8_config_map" "customer-api-configs" {
-  tenant_id = duplocloud_tenant.tenant1.tenant_id
-  name      = "customer-api-configs"
-  data = jsonencode(
-    {
-      "ABC" : "DEF",
-      "123" : "456"
-    }
-  )
-}
-
-//secret_data  secret_name  secret_version  secret_type
-resource "duplocloud_k8_secret" "customer-api-secrets" {
-  tenant_id   = duplocloud_tenant.tenant1.tenant_id
-  secret_type = "Opaque"
-  secret_name = "customer-api-secrets"
-  secret_data = file("customer-api-secrets.json")
+  rule {
+    path         = "/"
+    path_type    = "Prefix"
+    service_name = "redirect-to-new-domain"
+    port_name    = "use-annotation"
+  }
 }


### PR DESCRIPTION
## **User description**
## Change description

> Description here

## Type of change
- [ ] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


___

## **Type**
enhancement


___

## **Description**
- Added support for specifying service port by name (`port_name`) in Kubernetes ingress rules.
- Made `port` attribute optional and added validation to ensure the port number is within the valid range.
- Updated SDK and Terraform examples to reflect these changes.
- Updated CHANGELOG.md to document these enhancements.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_k8_ingress.go</strong><dd><code>Support Ingress Port Name Attribute and Optional Port Configuration</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_k8_ingress.go

<li>Added <code>port_name</code> attribute to ingress backend service configuration.<br> <li> Made <code>port</code> attribute optional and added validation for port range.<br> <li> Updated function <code>expandK8sIngressRule</code> to handle mutual exclusivity of <br><code>port</code> and <code>port_name</code>.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/391/files#diff-be09e65d7ea258d6c07f835b50a48434c26fc92a19c6b08b9433b9cd70e749ab">+36/-11</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>k8s_ingress.go</strong><dd><code>Add Port Name Support in Kubernetes Ingress SDK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/k8s_ingress.go

<li>Added <code>PortName</code> field to <code>DuploK8sIngressRule</code> struct to support <br>specifying service port by name.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/391/files#diff-adbb1c8926ba9d75f91fe0640b9806fb0c3bb4938bfe85e180bf53ab34c4a8ac">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update Terraform Example with New Ingress Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
examples/k8/main.tf

<li>Commented out previous resources and added a new <code>duplocloud_k8_ingress</code> <br>resource example.<br> <li> Demonstrated the use of <code>port_name</code> attribute in the new ingress <br>resource.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/391/files#diff-d321aae3a7e1abc461756794755494d6d3521623001fa0a0a1a3ec89ca228a25">+118/-83</a></td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update Changelog for Kubernetes Ingress Enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
CHANGELOG.md

<li>Documented the addition of <code>port_name</code> attribute and making <code>port</code> <br>optional in Kubernetes ingress rules.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/391/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
