### PR TITLE
[DUPLO-14500] - TF: Not able create OpenSearch with (warm enable =false and cold storage=false)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2024-02-21
+## 2024-02-27
 
 ### Fixed
 - Resolved an issue in `duplocloud_aws_elasticsearch` resource where OpenSearch could not be created with both warm enable and cold storage set to false.

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -654,10 +654,16 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 		obj := v.([]interface{})
 		log.Printf("cold storage option value %+v", obj)
 		if len(obj) > 0 {
-			coldStorageOptions := duplosdk.DuploElasticSearchDomainColdStorageOptions{
-				Enabled: obj[0].(map[string]interface{})["enabled"].(bool),
+			value := obj[0].(map[string]interface{})["enabled"].(bool)
+			if value {
+				coldStorageOptions := duplosdk.DuploElasticSearchDomainColdStorageOptions{
+					Enabled: value,
+				}
+				duplo.ColdStorageOptions = &coldStorageOptions
+			} else {
+				duplo.ColdStorageOptions = nil
 			}
-			duplo.ColdStorageOptions = &coldStorageOptions
+
 		}
 	}
 	if v, ok := m["warm_count"]; ok {

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -654,8 +654,9 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 		obj := v.([]interface{})
 		log.Printf("cold storage option value %+v", obj)
 		if len(obj) > 0 {
-			value := obj[0].(map[string]interface{})["enabled"].(bool)
-			if value {
+			value, ok := obj[0].(map[string]interface{})["enabled"].(bool)
+
+			if ok && value {
 				coldStorageOptions := duplosdk.DuploElasticSearchDomainColdStorageOptions{
 					Enabled: value,
 				}


### PR DESCRIPTION
## **User description**
## Overview

[DUPLO-14500] - TF: Not able create OpenSearch with (warm enable =false and cold storage=false)
## Summary of changes

This PR does the following:

- later commits overriden my changes
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
bug_fix


___

## **Description**
- Corrected the logic for setting `ColdStorageOptions` in AWS Elasticsearch configurations to address issues when cold storage is disabled.
- This fix ensures that Elasticsearch domains are correctly configured without cold storage when specified by the user.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_elasticsearch.go</strong><dd><code>Fix Cold Storage Options Handling in AWS Elasticsearch</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_aws_elasticsearch.go

<li>Fixed handling of cold storage options for AWS Elasticsearch to <br>properly handle cases where cold storage is disabled.<br> <li> Ensured that <code>ColdStorageOptions</code> is set to nil when cold storage is not <br>enabled, preventing incorrect configuration.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/413/files#diff-74075534ff698afe18f26ee1215cb2f57c76aa949aca23c1464f4dcaed02386f">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

