### PR TITLE
DUPLO-13077 fixes broken elastic search creation with no dedicated master type and fixes elasticsearch_version mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,6 @@
 ### Fixed
 - Resolved an issue in `duplocloud_aws_elasticsearch` resource where OpenSearch could not be created with both warm enable and cold storage set to false.
 - Corrected the `FileSystemId` assignment in the EFS update function for `duplocloud_aws_efs_lifecycle_policy`
-
-## 2024-02-21
-
-### Fixed
 - Fixed a potential crash in `duplocloud_aws_elasticsearch` creation when `dedicated_master_type` was not defined.
 
 ## 2024-02-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2024-02-21
+
+### Fixed
+- Fixed a potential crash in ElasticSearch resource creation when `dedicated_master_type` was not defined.
+- Corrected the parameter name from `ElasticSearchVersion` to `EngineVersion` to accurately reflect the API's expected parameter.
+
 ## 2024-02-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 ## 2024-02-21
 
 ### Fixed
-- Fixed a potential crash in ElasticSearch resource creation when `dedicated_master_type` was not defined.
-- Corrected the parameter name from `ElasticSearchVersion` to `EngineVersion` to accurately reflect the API's expected parameter.
+- Fixed a potential crash in `duplocloud_aws_elasticsearch` creation when `dedicated_master_type` was not defined.
 
 ## 2024-02-15
 

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -685,7 +685,11 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 				duplo.DedicatedMasterCount = v.(int)
 			}
 			if v, ok := m["dedicated_master_type"]; ok && v.(string) != "" {
-				duplo.DedicatedMasterType.Value = v.(string)
+				obj := v.(string)
+				duplo.DedicatedMasterType = nil
+				if obj != "" {
+					duplo.DedicatedMasterType.Value = obj
+				}
 			}
 		}
 	}

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -685,11 +685,10 @@ func awsElasticSearchDomainClusterConfigFromState(m map[string]interface{}, dupl
 				duplo.DedicatedMasterCount = v.(int)
 			}
 			if v, ok := m["dedicated_master_type"]; ok && v.(string) != "" {
-				obj := v.(string)
-				duplo.DedicatedMasterType = nil
-				if obj != "" {
-					duplo.DedicatedMasterType.Value = obj
+				dedicatedMasterType := duplosdk.DuploStringValue{
+					Value: v.(string),
 				}
+				duplo.DedicatedMasterType = &dedicatedMasterType
 			}
 		}
 	}

--- a/duplosdk/aws_elasticsearch.go
+++ b/duplosdk/aws_elasticsearch.go
@@ -37,7 +37,7 @@ type DuploElasticSearchDomainEndpointOptions struct {
 type DuploElasticSearchDomainClusterConfig struct {
 	DedicatedMasterCount   int                                         `json:"DedicatedMasterCount,omitempty"`
 	DedicatedMasterEnabled bool                                        `json:"DedicatedMasterEnabled,omitempty"`
-	DedicatedMasterType    DuploStringValue                            `json:"DedicatedMasterType,omitempty"`
+	DedicatedMasterType    *DuploStringValue                           `json:"DedicatedMasterType,omitempty"`
 	InstanceCount          int                                         `json:"InstanceCount,omitempty"`
 	InstanceType           DuploStringValue                            `json:"InstanceType,omitempty"`
 	WarmCount              int                                         `json:"WarmCount,omitempty"`


### PR DESCRIPTION
## **User description**
## Overview

Creation of Elastic search cluster was crashing when `dedicated_master_type` field of cluster config was not defined because it was implicitly being assigned `{ Value: null }` by Go. The unexpected structure made AWS throw a non descriptive error message `Value cannot be null, parameter : key`. This PR makes this field into a pointer so we may properly assign it `null` when it is not defined. AWS lets us create it properly with no errors if dedicated_master_type is null.

This PR also fixes attribute mapping between API response and TF state. The correct version field is called `EngineVerion` instead of `ElasticSearchVersion`.

## Summary of changes

This PR does the following:

- Makes `dedicated_master_type` into a pointer so it is null if absent from parameters when creating `DuploElasticSearchDomainRequest`
- fixes mapping between `elsaticsearch_version` and the BE's `EngineVersion` fields

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
bug_fix


___

## **Description**
- Fixed a potential crash in `duplocloud_aws_elasticsearch` creation when `dedicated_master_type` was not defined by changing `DedicatedMasterType` to a pointer.
- Updated `DuploElasticSearchDomainClusterConfig` to handle null values for `DedicatedMasterType` more gracefully.
- Documented the fix in the CHANGELOG.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_elasticsearch.go</strong><dd><code>Fix ElasticSearch Creation with Undefined `dedicated_master_type`</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_aws_elasticsearch.go

<li>Changed <code>DedicatedMasterType</code> from <code>DuploStringValue</code> to a pointer of <br><code>DuploStringValue</code> to handle null values correctly.<br> <li> Ensured <code>dedicated_master_type</code> is assigned correctly when creating <br><code>DuploElasticSearchDomainRequest</code>.<br>


</details>
    

  </td>
  <td><a href="https:/duplocloud/terraform-provider-duplocloud/pull/416/files#diff-74075534ff698afe18f26ee1215cb2f57c76aa949aca23c1464f4dcaed02386f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws_elasticsearch.go</strong><dd><code>Update `DedicatedMasterType` to Pointer for Null Handling</code></dd></summary>
<hr>
      
duplosdk/aws_elasticsearch.go

<li>Modified <code>DedicatedMasterType</code> in <code>DuploElasticSearchDomainClusterConfig</code> <br>to be a pointer to handle null values.<br>


</details>
    

  </td>
  <td><a href="https:/duplocloud/terraform-provider-duplocloud/pull/416/files#diff-aa10acb1bd1e5bbc66aecf2b5383547b4724d45bfeab0c654a8b9f61148dcf61">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update CHANGELOG for ElasticSearch Creation Fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
CHANGELOG.md

<li>Added entry for fixing crash in <code>duplocloud_aws_elasticsearch</code> creation <br>when <code>dedicated_master_type</code> was not defined.<br>


</details>
    

  </td>
  <td><a href="https:/duplocloud/terraform-provider-duplocloud/pull/416/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

