### PR TITLE
[DUPLO-14500] - TF: Not able create OpenSearch with (warm enable =false and cold storage=false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-02-09
+
+### Fixed
+- Fixed a bug that prevented the creation of OpenSearch with both warm enable and cold storage options set to false. Now, these options are properly handled, preventing errors during the creation of OpenSearch domains with these options disabled.
+
 ## 2024-02-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2024-02-09
 
 ### Fixed
-- Fixed a bug that prevented the creation of AWS elasticsearch with both warm enable and cold storage options are set to false. Now, these options are properly handled, preventing errors during the creation of AWS elasticsearch domains with these options disabled.
+- Fixed a bug that prevented the creation of `duplocloud_aws_elasticsearch` with both `warm_enabled` and `cold_storage_options` are set to `false`. Now, these options are properly handled, preventing errors during the creation of `duplocloud_aws_elasticsearch`  with these options disabled.
 - Fixed a regression in `duplocloud_k8_ingress` validation where `port` and `port_name` were not correctly validated as mutually exclusive.
 
 ## 2024-02-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2024-02-09
 
 ### Fixed
-- Fixed a bug that prevented the creation of OpenSearch with both warm enable and cold storage options set to false. Now, these options are properly handled, preventing errors during the creation of OpenSearch domains with these options disabled.
+- Fixed a bug that prevented the creation of OpenSearch with both warm enable and cold storage options are set to false. Now, these options are properly handled, preventing errors during the creation of OpenSearch domains with these options disabled.
 
 ## 2024-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2024-02-09
 
 ### Fixed
-- Fixed a bug that prevented the creation of OpenSearch with both warm enable and cold storage options are set to false. Now, these options are properly handled, preventing errors during the creation of OpenSearch domains with these options disabled.
+- Fixed a bug that prevented the creation of AWS elasticsearch with both warm enable and cold storage options are set to false. Now, these options are properly handled, preventing errors during the creation of AWS elasticsearch domains with these options disabled.
 
 ## 2024-02-08
 

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -658,7 +658,6 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 			if value {
 				duplo.ColdStorageOptions.Enabled = value
 			}
-
 		}
 
 	}

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -659,7 +659,6 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 				duplo.ColdStorageOptions.Enabled = value
 			}
 		}
-
 	}
 	if v, ok := m["warm_count"]; ok {
 		duplo.WarmCount = v.(int)

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -651,7 +651,16 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 		duplo.InstanceType.Value = "t2.small.elasticsearch"
 	}
 	if v, ok := m["cold_storage_options"]; ok {
-		duplo.ColdStorageOptions.Enabled = v.([]interface{})[0].(map[string]interface{})["enabled"].(bool)
+		obj := v.([]interface{})
+		duplo.ColdStorageOptions = nil
+		if len(obj) > 0 {
+			value := obj[0].(map[string]interface{})["enabled"].(bool)
+			if value {
+				duplo.ColdStorageOptions.Enabled = value
+			}
+
+		}
+
 	}
 	if v, ok := m["warm_count"]; ok {
 		duplo.WarmCount = v.(int)
@@ -660,7 +669,11 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 		duplo.WarmEnabled = v.(bool)
 	}
 	if v, ok := m["warm_type"]; ok {
-		duplo.WarmType.Value = v.(string)
+		obj := v.(string)
+		duplo.WarmType = nil
+		if obj != "" {
+			duplo.WarmType.Value = obj
+		}
 	}
 
 	if v, ok := m["dedicated_master_enabled"]; ok {

--- a/duplosdk/aws_elasticsearch.go
+++ b/duplosdk/aws_elasticsearch.go
@@ -35,15 +35,15 @@ type DuploElasticSearchDomainEndpointOptions struct {
 
 // DuploElasticSearchDomainClusterConfig represents an AWS ElasticSearch domain's endpoint options for a Duplo tenant
 type DuploElasticSearchDomainClusterConfig struct {
-	DedicatedMasterCount   int                                        `json:"DedicatedMasterCount,omitempty"`
-	DedicatedMasterEnabled bool                                       `json:"DedicatedMasterEnabled,omitempty"`
-	DedicatedMasterType    DuploStringValue                           `json:"DedicatedMasterType,omitempty"`
-	InstanceCount          int                                        `json:"InstanceCount,omitempty"`
-	InstanceType           DuploStringValue                           `json:"InstanceType,omitempty"`
-	WarmCount              int                                        `json:"WarmCount,omitempty"`
-	WarmEnabled            bool                                       `json:"WarmEnabled,omitempty"`
-	WarmType               DuploStringValue                           `json:"WarmType,omitempty"`
-	ColdStorageOptions     DuploElasticSearchDomainColdStorageOptions `json:"ColdStorageOptions,omitempty"`
+	DedicatedMasterCount   int                                         `json:"DedicatedMasterCount,omitempty"`
+	DedicatedMasterEnabled bool                                        `json:"DedicatedMasterEnabled,omitempty"`
+	DedicatedMasterType    DuploStringValue                            `json:"DedicatedMasterType,omitempty"`
+	InstanceCount          int                                         `json:"InstanceCount,omitempty"`
+	InstanceType           DuploStringValue                            `json:"InstanceType,omitempty"`
+	WarmCount              int                                         `json:"WarmCount,omitempty"`
+	WarmEnabled            bool                                        `json:"WarmEnabled,omitempty"`
+	WarmType               *DuploStringValue                           `json:"WarmType,omitempty"`
+	ColdStorageOptions     *DuploElasticSearchDomainColdStorageOptions `json:"ColdStorageOptions,omitempty"`
 }
 
 type DuploElasticSearchDomainColdStorageOptions struct {


### PR DESCRIPTION
## **User description**
…
[DUPLO-14500] - TF: Not able create OpenSearch with (warm enable =false and cold storage=false)

## Change description

> fixed the bug when warm enabled and cold storage options are set to false

## Type of change
- [ ] fixed the bug when warm enabled and cold storage options are set to false

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [ ] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable


___

## **Type**
bug_fix


___

## **Description**
- Corrected the logic in `resource_duplo_aws_elasticsearch.go` to properly handle cases where `cold_storage_options` and `warm_type` are not enabled or set, preventing errors during the creation of OpenSearch domains with these options disabled.
- Updated `DuploElasticSearchDomainClusterConfig` struct in `duplosdk/aws_elasticsearch.go` to use pointers for `WarmType` and `ColdStorageOptions`, making these fields optional and aligning with the corrected logic.


___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_elasticsearch.go</strong><dd><code>Fix handling of cold storage and warm type in AWS Elasticsearch <br>resource</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_aws_elasticsearch.go

<li>Fixed handling of <code>cold_storage_options</code> to avoid setting it when not <br>enabled.<br> <li> Corrected the handling of <code>warm_type</code> to only set it when a non-empty <br>string is provided.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/394/files#diff-74075534ff698afe18f26ee1215cb2f57c76aa949aca23c1464f4dcaed02386f">+15/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws_elasticsearch.go</strong><dd><code>Update Elasticsearch domain config struct for optional fields</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/aws_elasticsearch.go

<li>Changed <code>WarmType</code> and <code>ColdStorageOptions</code> fields to pointers to allow <br>omission when not set.


</details>

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/394/files#diff-aa10acb1bd1e5bbc66aecf2b5383547b4724d45bfeab0c654a8b9f61148dcf61">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
