### PR TITLE
DUPLO 14317 Plan Setting Bug 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2024-03-07
+
+### Fixed
+- `unrestricted_ext_lb` attribute not setting to false fix for `duplocloud_plan_settings` resource
 ## 2024-02-28
 
 ### Added

--- a/duplocloud/resource_duplo_plan_settings.go
+++ b/duplocloud/resource_duplo_plan_settings.go
@@ -142,11 +142,11 @@ func resourcePlanSettingsCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 	log.Printf("[TRACE] resourcePlanSettingsCreateOrUpdate(%s): start", planID)
 
 	c := m.(*duplosdk.Client)
-
 	// Apply "special" plan settings.
-	if v, ok := d.GetOk("unrestricted_ext_lb"); ok {
+	if d.HasChange("unrestricted_ext_lb") {
+		unRestrictedExtLB := d.Get("unrestricted_ext_lb").(bool)
 		settings := duplosdk.DuploPlanSettings{
-			UnrestrictedExtLB: v.(bool),
+			UnrestrictedExtLB: unRestrictedExtLB,
 		}
 		_, err := c.PlanUpdateSettings(planID, &settings)
 		if err != nil {


### PR DESCRIPTION
## Overview

Plan setting resource Bug
## Summary of changes
Terraform fails to set unrestricted_ext_lb fixed
This PR does the following:

- Looking for change on unrestricted_ext_lb
- Updating unrestricted_ext_lb attribute

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...
