### PR TITLE
Duplo 15257 Elastic cache support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2024-03-07
 
 ### Added
-- Added support for cluster mode enable/disable and number of shards for `duplocloud_ecache_instance` resource
+- Added support attribute for setting cluster mode and number of shards for `duplocloud_ecache_instance` resource
 
 ## 2024-02-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-03-07
+
+### Added
+- Added support for cluster mode enable/disable and number of shards for `duplocloud_ecache_instance` resource
+
 ## 2024-02-28
 
 ### Added

--- a/docs/resources/aws_dynamodb_table_v2.md
+++ b/docs/resources/aws_dynamodb_table_v2.md
@@ -24,10 +24,6 @@ resource "duplocloud_aws_dynamodb_table_v2" "tst-dynamodb-table" {
   name           = "tst-dynamodb-table"
   read_capacity  = 10
   write_capacity = 10
-  
-  deletion_protection_enabled = false
-  is_point_in_time_recovery = false
-
   #billing_mode = "PAY_PER_REQUEST"
   tag {
     key   = "CreatedBy"
@@ -89,7 +85,9 @@ resource "duplocloud_aws_dynamodb_table_v2" "tst-dynamodb-table" {
 
 - `attribute` (Block Set) (see [below for nested schema](#nestedblock--attribute))
 - `billing_mode` (String) Controls how you are charged for read and write throughput and how you manage capacity. The valid values are `PROVISIONED` and `PAY_PER_REQUEST`. Defaults to `PROVISIONED`.
+- `deletion_protection_enabled` (Boolean) Deletion protection keeps the tables from being deleted unintentionally. While this setting is on, you can't delete the table.
 - `global_secondary_index` (Block Set) Describe a GSI for the table; subject to the normal limits on the number of GSIs, projected attributes, etc. (see [below for nested schema](#nestedblock--global_secondary_index))
+- `is_point_in_time_recovery` (Boolean) The point in time recovery status of the dynamodb table. Enabled if true.
 - `key_schema` (Block List) (see [below for nested schema](#nestedblock--key_schema))
 - `local_secondary_index` (Block Set) (see [below for nested schema](#nestedblock--local_secondary_index))
 - `read_capacity` (Number) The number of read units for this table. If the `billing_mode` is `PROVISIONED`, this field is required.

--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -19,11 +19,13 @@ resource "duplocloud_tenant" "myapp" {
 }
 
 resource "duplocloud_ecache_instance" "mycache" {
-  tenant_id  = duplocloud_tenant.myapp.tenant_id
-  name       = "mycache"
-  cache_type = 0 // Redis
-  replicas   = 1
-  size       = "cache.t2.small"
+  tenant_id           = duplocloud_tenant.myapp.tenant_id
+  name                = "mycache"
+  cache_type          = 0 // Redis
+  replicas            = 1
+  size                = "cache.t2.small"
+  enable_cluster_mode = true // applicable only for redis
+  number_of_shards    = 1    // applicable only for redis
 }
 ```
 
@@ -49,11 +51,13 @@ Should be one of:
    - `1` : Memcache
 
  Defaults to `0`.
+- `enable_cluster_mode` (Boolean) Flag to enable/disable redis cluster mode.
 - `encryption_at_rest` (Boolean) Enables encryption-at-rest. Defaults to `false`.
 - `encryption_in_transit` (Boolean) Enables encryption-in-transit. Defaults to `false`.
 - `engine_version` (String) The engine version of the elastic instance.
 See AWS documentation for the [available Redis instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) or the [available Memcached instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions-mc.html).
 - `kms_key_id` (String) The globally unique identifier for the key.
+- `number_of_shards` (Number) The number of shards to create. Defaults to `2`.
 - `parameter_group_name` (String) The REDIS parameter group to supply.
 - `replicas` (Number) The number of replicas to create. Defaults to `1`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -313,10 +313,14 @@ func expandEcacheInstance(d *schema.ResourceData) *duplosdk.DuploEcacheInstance 
 		ParameterGroupName:  d.Get("parameter_group_name").(string),
 	}
 	if data.CacheType == 0 {
-		data.EnableClusterMode = d.Get("enable_cluster_mode").(bool)
+		if v, ok := d.GetOk("enable_cluster_mode"); ok { //applicable for only redis type
+			data.EnableClusterMode = v.(bool)
+		}
 	}
 	if data.EnableClusterMode {
-		data.NumberOfShards = d.Get("number_of_shards").(int)
+		if v, ok := d.GetOk("number_of_shards"); ok {
+			data.NumberOfShards = v.(int) //number of shards accepted if cluster mode is enabled
+		}
 	}
 	return data
 }

--- a/duplosdk/ecache_instance.go
+++ b/duplosdk/ecache_instance.go
@@ -25,6 +25,8 @@ type DuploEcacheInstance struct {
 	AuthToken           string `json:"AuthToken,omitempty"`
 	ParameterGroupName  string `json:"ParameterGroupName,omitempty"`
 	InstanceStatus      string `json:"InstanceStatus,omitempty"`
+	EnableClusterMode   bool   `json:"ClusteringEnabled,omitempty"`
+	NumberOfShards      int    `json:"NoOfShards,omitempty"`
 }
 
 /*************************************************

--- a/examples/resources/duplocloud_ecache_instance/resource.tf
+++ b/examples/resources/duplocloud_ecache_instance/resource.tf
@@ -4,9 +4,11 @@ resource "duplocloud_tenant" "myapp" {
 }
 
 resource "duplocloud_ecache_instance" "mycache" {
-  tenant_id  = duplocloud_tenant.myapp.tenant_id
-  name       = "mycache"
-  cache_type = 0 // Redis
-  replicas   = 1
-  size       = "cache.t2.small"
+  tenant_id           = duplocloud_tenant.myapp.tenant_id
+  name                = "mycache"
+  cache_type          = 0 // Redis
+  replicas            = 1
+  size                = "cache.t2.small"
+  enable_cluster_mode = true // applicable only for redis
+  number_of_shards    = 1    // applicable only for redis
 }


### PR DESCRIPTION
## Overview

Added support attribute for setting cluster mode and number of shards
## Summary of changes
Added support attribute NumberOfShards and EnableClusterMode
This PR does the following:

- Added schema attribute enable_cluster_mode and number_of_shards
- Added request/response attribute EnableClusterMode and NumberOfShards
- Updated documents

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
