### PR TITLE
DUPLO-15103 Bug Fix Plugin crashed when creating opensearch with the warm_enabled set to true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 ## 2024-02-15
 
 ### Fixed
-- Fixed plugin crash while creating opensearch resource when warm enabled set to true.
-- Resolved nil pointer exceptions in CloudWatch Event Rule and Elasticsearch resources.
-- Enhanced logging for debugging cold storage options in Elasticsearch resource.
+- Fixed plugin crash while creating opensearch resource when warm enabled set to true for `duplocloud_aws_elasticsearch resource.
 
 ## 2024-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2024-02-15
+
+### Fixed
+- Fixed plugin crash while creating opensearch resource when warm enabled set to true.
+- Resolved nil pointer exceptions in CloudWatch Event Rule and Elasticsearch resources.
+- Enhanced logging for debugging cold storage options in Elasticsearch resource.
+
 ## 2024-02-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ## 2024-02-15
 
+### Added
+- Introduced `skip_final_snapshot` attribute to `duplocloud_rds_instance`, allowing control over whether a final snapshot is taken upon RDS instance deletion.
+
 ### Fixed
-- Fixed plugin crash while creating opensearch resource when warm enabled set to true for `duplocloud_aws_elasticsearch resource.
+- Fixed plugin crash while creating opensearch resource when warm enabled set to true for `duplocloud_aws_elasticsearch` resource at `awsElasticSearchDomainClusterConfigFromState`..
+- Handled nil pointer exceptions in `duplocloud_aws_cloudwatch_event_rule` resources at `resourceAwsCloudWatchEventRuleRead`  
 
 ## 2024-02-13
 

--- a/duplocloud/resource_duplo_aws_cloudwatch_event_rule.go
+++ b/duplocloud/resource_duplo_aws_cloudwatch_event_rule.go
@@ -121,15 +121,17 @@ func resourceAwsCloudWatchEventRuleRead(ctx context.Context, d *schema.ResourceD
 		}
 		return diag.Errorf("Unable to retrieve tenant %s cloudwatch event rule'%s': %s", tenantID, fullName, clientErr)
 	}
-	if duplo != nil {
-		d.Set("tenant_id", tenantID)
-		d.Set("fullname", fullName)
-		d.Set("arn", duplo.Arn)
-		d.Set("event_bus_name", duplo.EventBusName)
-		d.Set("role_arn", duplo.RoleArn)
-		d.Set("schedule_expression", duplo.ScheduleExpression)
-		d.Set("event_pattern", duplo.EventPattern)
+	if duplo == nil {
+		d.SetId("") // object missing
+		return nil
 	}
+	d.Set("tenant_id", tenantID)
+	d.Set("fullname", fullName)
+	d.Set("arn", duplo.Arn)
+	d.Set("event_bus_name", duplo.EventBusName)
+	d.Set("role_arn", duplo.RoleArn)
+	d.Set("schedule_expression", duplo.ScheduleExpression)
+	d.Set("event_pattern", duplo.EventPattern)
 	log.Printf("[TRACE] resourceAwsCloudWatchEventRuleRead(%s, %s): end", tenantID, fullName)
 	return nil
 }

--- a/duplocloud/resource_duplo_aws_cloudwatch_event_rule.go
+++ b/duplocloud/resource_duplo_aws_cloudwatch_event_rule.go
@@ -121,15 +121,15 @@ func resourceAwsCloudWatchEventRuleRead(ctx context.Context, d *schema.ResourceD
 		}
 		return diag.Errorf("Unable to retrieve tenant %s cloudwatch event rule'%s': %s", tenantID, fullName, clientErr)
 	}
