### PR TITLE
DUPLO-15831 MEMCACHE no change bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-03-11
+
+## Fixed
+- fixed changes occuring while planning on already created memcache type for `duplocloud_ecache_instance` resource when no changes done
+
 ## 2024-03-07
 
 ### Fixed

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -149,12 +149,10 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			Optional:    true,
 		},
 		"number_of_shards": {
-			Description:  "The number of shards to create.",
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Default:      2,
-			ForceNew:     true,
-			ValidateFunc: validation.IntBetween(1, 500),
+			Description: "The number of shards to create.",
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
 		},
 	}
 }
@@ -319,7 +317,11 @@ func expandEcacheInstance(d *schema.ResourceData) *duplosdk.DuploEcacheInstance 
 	}
 	if data.EnableClusterMode {
 		if v, ok := d.GetOk("number_of_shards"); ok {
-			data.NumberOfShards = v.(int) //number of shards accepted if cluster mode is enabled
+			shards := v.(int)
+			if shards < 1 && shards > 500 {
+				shards = 2
+			}
+			data.NumberOfShards = shards //number of shards accepted if cluster mode is enabled
 		}
 	}
 	return data

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -78,9 +78,10 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			Description: "The engine version of the elastic instance.\n" +
 				"See AWS documentation for the [available Redis instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) " +
 				"or the [available Memcached instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions-mc.html).",
-			Type:     schema.TypeString,
-			Optional: true,
-			ForceNew: true,
+			Type:             schema.TypeString,
+			Optional:         true,
+			ForceNew:         true,
+			DiffSuppressFunc: suppressEnginePatchVersion,
 		},
 		"size": {
 			Description: "The instance type of the elasticache instance.\n" +
@@ -149,10 +150,12 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			Optional:    true,
 		},
 		"number_of_shards": {
-			Description: "The number of shards to create.",
-			Type:        schema.TypeInt,
-			Optional:    true,
-			Computed:    true,
+			Description:      "The number of shards to create.",
+			Type:             schema.TypeInt,
+			Optional:         true,
+			DiffSuppressFunc: suppressNoOfShardsDiff,
+			Computed:         true,
+			ValidateFunc:     validation.IntBetween(1, 500),
 		},
 	}
 }
@@ -316,12 +319,10 @@ func expandEcacheInstance(d *schema.ResourceData) *duplosdk.DuploEcacheInstance 
 		}
 	}
 	if data.EnableClusterMode {
-		if v, ok := d.GetOk("number_of_shards"); ok {
-			shards := v.(int)
-			if shards < 1 && shards > 500 {
-				shards = 2
-			}
-			data.NumberOfShards = shards //number of shards accepted if cluster mode is enabled
+		if v, ok := d.GetOk("number_of_shards"); !ok || (v.(int) < 1 && v.(int) > 500) {
+			data.NumberOfShards = 2
+		} else {
+			data.NumberOfShards = v.(int) //number of shards accepted if cluster mode is enabled
 		}
 	}
 	return data
@@ -390,4 +391,35 @@ func parseECacheInstanceIdParts(id string) (tenantID, name string, err error) {
 		err = fmt.Errorf("invalid resource ID: %s", id)
 	}
 	return
+}
+
+func suppressNoOfShardsDiff(k, old, new string, d *schema.ResourceData) bool {
+	newValue, err := strconv.Atoi(new)
+	if err != nil {
+		return false // Unexpected new value type
+	}
+	if newValue == 0 {
+		return true
+	}
+
+	oldValue, err := strconv.Atoi(old)
+	if err != nil {
+		return false // Unexpected old value type
+	}
+
+	return newValue == oldValue // Suppress diff if between 1 and 500 (inclusive)
+}
+
+func suppressEnginePatchVersion(k, old, new string, d *schema.ResourceData) bool {
+	oldVer := removePatchVersion(old)
+	newVer := removePatchVersion(new)
+	return oldVer == newVer // Suppress diff if patch exist
+}
+
+func removePatchVersion(version string) string {
+	parts := strings.Split(version, ".")
+	if len(parts) >= 2 {
+		return strings.Join(parts[:2], ".")
+	}
+	return version
 }


### PR DESCRIPTION
## Overview

Change occuring for unchange on plan
## Summary of changes
Fix for on planing of already created memcache resource without change, showing changes 
This PR does the following:

- Removed default value on number of shards, replaced force new with computed
- No of shards validation handled inside code

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
