### PR TITLE
DUPLO-11165: Added dead letter queue configuration to AWS lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2024-02-27
 
 ### Added
-- Added support for configuring a dead letter queue (DLQ) for AWS Lambda functions, allowing users to specify an SNS topic or SQS queue for failed invocation notifications. This includes CRUD operations for this new feature and state management in the Terraform provider.
+- Added support for configuring a dead letter queue (DLQ) `dead_letter_queue` for AWS Lambda functions `duplocloud_aws_lambda_function`, allowing users to specify an SNS topic or SQS queue for failed invocation notifications. This includes CRUD operations for this new feature and state management in the Terraform provider.
 
 ## 2024-02-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-02-27
+
+### Added
+- Added support for configuring a dead letter queue (DLQ) for AWS Lambda functions, allowing users to specify an SNS topic or SQS queue for failed invocation notifications. This includes CRUD operations for this new feature and state management in the Terraform provider.
+
 ## 2024-02-15
 
 ### Added

--- a/duplosdk/aws_lambda_function.go
+++ b/duplosdk/aws_lambda_function.go
@@ -49,6 +49,7 @@ type DuploLambdaConfiguration struct {
 	VpcConfig        *DuploLambdaVpcConfig        `json:"VpcConfig,omitempty"`
 	Layers           *[]DuploLambdaLayerGet       `json:"Layers,omitempty"`
 	EphemeralStorage *DuploLambdaEphemeralStorage `json:"EphemeralStorage,omitempty"`
+	DeadLetterConfig *DuploDeadLetterConfig       `json:"DeadLetterConfig,omitempty"`
 }
 
 // DuploLambdaCode is a Duplo SDK object that represents a lambda function's code.
@@ -72,6 +73,11 @@ type DuploLambdaEnvironment struct {
 // DuploLambdaEphemeralStorage is a Duplo SDK object that represents a lambda function's ephemeral storage config.
 type DuploLambdaEphemeralStorage struct {
 	Size int `json:"Size"`
+}
+
+// DuploDeadLetterConfig is a Duplo SDK object that represents a lambda function's dead letter config (SNS or SQS).
+type DuploDeadLetterConfig struct {
+	TargetArn string `json:"TargetArn"`
 }
 
 // DuploLambdaTracingConfig is a Duplo SDK object that represents a lambda function's tracing config.
@@ -102,6 +108,7 @@ type DuploLambdaCreateRequest struct {
 	Tags             map[string]string            `json:"Tags,omitempty"`
 	Layers           *[]string                    `json:"Layers,omitempty"`
 	TracingConfig    *DuploLambdaTracingConfig    `json:"TracingConfig,omitempty"`
+	DeadLetterConfig *DuploDeadLetterConfig       `json:"DeadLetterConfig,omitempty"`
 }
 
 // DuploLambdaUpdateRequest is a Duplo SDK object that represents a request to update a lambda function's code.
@@ -126,6 +133,7 @@ type DuploLambdaConfigurationRequest struct {
 	Tags             map[string]string            `json:"Tags,omitempty"`
 	Timeout          int                          `json:"Timeout,omitempty"`
 	TracingConfig    *DuploLambdaTracingConfig    `json:"TracingConfig,omitempty"`
+	DeadLetterConfig *DuploDeadLetterConfig       `json:"DeadLetterConfig,omitempty"`
 }
 
 type DuploLambdaPermissionStatement struct {


### PR DESCRIPTION
## **User description**
## Overview

Added dead letter queue configuration to AWS lambda

## Summary of changes

This PR does the following:

Added dead letter queue configuration to AWS lambda

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system


___

## **Type**
enhancement


___

## **Description**
- Added support for configuring a dead letter queue (DLQ) for AWS Lambda functions, allowing specification of an SNS topic or SQS queue for failed invocation notifications.
- Implemented CRUD operations and Terraform state management for the new `dead_letter_config` feature in AWS Lambda resource.
- Updated SDK with `DuploDeadLetterConfig` struct to support dead letter configuration in Lambda functions.
- Updated CHANGELOG.md to document the addition of dead letter queue configuration support.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_lambda_function.go</strong><dd><code>Implement Dead Letter Queue Configuration for AWS Lambda Functions</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_aws_lambda_function.go

<li>Added <code>dead_letter_config</code> schema definition for AWS Lambda functions.<br> <li> Implemented CRUD operations for the dead letter queue configuration.<br> <li> Added handling for <code>dead_letter_config</code> in resource read, create, and <br>update functions.<br>


</details>
    

  </td>
  <td><a href="https:/duplocloud/terraform-provider-duplocloud/pull/423/files#diff-c13f14fb2a32c7d12b7beb43bd7a8d80d643b446a7def447c9774e170bb9e9e2">+45/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aws_lambda_function.go</strong><dd><code>SDK Support for Lambda Function Dead Letter Configuration</code></dd></summary>
<hr>
      
duplosdk/aws_lambda_function.go

<li>Introduced <code>DuploDeadLetterConfig</code> struct to represent dead letter <br>configuration.<br> <li> Added <code>DeadLetterConfig</code> field to relevant structs for Lambda function <br>operations.<br>


</details>
    

  </td>
  <td><a href="https:/duplocloud/terraform-provider-duplocloud/pull/423/files#diff-481201c30d6877a01e9dd350d11edce52e01e472cfab7e6b6ecaffca4ed8f6e2">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update CHANGELOG for Dead Letter Queue Support in AWS Lambda</code></dd></summary>
<hr>
      
CHANGELOG.md

<li>Documented the addition of dead letter queue configuration for AWS <br>Lambda functions.<br>


</details>
    

  </td>
  <td><a href="https:/duplocloud/terraform-provider-duplocloud/pull/423/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

