### PR TITLE
DUPLO-13374 - Add SkipFinalSnapshot support for create and update rds.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2024-02-15
+
+### Added
+- Introduced `skip_final_snapshot` attribute to RDS instance creation and update, allowing control over whether a final snapshot is taken upon RDS instance deletion.
+- Enhanced deletion protection and backup retention period handling in RDS instance creation and update.
+- Updated SDK structs and functions to support the new `skip_final_snapshot` feature.
+- Updated RDS instance documentation to include the new `skip_final_snapshot` attribute.
+
 ## 2024-02-12
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,7 @@
 ## 2024-02-15
 
 ### Added
-- Introduced `skip_final_snapshot` attribute to RDS instance creation and update, allowing control over whether a final snapshot is taken upon RDS instance deletion.
-- Enhanced deletion protection and backup retention period handling in RDS instance creation and update.
-- Updated SDK structs and functions to support the new `skip_final_snapshot` feature.
-- Updated RDS instance documentation to include the new `skip_final_snapshot` attribute.
+- Introduced `skip_final_snapshot` attribute to `duplocloud_rds_instance`, allowing control over whether a final snapshot is taken upon RDS instance deletion.
 
 ## 2024-02-12
 

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -81,6 +81,7 @@ If you don't know the available engine versions for your RDS instance, you can u
 - `master_username` (String) The master username of the RDS instance.
 - `multi_az` (Boolean) Specifies if the RDS instance is multi-AZ.
 - `parameter_group_name` (String) A RDS parameter group name to apply to the RDS instance.
+- `skip_final_snapshot` (Boolean) If the final snapshot should be taken. When set to true, the final snapshot will not be taken when the resource is deleted. Defaults to `false`.
 - `snapshot_id` (String) A database snapshot to initialize the RDS instance from, at launch.
 - `storage_type` (String) Valid values: gp2 | gp3 | io1 | standard. Storage type to be used for RDS instance storage.
 - `store_details_in_secret_manager` (Boolean) Whether or not to store RDS details in the AWS secrets manager.

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -248,6 +248,13 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"skip_final_snapshot": {
+			Description: "If the final snapshot should be taken." +
+				"When set to true, the final snapshot will not be taken when the resource is deleted. Default final snapshot will be taken.",
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
 	}
 }
 
@@ -347,16 +354,17 @@ func resourceDuploRdsInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		identifier := d.Get("identifier").(string)
 		deleteProtection := new(bool)
 		*deleteProtection = d.Get("deletion_protection").(bool)
