### PR TITLE
DUPLO-15007: Happy path tests for duplocloud_aws_host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2024-02-12
+
+### Added
+- Unit tests for `duplocloud_aws_host`
+  - Added comprehensive test cases for AWS host resource, covering basic configuration, public/private subnets, and zone selection.
+  - Enhanced emulator response for AWS hosts to include `UserAccount` and `IdentityRole`.
+  - Improved handling of `volume` and `network_interface` in AWS host resource to avoid unnecessary diffs.
+  - Extended the emulator to support AWS host creation and deletion APIs, and to list external and internal subnets per tenant.
+  - Introduced helper functions for generating Terraform resource definitions in tests.
+  - Updated and added new fixtures for AWS hosts and subnets to support testing.
+
 ## 2024-02-10
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install_window: build
 #	mv ${BINARY} bin
 test:
 	go test -i $(TEST) || exit 1
-	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=30s -parallel=4
+	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=90s -parallel=4
 
 testacc:
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/duplocloud/provider_test.go
+++ b/duplocloud/provider_test.go
@@ -61,7 +61,9 @@ func testAccProvider_ConfigureContextFunc(d *schema.Provider) schema.ConfigureCo
 						host.UserAccount = tenant.AccountName
 					}
 					host.IdentityRole = "duploservices-" + host.UserAccount
