### PR TITLE
Azure tenant creation issue fixed.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-03-13
+
+### Fixed
+- Fixed an issue with Azure tenant creation by updating the `TenantCreate` function to return a response string, improving error handling and feedback.
+
 ## 2024-03-12
 
 ### Added

--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -173,7 +173,7 @@ func resourceTenantCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		return diags
 	}
 
-	err := c.TenantCreate(rq)
+	_, err := c.TenantCreate(rq)
 	if err != nil {
 		return diag.Errorf("Unable to create tenant '%s': %s", rq.AccountName, err)
 	}

--- a/duplosdk/tenant.go
+++ b/duplosdk/tenant.go
@@ -144,8 +144,14 @@ func (c *Client) TenantGetV3(tenantID string) (*DuploTenant, ClientError) {
 }
 
 // TenantCreate creates a tenant via the Duplo API.
-func (c *Client) TenantCreate(rq DuploTenant) ClientError {
-	return c.postAPI(fmt.Sprintf("TenantCreate(%s, %s)", rq.AccountName, rq.PlanID), "admin/AddTenant", &rq, nil)
+func (c *Client) TenantCreate(rq DuploTenant) (string, ClientError) {
+	rp := ""
+	err := c.postAPI(fmt.Sprintf("TenantCreate(%s, %s)", rq.AccountName, rq.PlanID), "admin/AddTenant", &rq, &rp)
+	if err != nil {
+		return "", err
+	}
+	return rp, err
+	// return c.postAPI(fmt.Sprintf("TenantCreate(%s, %s)", rq.AccountName, rq.PlanID), "admin/AddTenant", &rq, nil)
 }
 
 // TenantDelete deletes an AWS host via the Duplo API.


### PR DESCRIPTION
## **User description**
## Overview

Azure tenant creation issue fixed.

## Summary of changes

This PR does the following:

- Tenant creation response is a string.
-
## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Updated the `TenantCreate` function in `duplosdk/tenant.go` to return a response string along with an error, enhancing the feedback from the tenant creation process.
- Adjusted the call to `TenantCreate` in `duplocloud/resource_duplo_tenant.go` to handle the new return value, improving error handling and response management.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_tenant.go</strong><dd><code>Update Tenant Creation Function Call in Resource File</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_tenant.go

- Updated the `TenantCreate` function call to handle a return value.



</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/445/files#diff-fd738e9bb1cb4f0e03eed01292440c2c79dc914139da1f32e1ebacf2ede9b861">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tenant.go</strong><dd><code>Enhance Tenant Creation to Return Response String</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/tenant.go

<li>Modified the <code>TenantCreate</code> function to return a string along with an <br>error.<br> <li> Added error handling and return statement for the tenant creation <br>response.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/445/files#diff-b8d6917edf217103423ca7aba0ff7bc3ab0e9088269f2e84e496f64d27f4221d">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

