### PR TITLE
DUPLO-15049: Unit Tests: Resource: duplocloud_tenant_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2024-02-13
+
+### Added
+- Unit tests for `duplocloud_tenant_config` resource and data source, both happy path and edge cases.
+- Updates to `TenantSetConfigKey` and `TenantDeleteConfigKey` methods in the SDK to use the v3 API, improving the handling of tenant configurations.
+
+### Changed
+- The emulator now supports dynamic path parameters and added routes for the tenant metadata API.
+- Updated the `duplocloud_aws_host` resource test helper function to use the new test helper for generating Terraform resource definitions.
+
+### Breaking Changes
+- Duplo releases older than 1/2023 will be missing the v3 tenant metadata APIs.
+
 ## 2024-02-12
 
 ### Added

--- a/duplocloud/data_source_duplo_tenant_config_test.go
+++ b/duplocloud/data_source_duplo_tenant_config_test.go
@@ -1,0 +1,41 @@
+package duplocloud
+
+import (
+	"terraform-provider-duplocloud/internal/duplosdktest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAccDataSource_duplocloud_tenant_config_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(2, acctest.CharSetAlpha) +
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		PreCheck:   duplosdktest.ResetEmulator,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccProvider_GenConfig(
+					"data \"duplocloud_tenant_config\" \"" + rName + "\" {\n" +
+						"	 tenant_id = \"" + Tenant_testacc1a + "\"\n" +
+						"}",
+				),
+				Check: func(state *terraform.State) error {
+					r := "data.duplocloud_tenant_config." + rName
+					return resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(r, "tenant_id", Tenant_testacc1a),
+						resource.TestCheckResourceAttr(r, "metadata.#", "2"),
+						resource.TestCheckResourceAttr(r, "metadata.0.key", "foo"),
+						resource.TestCheckResourceAttr(r, "metadata.0.value", "bar"),
+						resource.TestCheckResourceAttr(r, "metadata.1.key", "xyz"),
+						resource.TestCheckResourceAttr(r, "metadata.1.value", "abc"),
+					)(state)
+				},
+			},
+		},
+	})
+}

--- a/duplocloud/data_source_duplo_tenant_test.go
+++ b/duplocloud/data_source_duplo_tenant_test.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	Tenant_testacc1a = "302c6a63-ffc4-4276-b52e-48a84108b658"
+	Tenant_testacc1b = "6b2672db-b930-4875-b327-78d9dcbd5dd6"
 )
 
 func TestAccDatasource_duplocloud_tenant_basic(t *testing.T) {

--- a/duplocloud/provider_test.go
+++ b/duplocloud/provider_test.go
@@ -67,6 +67,13 @@ func testAccProvider_ConfigureContextFunc(d *schema.Provider) schema.ConfigureCo
 					return
 				},
 			},
+			"tenant/:tenantId/metadata": {
+				Factory: func() interface{} { return &duplosdk.DuploKeyStringValue{} },
+				Responder: func(in interface{}) (id string, out interface{}) {
+					out = deepcopy.MustAnything(in.(*duplosdk.DuploKeyStringValue))
+					return
+				},
+			},
 		},
 	})
 

