### PR TITLE
Duplo 15350 Infrastructure dereference bug fix 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-03-12
+
+### Fixed
+- `duplocloud_infrastructure` resource dereference bug fix
+
 ## 2024-03-07
 
 ### Fixed

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -537,15 +537,20 @@ func duploInfrastructureWaitUntilReady(ctx context.Context, c *duplosdk.Client, 
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {
 			rp, err := c.InfrastructureGetConfig(name)
-			log.Printf("[DEBUG] Infrastructure provisioning status is %s", rp.ProvisioningStatus)
+			log.Printf("\n***********************\nduploInfrastructureWaitUntilReady\n\n%+v\n\n*******************", rp)
 			status := "pending"
-			if err == nil && (rp.ProvisioningStatus == "Complete" || strings.Contains(rp.ProvisioningStatus, "Ready")) {
-				status = "ready"
+			if rp != nil && err == nil {
+				log.Printf("[DEBUG] Infrastructure provisioning status is %s", rp.ProvisioningStatus)
+				if rp.ProvisioningStatus == "Complete" || strings.Contains(rp.ProvisioningStatus, "Ready") {
+					status = "ready"
+				}
+				return rp, status, nil
 			}
-			return rp, status, err
+			log.Printf("[TRACE] ERROR \nxxxxxxxxxxxxxx\n%s\nxxxxxxxxxxxxx\n", err.Error())
+			return nil, status, nil
 		},
 		// MinTimeout will be 10 sec freq, if times-out forces 30 sec anyway
-		PollInterval: 30 * time.Second,
+		PollInterval: 45 * time.Second,
 		Timeout:      timeout,
 	}
 	log.Printf("[DEBUG] duploInfrastructureWaitUntilReady(%s)", name)

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -537,7 +537,6 @@ func duploInfrastructureWaitUntilReady(ctx context.Context, c *duplosdk.Client, 
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {
 			rp, err := c.InfrastructureGetConfig(name)
-			log.Printf("\n***********************\nduploInfrastructureWaitUntilReady\n\n%+v\n\n*******************", rp)
 			status := "pending"
 			if rp != nil && err == nil {
 				log.Printf("[DEBUG] Infrastructure provisioning status is %s", rp.ProvisioningStatus)
@@ -546,10 +545,9 @@ func duploInfrastructureWaitUntilReady(ctx context.Context, c *duplosdk.Client, 
 				}
 				return rp, status, nil
 			}
-			log.Printf("[TRACE] ERROR \nxxxxxxxxxxxxxx\n%s\nxxxxxxxxxxxxx\n", err.Error())
-			return nil, status, nil
+			return nil, status, err
 		},
-		// MinTimeout will be 10 sec freq, if times-out forces 30 sec anyway
+		// MinTimeout will be 10 sec freq, if times-out forces 45 sec anyway
 		PollInterval: 45 * time.Second,
 		Timeout:      timeout,
 	}

--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -2,6 +2,7 @@ package duplosdk
 
 import (
 	"fmt"
+	"log"
 	"strings"
 )
 
@@ -227,6 +228,8 @@ func (c *Client) InfrastructureGet(name string) (*DuploInfrastructureConfig, Cli
 // InfrastructureGetConfig retrieves extended infrastructure configuration by name via the Duplo API.
 func (c *Client) InfrastructureGetConfig(name string) (*DuploInfrastructureConfig, ClientError) {
 	rp := DuploInfrastructureConfig{}
+	x := fmt.Sprintf("adminproxy/GetInfrastructureConfig/%s", name)
+	log.Printf("[TRACE] infra config req \n================\n%+v\n================\n", x)
 	err := c.getAPI(fmt.Sprintf("InfrastructureGetConfig(%s)", name), fmt.Sprintf("adminproxy/GetInfrastructureConfig/%s", name), &rp)
 	if err != nil || rp.Name == "" {
 		return nil, err

--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -2,7 +2,6 @@ package duplosdk
 
 import (
 	"fmt"
-	"log"
 	"strings"
 )
 
@@ -228,8 +227,6 @@ func (c *Client) InfrastructureGet(name string) (*DuploInfrastructureConfig, Cli
 // InfrastructureGetConfig retrieves extended infrastructure configuration by name via the Duplo API.
 func (c *Client) InfrastructureGetConfig(name string) (*DuploInfrastructureConfig, ClientError) {
 	rp := DuploInfrastructureConfig{}
-	x := fmt.Sprintf("adminproxy/GetInfrastructureConfig/%s", name)
-	log.Printf("[TRACE] infra config req \n================\n%+v\n================\n", x)
 	err := c.getAPI(fmt.Sprintf("InfrastructureGetConfig(%s)", name), fmt.Sprintf("adminproxy/GetInfrastructureConfig/%s", name), &rp)
 	if err != nil || rp.Name == "" {
 		return nil, err


### PR DESCRIPTION
## Overview

Fix for dereference

## Summary of changes
Handled dereference issue for infrastructure resource
This PR does the following:

- Extended polling time
- Handled nil pointer exception

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