+
 		// Update delete protection settings.
 		log.Printf("[DEBUG] Updating delete protection settings to '%t' for db instance '%s'.", d.Get("deletion_protection").(bool), identifier)
 		if isAuroraDB(d) {
-			err = c.RdsClusterUpdateRequest(tenantID, duplosdk.DuploRdsClusterUpdateRequest{
+			err = c.UpdateRdsCluster(tenantID, duplosdk.DuploRdsUpdateCluster{
 				DBClusterIdentifier: identifier + "-cluster",
 				DeletionProtection:  deleteProtection,
 				ApplyImmediately:    true,
 			})
 		} else {
-			err = c.RdsInstanceChangeRequest(tenantID, duplosdk.DuploRdsInstanceUpdateRequest{
+			err = c.UpdateRDSDBInstance(tenantID, duplosdk.DuploRdsUpdateInstance{
 				DBInstanceIdentifier: identifier,
 				DeletionProtection:   deleteProtection,
 			})
@@ -455,40 +463,36 @@ func resourceDuploRdsInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		}
 	}
 
-	runUpdate := false
-	backupRetentionPeriod := new(int)
-	if d.HasChange("backup_retention_period") {
-		*backupRetentionPeriod = d.Get("backup_retention_period").(int)
-		log.Printf("[DEBUG] Updating backup_retention_period to: '%v' for db instance '%s'.", backupRetentionPeriod, identifier)
-		runUpdate = true
-	}
+	if d.HasChange("backup_retention_period") || d.HasChange("deletion_protection") || d.HasChange("skip_final_snapshot") {
+		backupRetentionPeriod := d.Get("backup_retention_period").(int)
+		skipFinalSnapshot := d.Get("skip_final_snapshot").(bool)
+		deleteProtection := new(bool)
 
-	deleteProtection := new(bool)
-	if isDeleteProtectionSupported(d) && d.HasChange("deletion_protection") {
-		*deleteProtection = d.Get("deletion_protection").(bool)
-		log.Printf("[DEBUG] Updating delete protection settings to '%v' for db instance '%s'.", deleteProtection, identifier)
-		runUpdate = true
-	}
+		if isDeleteProtectionSupported(d) {
+			log.Printf("[DEBUG] Updating delete protection settings to '%t' for db instance '%s'.", d.Get("deletion_protection").(bool), d.Get("identifier").(string))
+			*deleteProtection = d.Get("deletion_protection").(bool)
+		}
 
-	if runUpdate {
 		if isAuroraDB(d) {
-			err = c.RdsClusterUpdateRequest(tenantID, duplosdk.DuploRdsClusterUpdateRequest{
+			err = c.UpdateRdsCluster(tenantID, duplosdk.DuploRdsUpdateCluster{
 				DBClusterIdentifier:   identifier + "-cluster",
-				BackupRetentionPeriod: *backupRetentionPeriod,
+				BackupRetentionPeriod: backupRetentionPeriod,
 				DeletionProtection:    deleteProtection,
+				SkipFinalSnapshot:     skipFinalSnapshot,
 				ApplyImmediately:      true,
 			})
 		} else {
-			err = c.RdsInstanceChangeRequest(tenantID, duplosdk.DuploRdsInstanceUpdateRequest{
+			err = c.UpdateRDSDBInstance(tenantID, duplosdk.DuploRdsUpdateInstance{
 				DBInstanceIdentifier:  identifier,
-				BackupRetentionPeriod: *backupRetentionPeriod,
+				BackupRetentionPeriod: backupRetentionPeriod,
 				DeletionProtection:    deleteProtection,
+				SkipFinalSnapshot:     skipFinalSnapshot,
 			})
 		}
+	}
 
-		if err != nil {
-			return diag.FromErr(err)
-		}
+	if err != nil {
+		return diag.FromErr(err)
 	}
 
 	// Wait for the instance to become unavailable - but continue on if we timeout, without any errors raised.
@@ -621,6 +625,8 @@ func rdsInstanceFromState(d *schema.ResourceData) (*duplosdk.DuploRdsInstance, e
 	duploObject.BackupRetentionPeriod = d.Get("backup_retention_period").(int)
 	duploObject.MultiAZ = d.Get("multi_az").(bool)
 	duploObject.InstanceStatus = d.Get("instance_status").(string)
+	duploObject.SkipFinalSnapshot = d.Get("skip_final_snapshot").(bool)
+
 	if v, ok := d.GetOk("v2_scaling_configuration"); ok {
 		duploObject.V2ScalingConfiguration = expandV2ScalingConfiguration(v.([]interface{}))
 	}
@@ -695,6 +701,8 @@ func rdsInstanceToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Resour
 	jo["backup_retention_period"] = duploObject.BackupRetentionPeriod
 	jo["multi_az"] = duploObject.MultiAZ
 	jo["instance_status"] = duploObject.InstanceStatus
+	jo["skip_final_snapshot"] = duploObject.SkipFinalSnapshot
+
 	if duploObject.V2ScalingConfiguration != nil && duploObject.V2ScalingConfiguration.MinCapacity != 0 {
 		d.Set("v2_scaling_configuration", []map[string]interface{}{{
 			"min_capacity": duploObject.V2ScalingConfiguration.MinCapacity,

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -250,7 +250,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 		},
 		"skip_final_snapshot": {
 			Description: "If the final snapshot should be taken." +
-				"When set to true, the final snapshot will not be taken when the resource is deleted. Default final snapshot will be taken.",
+				" When set to true, the final snapshot will not be taken when the resource is deleted.",
 			Type:     schema.TypeBool,
 			Optional: true,
 			Default:  false,

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -348,9 +348,12 @@ func resourceDuploRdsInstanceCreate(ctx context.Context, d *schema.ResourceData,
 		return diag.Errorf("Error waiting for RDS DB instance '%s' to be available: %s", id, err)
 	}
 
-	diags = resourceDuploRdsInstanceRead(ctx, d, m)
+	createdRds, err := c.RdsInstanceGet(d.Id())
+	if err != nil {
+		return diag.FromErr(err)
+	}
 
-	identifier := d.Get("identifier").(string)
+	identifier := createdRds.Identifier
 
 	if d.HasChange("deletion_protection") || d.HasChange("skip_final_snapshot") {
 		skipFinalSnapshot := d.Get("skip_final_snapshot").(bool)
@@ -380,6 +383,8 @@ func resourceDuploRdsInstanceCreate(ctx context.Context, d *schema.ResourceData,
 			return diag.FromErr(err)
 		}
 	}
+
+	diags = resourceDuploRdsInstanceRead(ctx, d, m)
 
 	log.Printf("[TRACE] resourceDuploRdsInstanceCreate ******** end")
 	return diags

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -52,6 +52,7 @@ type DuploRdsInstance struct {
 	EncryptionKmsKeyId          string                  `json:"EncryptionKmsKeyId,omitempty"`
 	EnableLogging               bool                    `json:"EnableLogging,omitempty"`
 	BackupRetentionPeriod       int                     `json:"BackupRetentionPeriod,omitempty"`
+	SkipFinalSnapshot           bool                    `json:"SkipFinalSnapshot,omitempty"`
 	MultiAZ                     bool                    `json:"MultiAZ,omitempty"`
 	InstanceStatus              string                  `json:"InstanceStatus,omitempty"`
 	DBSubnetGroupName           string                  `json:"DBSubnetGroupName,omitempty"`
@@ -77,17 +78,19 @@ type DuploRdsUpdatePayload struct {
 	SizeEx        string `json:"SizeEx,omitempty"`
 }
 
-type DuploRdsInstanceUpdateRequest struct {
+type DuploRdsUpdateInstance struct {
 	DBInstanceIdentifier  string `json:"DBInstanceIdentifier"`
 	DeletionProtection    *bool  `json:"DeletionProtection,omitempty"`
 	BackupRetentionPeriod int    `json:"BackupRetentionPeriod,omitempty"`
+	SkipFinalSnapshot     bool   `json:"SkipFinalSnapshot,omitempty"`
 }
 
-type DuploRdsClusterUpdateRequest struct {
+type DuploRdsUpdateCluster struct {
 	DBClusterIdentifier   string `json:"DBClusterIdentifier"`
 	ApplyImmediately      bool   `json:"ApplyImmediately"`
 	DeletionProtection    *bool  `json:"DeletionProtection,omitempty"`
 	BackupRetentionPeriod int    `json:"BackupRetentionPeriod,omitempty"`
+	SkipFinalSnapshot     bool   `json:"SkipFinalSnapshot,omitempty"`
 }
 
 type DuploRdsModifyAuroraV2ServerlessInstanceSize struct {
@@ -234,18 +237,18 @@ func (c *Client) RdsInstanceChangeSizeOrEnableLogging(tenantID string, instanceI
 	)
 }
 
-func (c *Client) RdsInstanceChangeRequest(tenantID string, duploObject DuploRdsInstanceUpdateRequest) ClientError {
+func (c *Client) UpdateRDSDBInstance(tenantID string, duploObject DuploRdsUpdateInstance) ClientError {
 	return c.putAPI(
-		fmt.Sprintf("RdsInstanceChangeRequest(%s, %s)", tenantID, duploObject.DBInstanceIdentifier),
+		fmt.Sprintf("UpdateRDSDBInstance(%s, %s)", tenantID, duploObject.DBInstanceIdentifier),
 		fmt.Sprintf("v3/subscriptions/%s/aws/rds/instance/%s", tenantID, duploObject.DBInstanceIdentifier),
 		&duploObject,
 		nil,
 	)
 }
 
-func (c *Client) RdsClusterUpdateRequest(tenantID string, duploObject DuploRdsClusterUpdateRequest) ClientError {
+func (c *Client) UpdateRdsCluster(tenantID string, duploObject DuploRdsUpdateCluster) ClientError {
 	return c.putAPI(
-		fmt.Sprintf("RdsClusterUpdateRequest(%s, %s)", tenantID, duploObject.DBClusterIdentifier),
+		fmt.Sprintf("UpdateRdsCluster(%s, %s)", tenantID, duploObject.DBClusterIdentifier),
 		fmt.Sprintf("v3/subscriptions/%s/aws/rds/cluster/%s", tenantID, duploObject.DBClusterIdentifier),
 		&duploObject,
 		nil,


### PR DESCRIPTION
## **User description**
## Overview

DUPLO-13374 - Add SkipFinalSnapshot support for create and update rds.

## Summary of changes

This PR does the following:

- Add SkipFinalSnapshot support for create and update rds.
- Updated generated docs

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [x] Manually, on a remote test system

## Describe any breaking changes

- none


___

## **Type**
enhancement


___

## **Description**
- Introduced the `skip_final_snapshot` attribute to control whether a final snapshot is taken upon RDS instance deletion.
- Enhanced the RDS instance creation and update logic to support `skip_final_snapshot`, alongside improvements to deletion protection and backup retention period handling.
- Updated SDK structs and functions to reflect the new `skip_final_snapshot` feature and improved clarity in naming.
- Updated the RDS instance documentation to include the new `skip_final_snapshot` attribute.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_instance.go</strong><dd><code>Add Support for Skip Final Snapshot on RDS Instances</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_rds_instance.go

<li>Added support for <code>skip_final_snapshot</code> attribute in RDS instance <br>creation and update.<br> <li> Enhanced deletion protection and backup retention period update logic.<br> <li> Refactored update logic to include changes for <code>skip_final_snapshot</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/408/files#diff-a8bf9b56a3e9b39899a5d37d7608110678908754e0848fab2d0320653ea65f71">+49/-30</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rds_instance.go</strong><dd><code>Enhance SDK with Skip Final Snapshot for RDS Instances</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/rds_instance.go

<li>Introduced <code>SkipFinalSnapshot</code> attribute in RDS instance and update <br>structs.<br> <li> Renamed update request structs for clarity.<br> <li> Added <code>SkipFinalSnapshot</code> handling in RDS instance and cluster update <br>functions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/408/files#diff-3aeb597ae11ae40342366a786a3b78f55a1265ea03d8d2729401d9a7f3b7291a">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rds_instance.md</strong><dd><code>Document Skip Final Snapshot Attribute for RDS Instances</code>&nbsp; </dd></summary>
<hr>
      
docs/resources/rds_instance.md

- Documented the `skip_final_snapshot` attribute for RDS instances.



</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/408/files#diff-2be785952795586c48f30db78e5f3684f72a430f66155dd8ea0d85f0607eedb7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