-					host.FriendlyName = host.IdentityRole + "-" + host.FriendlyName
+					if !strings.HasPrefix(host.FriendlyName, host.IdentityRole) {
+						host.FriendlyName = host.IdentityRole + "-" + host.FriendlyName
+					}
 					return
 				},
 			},

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -170,6 +170,7 @@ func nativeHostSchema() map[string]*schema.Schema {
 		"volume": {
 			Type:     schema.TypeList,
 			Optional: true,
+			Computed: true,
 			ForceNew: true, // relaunch instance
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
@@ -205,6 +206,7 @@ func nativeHostSchema() map[string]*schema.Schema {
 			Description: "An optional list of custom network interface configurations to use when creating the host.",
 			Type:        schema.TypeList,
 			Optional:    true,
+			Computed:    true,
 			ForceNew:    true, // relaunch instance
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
@@ -635,10 +637,9 @@ func nativeHostToState(d *schema.ResourceData, duplo *duplosdk.DuploNativeHost) 
 		d.Set("allocated_public_ip", duplo.AllocatedPublicIP)
 	}
 
-	// TODO:  The backend doesn't return these yet.
-	// d.Set("metadata", keyValueToState("metadata", duplo.MetaData))
-	// d.Set("volume", flattenNativeHostVolumes(duplo.Volumes))
-	// d.Set("network_interface", flattenNativeHostNetworkInterfaces(duplo.NetworkInterfaces))
+	//d.Set("metadata", keyValueToState("metadata", duplo.MetaData))
+	d.Set("volume", flattenNativeHostVolumes(duplo.Volumes))
+	d.Set("network_interface", flattenNativeHostNetworkInterfaces(duplo.NetworkInterfaces))
 }
 
 func flattenNativeHostVolumes(duplo *[]duplosdk.DuploNativeHostVolume) []interface{} {

--- a/duplocloud/resource_duplo_aws_host_test.go
+++ b/duplocloud/resource_duplo_aws_host_test.go
@@ -1,8 +1,5 @@
 package duplocloud
 
-import "testing"
-
-/*
 import (
 	"fmt"
 	"terraform-provider-duplocloud/duplosdk"
@@ -13,100 +10,54 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
-*/
 
 func TestAccResource_duplocloud_aws_host_basic(t *testing.T) {
-	/*
-		rName := acctest.RandStringFromCharSet(2, acctest.CharSetAlpha) +
-			acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
-		tenantName := acctest.RandStringFromCharSet(2, acctest.CharSetAlpha) +
-			acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	rName := acctest.RandStringFromCharSet(2, acctest.CharSetAlpha) +
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	hostName := acctest.RandStringFromCharSet(2, acctest.CharSetAlpha) +
+		acctest.RandStringFromCharSet(5, acctest.CharSetAlphaNum)
+	roleName := "duploservices-testacc1a"
 
-		// Tenant that is allowed to be deleted.
-		resource.Test(t, resource.TestCase{
-			IsUnitTest: true,
-			Providers:  testAccProviders,
-			PreCheck:   duplosdktest.ResetEmulator,
-			CheckDestroy: func(state *terraform.State) error {
-				deleted := duplosdktest.EmuDeleted()
-				if len(deleted) == 0 {
-					return fmt.Errorf("Not deleted: %s", "duplocloud_aws_host."+rName)
-				}
-				return nil
-			},
-			Steps: []resource.TestStep{
-				{
-					Config: testAccProvider_GenConfig(
-						"resource \"duplocloud_aws_host\" \"" + rName + "\" {\n" +
-							"	 account_name = \"" + tenantName + "\"\n" +
-							"	 plan_id = \"testacc1\"\n" +
-							"	 wait_until_created = false\n" +
-							"	 allow_deletion = true\n" +
-							"}",
-					),
-					Check: func(state *terraform.State) error {
-						tenant := duplosdktest.EmuCreated()[0].(*duplosdk.DuploTenant)
-						return resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr("duplocloud_aws_host."+rName, "tenant_id", tenant.TenantID),
-							resource.TestCheckResourceAttr("duplocloud_aws_host."+rName, "plan_id", "testacc1"),
-							resource.TestCheckResourceAttr("duplocloud_aws_host."+rName, "account_name", tenantName),
-						)(state)
-					},
-				},
-				{
-					Config: testAccProvider_GenConfig(
-						"resource \"duplocloud_aws_host\" \"" + rName + "\" {\n" +
-							"	 account_name = \"" + tenantName + "\"\n" +
-							"	 plan_id = \"testacc1\"\n" +
-							"	 wait_until_created = false\n" +
-							"	 allow_deletion = true\n" +
-							"}",
-					),
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		PreCheck:   duplosdktest.ResetEmulator,
+		CheckDestroy: func(state *terraform.State) error {
+			deleted := duplosdktest.EmuDeleted()
+			if len(deleted) == 0 {
+				return fmt.Errorf("Not deleted: %s", "duplocloud_aws_host."+rName)
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProvider_GenConfig(
+					"resource \"duplocloud_aws_host\" \"" + rName + "\" {\n" +
+						"	 tenant_id = \"" + Tenant_testacc1a + "\"\n" +
+						"	 user_account = \"testacc1a\"\n" +
+						"	 friendly_name = \"" + hostName + "\"\n" +
+						"	 zone = 0\n" +
+						"	 image_id = \"ami-1234abc\"\n" +
+						"	 capacity = \"t4g.small\"\n" +
+						"	 allocated_public_ip = true\n" +
+						"	 wait_until_connected = false\n" +
+						"}",
+				),
+				Check: func(state *terraform.State) error {
+					host := duplosdktest.EmuCreated()[0].(*duplosdk.DuploNativeHost)
+					r := "duplocloud_aws_host." + rName
+					return resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(r, "tenant_id", Tenant_testacc1a),
+						resource.TestCheckResourceAttr(r, "instance_id", host.InstanceID),
+						resource.TestCheckResourceAttr(r, "friendly_name", roleName+"-"+hostName),
+						resource.TestCheckResourceAttr(r, "image_id", "ami-1234abc"),
+						resource.TestCheckResourceAttr(r, "capacity", "t4g.small"),
+						resource.TestCheckResourceAttr(r, "allocated_public_ip", "true"),
+						resource.TestCheckResourceAttr(r, "network_interface.0.subnet_id", "subnet-ext1"),
+					)(state)
 				},
 			},
-		})
+		},
+	})
 
-		// Tenant that is not allowed to be deleted.
-		resource.Test(t, resource.TestCase{
-			IsUnitTest: true,
-			Providers:  testAccProviders,
-			PreCheck:   duplosdktest.ResetEmulator,
-			CheckDestroy: func(state *terraform.State) error {
-				if len(duplosdktest.EmuCreated()) == 0 {
-					return fmt.Errorf("Should not have been deleted: %s", "duplocloud_aws_host."+rName)
-				}
-				return nil
-			},
-			Steps: []resource.TestStep{
-				{
-					Config: testAccProvider_GenConfig(
-						"resource \"duplocloud_aws_host\" \"" + rName + "\" {\n" +
-							"	 account_name = \"" + tenantName + "\"\n" +
-							"	 plan_id = \"testacc1\"\n" +
-							"	 wait_until_created = false\n" +
-							"	 allow_deletion = false\n" +
-							"}",
-					),
-					Check: func(state *terraform.State) error {
-						tenant := duplosdktest.EmuCreated()[0].(*duplosdk.DuploTenant)
-						return resource.ComposeTestCheckFunc(
-							resource.TestCheckResourceAttr("duplocloud_aws_host."+rName, "tenant_id", tenant.TenantID),
-							resource.TestCheckResourceAttr("duplocloud_aws_host."+rName, "plan_id", "testacc1"),
-							resource.TestCheckResourceAttr("duplocloud_aws_host."+rName, "account_name", tenantName),
-						)(state)
-					},
-				},
-				{
-					Config: testAccProvider_GenConfig(
-						"resource \"duplocloud_aws_host\" \"" + rName + "\" {\n" +
-							"	 account_name = \"" + tenantName + "\"\n" +
-							"	 plan_id = \"testacc1\"\n" +
-							"	 wait_until_created = false\n" +
-							"	 allow_deletion = false\n" +
-							"}",
-					),
-				},
-			},
-		})
-	*/
 }

--- a/duplocloud/resource_duplo_aws_host_test.go
+++ b/duplocloud/resource_duplo_aws_host_test.go
@@ -35,7 +35,7 @@ func TestAccResource_duplocloud_aws_host_basic(t *testing.T) {
 					"resource \"duplocloud_aws_host\" \"" + rName + "\" {\n" +
 						"	 tenant_id = \"" + Tenant_testacc1a + "\"\n" +
 						"	 user_account = \"testacc1a\"\n" +
-						"	 friendly_name = \"" + hostName + "\"\n" +
+						"	 friendly_name = \"duploservices-testacc1a-" + hostName + "\"\n" +
 						"	 zone = 0\n" +
 						"	 image_id = \"ami-1234abc\"\n" +
 						"	 capacity = \"t4g.small\"\n" +

--- a/internal/duplocloudtest/helpers.go
+++ b/internal/duplocloudtest/helpers.go
@@ -1,0 +1,42 @@
+package duplocloudtest
+
+import (
+	"strings"
+)
+
+func WriteResource(rType, rName string, defaults, overrides map[string]string) string {
+	var sb strings.Builder
+	sb.WriteString("resource \"")
+	sb.WriteString(rType)
+	sb.WriteString("\" \"")
+	sb.WriteString(rName)
+	sb.WriteString("\" {\n")
+	writeAttrs(&sb, defaults, overrides)
+	sb.WriteString("}\n")
+	return sb.String()
+}
+
+func WriteAttrs(defaults, overrides map[string]string) string {
+	var sb strings.Builder
+	writeAttrs(&sb, defaults, overrides)
+	return sb.String()
+}
+
+func writeAttrs(sb *strings.Builder, defaults, overrides map[string]string) {
+	for k, v := range defaults {
+		if _, ok := overrides[k]; !ok {
+			WriteAttr(sb, k, v)
+		}
+	}
+	for k, v := range overrides {
+		WriteAttr(sb, k, v)
+	}
+}
+
+func WriteAttr(sb *strings.Builder, key, value string) {
+	sb.WriteString("  ")
+	sb.WriteString(key)
+	sb.WriteString(" = ")
+	sb.WriteString(value)
+	sb.WriteString("\n")
+}

--- a/internal/duplosdktest/emulator.go
+++ b/internal/duplosdktest/emulator.go
@@ -41,6 +41,10 @@ func EmuCreated() []interface{} {
 	return emuCreated
 }
 
+func EmuLastCreated() interface{} {
+	return emuCreated[len(emuCreated)-1]
+}
+
 func emuLocation(location string, ps httprouter.Params) string {
 	return emuParams.ReplaceAllStringFunc(location, func(match string) string {
 		return ps.ByName(match[1:])

--- a/internal/duplosdktest/emulator.go
+++ b/internal/duplosdktest/emulator.go
@@ -51,7 +51,7 @@ func emuList(location string) httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
 		l := emuLocation(location, ps)
 		log.Printf("[TRACE] emuList(%s)", l)
-		buff := fixtureList(l)
+		buff := ListFixtures(l)
 		w.WriteHeader(200)
 		w.Write(buff) // nolint
 	}
@@ -62,7 +62,7 @@ func emuGet(location string) httprouter.Handle {
 		id := ps.ByName("id")
 		l := emuLocation(location, ps) + "/" + id
 		log.Printf("[TRACE] emuGet(%s)", l)
-		buff := fixtureGet(l)
+		buff := GetFixture(l)
 		w.WriteHeader(200)
 		w.Write(buff) // nolint
 	}
@@ -90,7 +90,7 @@ func emuDelete(location string) httprouter.Handle {
 		id := ps.ByName("id")
 		l := emuLocation(location, ps) + "/" + id
 		log.Printf("[TRACE] emuDelete(%s)", l)
-		if fixtureDelete(l) {
+		if DeleteFixture(l) {
 			w.WriteHeader(204)
 		} else {
 			w.WriteHeader(404)
@@ -121,7 +121,7 @@ func NewEmulator(config EmuConfig) *httptest.Server {
 
 	router.NotFound = http.HandlerFunc(emuNotFound)
 
-	// tenant API emulation
+	// tenant APIs
 	router.GET("/admin/GetTenantsForUser", emuList("tenant"))
 	router.GET("/v2/admin/TenantV2", emuList("tenant"))
 	router.GET("/v2/admin/TenantV2/:id", emuGet("tenant"))
@@ -130,9 +130,15 @@ func NewEmulator(config EmuConfig) *httptest.Server {
 	router.POST("/admin/AddTenant", emuPost("tenant", config, true))
 	router.POST("/admin/DeleteTenant/:id", emuDelete("tenant"))
 
-	// AWS host API emulation
+	// non-admin tenant APIs
+	router.GET("/subscriptions/:tenantId/GetExternalSubnets", emuList("tenant/:tenantId/external_subnets"))
+	router.GET("/subscriptions/:tenantId/GetInternalSubnets", emuList("tenant/:tenantId/internal_subnets"))
+
+	// AWS host APIs
 	router.GET("/v2/subscriptions/:tenantId/NativeHostV2", emuList("tenant/:tenantId/aws_host"))
 	router.GET("/v2/subscriptions/:tenantId/NativeHostV2/:id", emuGet("tenant/:tenantId/aws_host"))
+	router.POST("/v2/subscriptions/:tenantId/NativeHostV2", emuPost("tenant/:tenantId/aws_host", config, false))
+	router.DELETE("/v2/subscriptions/:tenantId/NativeHostV2/:id", emuDelete("tenant/:tenantId/aws_host"))
 
 	return SetupHttptest(router)
 }

--- a/internal/duplosdktest/fixtures.go
+++ b/internal/duplosdktest/fixtures.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path"
+	"slices"
 	"strings"
 )
 
@@ -115,9 +116,10 @@ func ListFixtures(location string) []byte {
 		locations = append(locations, key)
 	}
 
-	// Fill the buffer
+	// Fill the buffer, in sort order
 	buff := make([]byte, 0, size)
 	buff = append(buff, []byte("[")...)
+	slices.Sort(locations)
 	for i := range locations {
 		if i > 0 {
 			buff = append(buff, []byte(",")...)

--- a/internal/duplosdktest/fixtures.go
+++ b/internal/duplosdktest/fixtures.go
@@ -150,5 +150,5 @@ func GetFixture(location string) []byte {
 
 func GetResource(location string, target interface{}) error {
 	bytes := GetFixture(location)
-	return json.Unmarshal(bytes, &target)
+	return json.Unmarshal(bytes, target)
 }

--- a/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/aws_host/i-a4a64e4407f5ae678.json
+++ b/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/aws_host/i-a4a64e4407f5ae678.json
@@ -1,6 +1,7 @@
 {
   "InstanceId": "i-a4a64e4407f5ae678",
   "IdentityRole": "duploservices-testacc1a",
+  "UserAccount": "testacc1a",
   "PrivateIpAddress": "10.220.60.216",
   "Status": "running",
   "Arch": "amd64",

--- a/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/external_subnets/1.json
+++ b/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/external_subnets/1.json
@@ -1,0 +1,1 @@
+"subnet-ext1"

--- a/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/external_subnets/2.json
+++ b/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/external_subnets/2.json
@@ -1,0 +1,1 @@
+"subnet-ext2"

--- a/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/internal_subnets/1.json
+++ b/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/internal_subnets/1.json
@@ -1,0 +1,1 @@
+"subnet-int1"

--- a/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/internal_subnets/2.json
+++ b/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/internal_subnets/2.json
@@ -1,0 +1,1 @@
+"subnet-int2"


### PR DESCRIPTION
## Overview

DUPLO-15007: Happy path tests for duplocloud_aws_host

## Summary of changes

This PR does the following:

- Adds happy path tests for `duplocloud_aws_host`
- Fixes missing network interfaces for `duplocloud_aws_host`
- Export fixtures methods.
- Fix fixture delete bug where the cached fixture list was not invalidated.
- Fix fixture lists not being sorted

## Testing performed

- [x] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