--- a/duplocloud/resource_duplo_aws_host_test.go
+++ b/duplocloud/resource_duplo_aws_host_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func duplocloud_aws_host_basic(rName, hostName string, attrs map[string]string) string {
-	return duplocloudtest.WriteResource("duplocloud_aws_host", rName,
+	return duplocloudtest.WriteFlatResource("duplocloud_aws_host", rName,
 		map[string]string{
 			"tenant_id":            "\"" + Tenant_testacc1a + "\"",
 			"user_account":         "\"testacc1a\"",

--- a/duplocloud/resource_duplo_tenant_config_test.go
+++ b/duplocloud/resource_duplo_tenant_config_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func duplocloud_tenant_config_basic(rName string, deleteUnspecified bool, settings []duplosdk.DuploKeyStringValue) string {
+func duplocloud_tenant_config_basic(rName, tenantId string, deleteUnspecified bool, settings []duplosdk.DuploKeyStringValue) string {
 	return duplocloudtest.WriteCustomResource("duplocloud_tenant_config", rName, func(sb *strings.Builder) {
-		duplocloudtest.WriteAttr(sb, "tenant_id", "\""+Tenant_testacc1a+"\"")
+		duplocloudtest.WriteAttr(sb, "tenant_id", tenantId)
 		duplocloudtest.WriteAttr(sb, "delete_unspecified_settings", strconv.FormatBool(deleteUnspecified))
 
 		for i := range settings {
@@ -31,8 +31,12 @@ func duplocloud_tenant_config_basic(rName string, deleteUnspecified bool, settin
 func TestAccResource_duplocloud_tenant_config_basic(t *testing.T) {
 	rName := acctest.RandStringFromCharSet(2, acctest.CharSetAlpha) +
 		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	r := "duplocloud_tenant_config." + rName
 
-	// Tenant that is allowed to be deleted.
+	unmanagedLocation := "tenant/" + Tenant_testacc1a + "/metadata/unmanaged"
+	unmanagedSetting := duplosdk.DuploKeyStringValue{Key: "unmanaged", Value: "setting"}
+
+	// Happy Path
 	resource.Test(t, resource.TestCase{
 		IsUnitTest: true,
 		Providers:  testAccProviders,
@@ -40,7 +44,7 @@ func TestAccResource_duplocloud_tenant_config_basic(t *testing.T) {
 		CheckDestroy: func(state *terraform.State) error {
 			deleted := duplosdktest.EmuDeleted()
 			if len(deleted) == 0 {
-				return fmt.Errorf("Not deleted: %s", "duplocloud_tenant_conig."+rName)
+				return fmt.Errorf("Should be deleted, but wasn't: %s", r)
 			}
 			return nil
 		},
@@ -48,14 +52,17 @@ func TestAccResource_duplocloud_tenant_config_basic(t *testing.T) {
 			// No deletion of unspecified settings.
 			// No modification of unspecified settings.
 			{
+				PreConfig: func() {
+					// Insert an unmanaged key in the metadata for this tenant
+					duplosdktest.SetResource(unmanagedLocation, &unmanagedSetting)
+				},
 				Config: testAccProvider_GenConfig(
-					duplocloud_tenant_config_basic(rName, false, []duplosdk.DuploKeyStringValue{
+					duplocloud_tenant_config_basic(rName, "\""+Tenant_testacc1a+"\"", false, []duplosdk.DuploKeyStringValue{
 						{Key: "abc", Value: "xyz"},
 						{Key: "mermaid", Value: "cousin"},
 					}),
 				),
 				Check: func(state *terraform.State) error {
-					r := "duplocloud_tenant_config." + rName
 					return resource.ComposeTestCheckFunc(
 						resource.TestCheckResourceAttr(r, "tenant_id", Tenant_testacc1a),
 						resource.TestCheckResourceAttr(r, "delete_unspecified_settings", "false"),
@@ -67,15 +74,75 @@ func TestAccResource_duplocloud_tenant_config_basic(t *testing.T) {
 						resource.TestCheckResourceAttr(r, "specified_settings.#", "2"),
 						resource.TestCheckResourceAttr(r, "specified_settings.0", "abc"),
 						resource.TestCheckResourceAttr(r, "specified_settings.1", "mermaid"),
-						resource.TestCheckResourceAttr(r, "metadata.#", "4"),
+						resource.TestCheckResourceAttr(r, "metadata.#", "5"),
 						resource.TestCheckResourceAttr(r, "metadata.0.key", "abc"),
 						resource.TestCheckResourceAttr(r, "metadata.0.value", "xyz"),
 						resource.TestCheckResourceAttr(r, "metadata.1.key", "foo"),
 						resource.TestCheckResourceAttr(r, "metadata.1.value", "bar"),
 						resource.TestCheckResourceAttr(r, "metadata.2.key", "mermaid"),
 						resource.TestCheckResourceAttr(r, "metadata.2.value", "cousin"),
-						resource.TestCheckResourceAttr(r, "metadata.3.key", "xyz"),
-						resource.TestCheckResourceAttr(r, "metadata.3.value", "abc"),
+						resource.TestCheckResourceAttr(r, "metadata.3.key", "unmanaged"),
+						resource.TestCheckResourceAttr(r, "metadata.3.value", "setting"),
+						resource.TestCheckResourceAttr(r, "metadata.4.key", "xyz"),
+						resource.TestCheckResourceAttr(r, "metadata.4.value", "abc"),
+					)(state)
+				},
+			},
+		},
+	})
+}
+
+func TestAccResource_duplocloud_tenant_config_delete_unspecified(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(2, acctest.CharSetAlpha) +
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+	r := "duplocloud_tenant_config." + rName
+
+	unmanagedLocation := "tenant/" + Tenant_testacc1b + "/metadata/unmanaged"
+	unmanagedSetting := duplosdk.DuploKeyStringValue{Key: "unmanaged", Value: "setting"}
+
+	// Edge cases
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		PreCheck:   duplosdktest.ResetEmulator,
+		CheckDestroy: func(state *terraform.State) error {
+			deleted := duplosdktest.EmuDeleted()
+			if len(deleted) == 0 {
+				return fmt.Errorf("Should be deleted, but wasn't: %s", r)
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			// Deletion of unspecified settings.
+			{
+				PreConfig: func() {
+					// Insert an unmanaged key in the metadata for this tenant
+					duplosdktest.SetResource(unmanagedLocation, &unmanagedSetting)
+				},
+				Config: testAccProvider_GenConfig(
+					duplocloud_tenant_config_basic(rName, "\""+Tenant_testacc1b+"\"", true, []duplosdk.DuploKeyStringValue{
+						{Key: "abc", Value: "xyz"},
+						{Key: "mermaid", Value: "cousin"},
+					}),
+				),
+				Check: func(state *terraform.State) error {
+					r := "duplocloud_tenant_config." + rName
+					return resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(r, "tenant_id", Tenant_testacc1b),
+						resource.TestCheckResourceAttr(r, "delete_unspecified_settings", "true"),
+						resource.TestCheckResourceAttr(r, "setting.#", "2"),
+						resource.TestCheckResourceAttr(r, "setting.0.key", "abc"),
+						resource.TestCheckResourceAttr(r, "setting.0.value", "xyz"),
+						resource.TestCheckResourceAttr(r, "setting.1.key", "mermaid"),
+						resource.TestCheckResourceAttr(r, "setting.1.value", "cousin"),
+						resource.TestCheckResourceAttr(r, "specified_settings.#", "2"),
+						resource.TestCheckResourceAttr(r, "specified_settings.0", "abc"),
+						resource.TestCheckResourceAttr(r, "specified_settings.1", "mermaid"),
+						resource.TestCheckResourceAttr(r, "metadata.#", "2"),
+						resource.TestCheckResourceAttr(r, "metadata.0.key", "abc"),
+						resource.TestCheckResourceAttr(r, "metadata.0.value", "xyz"),
+						resource.TestCheckResourceAttr(r, "metadata.1.key", "mermaid"),
+						resource.TestCheckResourceAttr(r, "metadata.1.value", "cousin"),
 					)(state)
 				},
 			},

--- a/duplocloud/resource_duplo_tenant_config_test.go
+++ b/duplocloud/resource_duplo_tenant_config_test.go
@@ -1,0 +1,84 @@
+package duplocloud
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"terraform-provider-duplocloud/duplosdk"
+	"terraform-provider-duplocloud/internal/duplocloudtest"
+	"terraform-provider-duplocloud/internal/duplosdktest"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func duplocloud_tenant_config_basic(rName string, deleteUnspecified bool, settings []duplosdk.DuploKeyStringValue) string {
+	return duplocloudtest.WriteCustomResource("duplocloud_tenant_config", rName, func(sb *strings.Builder) {
+		duplocloudtest.WriteAttr(sb, "tenant_id", "\""+Tenant_testacc1a+"\"")
+		duplocloudtest.WriteAttr(sb, "delete_unspecified_settings", strconv.FormatBool(deleteUnspecified))
+
+		for i := range settings {
+			sb.WriteString("  setting {\n")
+			duplocloudtest.WriteAttr(sb, "  key", "\""+settings[i].Key+"\"")
+			duplocloudtest.WriteAttr(sb, "  value", "\""+settings[i].Value+"\"")
+			sb.WriteString("  }\n")
+		}
+	})
+}
+
+func TestAccResource_duplocloud_tenant_config_basic(t *testing.T) {
+	rName := acctest.RandStringFromCharSet(2, acctest.CharSetAlpha) +
+		acctest.RandStringFromCharSet(10, acctest.CharSetAlphaNum)
+
+	// Tenant that is allowed to be deleted.
+	resource.Test(t, resource.TestCase{
+		IsUnitTest: true,
+		Providers:  testAccProviders,
+		PreCheck:   duplosdktest.ResetEmulator,
+		CheckDestroy: func(state *terraform.State) error {
+			deleted := duplosdktest.EmuDeleted()
+			if len(deleted) == 0 {
+				return fmt.Errorf("Not deleted: %s", "duplocloud_tenant_conig."+rName)
+			}
+			return nil
+		},
+		Steps: []resource.TestStep{
+			// No deletion of unspecified settings.
+			// No modification of unspecified settings.
+			{
+				Config: testAccProvider_GenConfig(
+					duplocloud_tenant_config_basic(rName, false, []duplosdk.DuploKeyStringValue{
+						{Key: "abc", Value: "xyz"},
+						{Key: "mermaid", Value: "cousin"},
+					}),
+				),
+				Check: func(state *terraform.State) error {
+					r := "duplocloud_tenant_config." + rName
+					return resource.ComposeTestCheckFunc(
+						resource.TestCheckResourceAttr(r, "tenant_id", Tenant_testacc1a),
+						resource.TestCheckResourceAttr(r, "delete_unspecified_settings", "false"),
+						resource.TestCheckResourceAttr(r, "setting.#", "2"),
+						resource.TestCheckResourceAttr(r, "setting.0.key", "abc"),
+						resource.TestCheckResourceAttr(r, "setting.0.value", "xyz"),
+						resource.TestCheckResourceAttr(r, "setting.1.key", "mermaid"),
+						resource.TestCheckResourceAttr(r, "setting.1.value", "cousin"),
+						resource.TestCheckResourceAttr(r, "specified_settings.#", "2"),
+						resource.TestCheckResourceAttr(r, "specified_settings.0", "abc"),
+						resource.TestCheckResourceAttr(r, "specified_settings.1", "mermaid"),
+						resource.TestCheckResourceAttr(r, "metadata.#", "4"),
+						resource.TestCheckResourceAttr(r, "metadata.0.key", "abc"),
+						resource.TestCheckResourceAttr(r, "metadata.0.value", "xyz"),
+						resource.TestCheckResourceAttr(r, "metadata.1.key", "foo"),
+						resource.TestCheckResourceAttr(r, "metadata.1.value", "bar"),
+						resource.TestCheckResourceAttr(r, "metadata.2.key", "mermaid"),
+						resource.TestCheckResourceAttr(r, "metadata.2.value", "cousin"),
+						resource.TestCheckResourceAttr(r, "metadata.3.key", "xyz"),
+						resource.TestCheckResourceAttr(r, "metadata.3.value", "abc"),
+					)(state)
+				},
+			},
+		},
+	})
+}

--- a/internal/duplocloudtest/helpers.go
+++ b/internal/duplocloudtest/helpers.go
@@ -4,7 +4,19 @@ import (
 	"strings"
 )
 
-func WriteResource(rType, rName string, defaults, overrides map[string]string) string {
+func WriteCustomResource(rType, rName string, writer func(*strings.Builder)) string {
+	var sb strings.Builder
+	sb.WriteString("resource \"")
+	sb.WriteString(rType)
+	sb.WriteString("\" \"")
+	sb.WriteString(rName)
+	sb.WriteString("\" {\n")
+	writer(&sb)
+	sb.WriteString("}\n")
+	return sb.String()
+}
+
+func WriteFlatResource(rType, rName string, defaults, overrides map[string]string) string {
 	var sb strings.Builder
 	sb.WriteString("resource \"")
 	sb.WriteString(rType)

--- a/internal/duplosdktest/fixtures.go
+++ b/internal/duplosdktest/fixtures.go
@@ -80,13 +80,8 @@ func ListFixtures(location string) []byte {
 
 	// List files
 	files, err := os.ReadDir(dir)
-	if err != nil {
-		if os.IsNotExist(err) {
-			fc[location] = []byte("[]")
-			return fc[location]
-		} else {
-			log.Panicf("readdir: %s: %s", location, err)
-		}
+	if err != nil && !os.IsNotExist(err) {
+		log.Panicf("readdir: %s: %s", location, err)
 	}
 
 	// Cache all non-present elements.

--- a/internal/duplosdktest/fixtures.go
+++ b/internal/duplosdktest/fixtures.go
@@ -81,7 +81,12 @@ func ListFixtures(location string) []byte {
 	// List files
 	files, err := os.ReadDir(dir)
 	if err != nil {
-		log.Panicf("readdir: %s: %s", location, err)
+		if os.IsNotExist(err) {
+			fc[location] = []byte("[]")
+			return fc[location]
+		} else {
+			log.Panicf("readdir: %s: %s", location, err)
+		}
 	}
 
 	// Cache all non-present elements.
@@ -150,7 +155,20 @@ func GetFixture(location string) []byte {
 	return buff
 }
 
+func ResourceExists(location string) bool {
+	_, ok := fc[location]
+	return ok
+}
+
 func GetResource(location string, target interface{}) error {
 	bytes := GetFixture(location)
 	return json.Unmarshal(bytes, target)
+}
+
+func SetResource(location string, source interface{}) error {
+	bytes, err := json.Marshal(source)
+	if err == nil {
+		fc[location] = bytes
+	}
+	return err
 }

--- a/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/metadata/foo.json
+++ b/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/metadata/foo.json
@@ -1,0 +1,1 @@
+{"Key":"foo","Value":"bar"}

--- a/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/metadata/xyz.json
+++ b/internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/metadata/xyz.json
@@ -1,0 +1,1 @@
+{"Key":"xyz","Value":"abc"}

--- a/internal/duplosdktest/fixtures/tenant/6b2672db-b930-4875-b327-78d9dcbd5dd6.json
+++ b/internal/duplosdktest/fixtures/tenant/6b2672db-b930-4875-b327-78d9dcbd5dd6.json
@@ -1,0 +1,13 @@
+{
+  "TenantID":    "6b2672db-b930-4875-b327-78d9dcbd5dd6",
+  "AccountName": "testacc1b",
+  "PlanID":      "testacc1",
+  "TenantPolicy": {
+    "IamPolicies": [],
+    "AllowVolumeMapping": false,
+    "BlockExternalEp": false
+  },
+  "Tags": [
+    {"Key":"bar", "Value":"foo"}
+  ]
+}


### PR DESCRIPTION
## **User description**
## Overview

Adds unit tests:
- Resource: duplocloud_tenant_config

## Summary of changes

This PR does the following:

- Test Support:
  - emulate tenant metadata
  - emu PUT support
  - additional helper methods
  - bug fixes
- Unit Tests: Resource: duplocloud_tenant_config
  - happy path
  - edge case: (deleting unspecified settings)

## Testing performed

- [x] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- Duplo releases older than 1/2023 will be missing the v3 tenant metadata APIs


___

## **Type**
tests, enhancement


___

## **Description**
- Adds unit tests for `duplocloud_tenant_config` resource and data source, focusing on basic functionality and happy path scenarios.
- Enhances the emulator to support v3 tenant metadata APIs, including creation, update, and deletion of tenant metadata.
- Updates `TenantSetConfigKey` and `TenantDeleteConfigKey` methods in the SDK to use the v3 API, improving the handling of tenant configurations.
- Introduces new test helpers for more flexible and simplified resource creation in unit tests.
- Adds fixtures for tenant metadata to support the new unit tests.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests
</strong></td><td><details><summary>6 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>data_source_duplo_tenant_config_test.go</strong><dd><code>Add Unit Test for Data Source duplocloud_tenant_config</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/data_source_duplo_tenant_config_test.go

<li>Adds a new unit test for the data source <code>duplocloud_tenant_config</code>.<br> <li> Tests the basic retrieval of tenant configuration using the data <br>source.<br> <li> Verifies the tenant ID and metadata attributes are correctly fetched.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/407/files#diff-88051d40fedc31a57297e11e65575b26c7c4785c951197a9d331848dffc07700">+41/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_host_test.go</strong><dd><code>Refactor AWS Host Test Helper Method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_aws_host_test.go

<li>Refactors the helper method for AWS host resource tests to use a flat <br>resource writer.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/407/files#diff-1f1316c646bc9a213b79450ccd9c26b0372bbb8154b4e997fefc6cddee671129">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_tenant_config_test.go</strong><dd><code>Add Unit Tests for Resource duplocloud_tenant_config</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_tenant_config_test.go

<li>Adds unit tests for the <code>duplocloud_tenant_config</code> resource.<br> <li> Tests basic configuration setting and deletion behavior.<br> <li> Verifies the correct handling of specified and unspecified settings.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/407/files#diff-2ace4ec863908163bac5a2c7dc0b16a975256417f4a6a9e585c4b5c0417c081c">+84/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>helpers.go</strong><dd><code>Enhance Test Helpers with Custom and Flat Resource Writers</code></dd></summary>
<hr>
      
internal/duplocloudtest/helpers.go

<li>Adds a custom resource writer for more flexible test resource <br>generation.<br> <li> Introduces a flat resource writer for simplified test resource <br>creation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/407/files#diff-7cba2998784c07c4f5cf0c62f39952c85405f9565d654031ab1e3a0dcb372dfe">+13/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>foo.json</strong><dd><code>Add Fixture for Tenant Metadata Key `foo`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/metadata/foo.json

- Adds a fixture for tenant metadata with key `foo` and value `bar`.



</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/407/files#diff-e105314fa2f85a10c1c0b26316079de78d68fddc5e5307a2fd070ae68bd07cd5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>xyz.json</strong><dd><code>Add Fixture for Tenant Metadata Key `xyz`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
internal/duplosdktest/fixtures/tenant/302c6a63-ffc4-4276-b52e-48a84108b658/metadata/xyz.json

- Adds a fixture for tenant metadata with key `xyz` and value `abc`.



</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/407/files#diff-442d5296bbf3bd53728eff1034558e6b9f5e27305c902c6c527f9370dd44733d">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement
</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>provider_test.go</strong><dd><code>Enhance Emulator for Better API Support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/provider_test.go

<li>Enhances the emulator to support different HTTP verbs in the <br>responder.<br> <li> Adds support for emulating tenant metadata API.<br> <li> Improves the handling of AWS host and tenant creation and deletion in <br>the emulator.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/407/files#diff-75177a579ed2f81598ea793820ea80167844e948e1b11947d6080cb7ddb0a820">+24/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tenant.go</strong><dd><code>Update Tenant Configuration Methods to Use v3 API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/tenant.go

<li>Updates <code>TenantSetConfigKey</code> to use the v3 tenant metadata API.<br> <li> Adds return value to <code>TenantSetConfigKey</code> for the updated metadata.<br> <li> Implements <code>TenantDeleteConfigKey</code> using the v3 API.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/407/files#diff-b8d6917edf217103423ca7aba0ff7bc3ab0e9088269f2e84e496f64d27f4221d">+14/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>emulator.go</strong><dd><code>Enhance Emulator with v3 Tenant Metadata API Support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
internal/duplosdktest/emulator.go

<li>Adds support for emulating v3 tenant metadata APIs.<br> <li> Enhances HTTP method handling in the emulator for more accurate API <br>emulation.<br> <li> Implements emulation for creating, updating, and deleting tenant <br>metadata.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/407/files#diff-c5666c8c8d274f341af832bb5b324de49ef5b401bd676f3178fcf846bef76413">+26/-13</a>&nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
