### PR TITLE
DUPLO 15611 Add python version  3.11 and 3.12 support for lambda runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2024-03-12
+
+### Added
+- Extended python version support for `duplocloud_aws_lambda_function` resource
 ## 2024-03-07
 
 ### Fixed

--- a/duplocloud/resource_duplo_aws_lambda_function.go
+++ b/duplocloud/resource_duplo_aws_lambda_function.go
@@ -142,7 +142,7 @@ func awsLambdaFunctionSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringInSlice([]string{
 				"nodejs", "nodejs4.3", "nodejs6.10", "nodejs8.10", "nodejs10.x", "nodejs12.x", "nodejs14.x", "nodejs16.x", "nodejs18.x", "nodejs20.x",
 				"java8", "java8.al2", "java11", "java17",
-				"python2.7", "python3.6", "python3.7", "python3.8", "python3.9", "python3.10",
+				"python2.7", "python3.6", "python3.7", "python3.8", "python3.9", "python3.10", "python3.11", "python3.12",
 				"dotnetcore1.0", "dotnetcore2.0", "dotnetcore2.1", "dotnetcore3.1",
 				"dotnet6", "dotnet7",
 				"nodejs4.3-edge",
@@ -383,7 +383,13 @@ func resourceAwsLambdaFunctionCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(err)
 	}
 	rq.Environment = expandAwsLambdaEnvironment(environment)
-
+	if rq.Environment != nil {
+		if v, ok := rq.Environment.Variables["AWS_REGION"]; ok {
+			if strings.Contains(v, "gov") && rq.Runtime.Value == "python3.12" {
+				return diag.Errorf("unsupported runtime version for govcloud")
+			}
+		}
+	}
 	if v, ok := d.GetOk("ephemeral_storage"); ok && v != nil && v.(int) != 0 {
 		rq.EphemeralStorage = &duplosdk.DuploLambdaEphemeralStorage{Size: v.(int)}
 	}


### PR DESCRIPTION
## Overview

Extended python version support for lambda function
## Summary of changes

This PR does the following:

- Added version 3.11 and 3.12 python version in schema validation under runtime
- Implemented conditional check on gov region under lambda environment for runtime python3.12

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