-
-	d.Set("tenant_id", tenantID)
-	d.Set("fullname", fullName)
-	d.Set("arn", duplo.Arn)
-	d.Set("event_bus_name", duplo.EventBusName)
-	d.Set("role_arn", duplo.RoleArn)
-	d.Set("schedule_expression", duplo.ScheduleExpression)
-	d.Set("event_pattern", duplo.EventPattern)
-
+	if duplo != nil {
+		d.Set("tenant_id", tenantID)
+		d.Set("fullname", fullName)
+		d.Set("arn", duplo.Arn)
+		d.Set("event_bus_name", duplo.EventBusName)
+		d.Set("role_arn", duplo.RoleArn)
+		d.Set("schedule_expression", duplo.ScheduleExpression)
+		d.Set("event_pattern", duplo.EventPattern)
+	}
 	log.Printf("[TRACE] resourceAwsCloudWatchEventRuleRead(%s, %s): end", tenantID, fullName)
 	return nil
 }

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -652,8 +652,14 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 	}
 	if v, ok := m["cold_storage_options"]; ok {
 		obj := v.([]interface{})
+		log.Printf("cold storage option value %+v", obj)
 		if len(obj) > 0 {
-			duplo.ColdStorageOptions.Enabled = obj[0].(map[string]interface{})["enabled"].(bool)
+			//enabled := obj[0].(map[string]interface{})["enabled"].(bool)
+			//log.Printf("enabled value %+v", enabled)
+			coldStorageOptions := duplosdk.DuploElasticSearchDomainColdStorageOptions{
+				Enabled: obj[0].(map[string]interface{})["enabled"].(bool),
+			}
+			duplo.ColdStorageOptions = &coldStorageOptions
 		}
 	}
 	if v, ok := m["warm_count"]; ok {
@@ -664,9 +670,11 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 	}
 	if v, ok := m["warm_type"]; ok {
 		obj := v.(string)
-		duplo.WarmType = nil
 		if obj != "" {
-			duplo.WarmType.Value = obj
+			warmType := duplosdk.DuploStringValue{
+				Value: obj,
+			}
+			duplo.WarmType = &warmType
 		}
 	}
 

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -654,8 +654,6 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 		obj := v.([]interface{})
 		log.Printf("cold storage option value %+v", obj)
 		if len(obj) > 0 {
-			//enabled := obj[0].(map[string]interface{})["enabled"].(bool)
-			//log.Printf("enabled value %+v", enabled)
 			coldStorageOptions := duplosdk.DuploElasticSearchDomainColdStorageOptions{
 				Enabled: obj[0].(map[string]interface{})["enabled"].(bool),
 			}


### PR DESCRIPTION
## **User description**
## Overview
Fixed plugin crash while creating opensearch resource when warm enabled set to true

## Summary of changes
Fix bug related to creating duplo_aws_elasticsearch resource when warm enabled true due to nil pointer exception

This PR does the following:

- Created object for DuploElasticSearchDomainColdStorageOptions struct and assigned to ColdStorageOptions attribute by reference to handle nil pointer exception for duplo_aws_elasticsearch resource

- Created object for DuploStringValue struct and assigned to WarmType attribute by reference to handle nil pointer exception
for duplo_aws_elasticsearch resource


## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
bug_fix


___

## **Description**
- Fixed a potential nil pointer dereference in CloudWatch Event Rule resource by adding a nil check.
- Resolved nil pointer exceptions in Elasticsearch resource by properly initializing structs for cold storage options and warm type.
- Enhanced logging for debugging cold storage options in Elasticsearch resource.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_cloudwatch_event_rule.go</strong><dd><code>Prevent Nil Pointer Dereference in CloudWatch Event Rule Resource</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_aws_cloudwatch_event_rule.go

<li>Added a nil check for <code>duplo</code> before setting resource data to prevent <br>potential nil pointer dereference.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/409/files#diff-01c1b4a6128c58f7ada6b710fcdc6ba1cf66bf3000b24622dc4057d961a71044">+9/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_elasticsearch.go</strong><dd><code>Fix Nil Pointer Exception in Elasticsearch Resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_aws_elasticsearch.go

<li>Added detailed logging for cold storage options.<br> <li> Fixed nil pointer exception by initializing <br><code>DuploElasticSearchDomainColdStorageOptions</code> and <code>DuploStringValue</code> <br>structs before assignment.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/409/files#diff-74075534ff698afe18f26ee1215cb2f57c76aa949aca23c1464f4dcaed02386f">+11/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Inline File Walkthrough 💎</strong></summary><hr>

For enhanced user experience, the `describe` tool can add file summaries directly to the "Files changed" tab in the PR page.
This will enable you to quickly understand the changes in each file, while reviewing the code changes (diffs).

To enable inline file summary, set `pr_description.inline_file_summary` in the configuration file, possible values are:
- `'table'`: File changes walkthrough table will be displayed on the top of the "Files changed" tab, in addition to the "Conversation" tab.
- `true`: A collapsable file comment with changes title and a changes summary for each file in the PR.
- `false` (default): File changes walkthrough will be added only to the "Conversation" tab.
<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
