### PR TITLE
DUPLO-14315: added architecture field to lambda function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 markdown
+## 2024-03-18
+
+### Added
+- Added support for specifying the instruction set architecture for AWS Lambda functions in the Terraform provider, including `[x86_64]` and `[arm64]`.
+
+markdown
 ## 2024-03-14
 
 ### Added

--- a/duplosdk/aws_lambda_function.go
+++ b/duplosdk/aws_lambda_function.go
@@ -50,6 +50,7 @@ type DuploLambdaConfiguration struct {
 	Layers           *[]DuploLambdaLayerGet       `json:"Layers,omitempty"`
 	EphemeralStorage *DuploLambdaEphemeralStorage `json:"EphemeralStorage,omitempty"`
 	DeadLetterConfig *DuploDeadLetterConfig       `json:"DeadLetterConfig,omitempty"`
+	Architectures    *[]string                    `json:"Architectures,omitempty"`
 }
 
 // DuploLambdaCode is a Duplo SDK object that represents a lambda function's code.
@@ -109,14 +110,16 @@ type DuploLambdaCreateRequest struct {
 	Layers           *[]string                    `json:"Layers,omitempty"`
 	TracingConfig    *DuploLambdaTracingConfig    `json:"TracingConfig,omitempty"`
 	DeadLetterConfig *DuploDeadLetterConfig       `json:"DeadLetterConfig,omitempty"`
+	Architectures    *[]string                    `json:"Architectures,omitempty"`
 }
 
 // DuploLambdaUpdateRequest is a Duplo SDK object that represents a request to update a lambda function's code.
 type DuploLambdaUpdateRequest struct {
-	FunctionName string `json:"FunctionName,omitempty"`
-	ImageURI     string `json:"ImageUri,omitempty"`
-	S3Bucket     string `json:"S3Bucket,omitempty"`
-	S3Key        string `json:"S3Key,omitempty"`
+	FunctionName  string    `json:"FunctionName,omitempty"`
+	ImageURI      string    `json:"ImageUri,omitempty"`
+	S3Bucket      string    `json:"S3Bucket,omitempty"`
+	S3Key         string    `json:"S3Key,omitempty"`
+	Architectures *[]string `json:"Architectures,omitempty"`
 }
 
 // DuploLambdaConfigurationRequest is a Duplo SDK object that represents a request to update a lambda function's configuration.


### PR DESCRIPTION
## **User description**
## Overview

added architecture field to lambda function

## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
enhancement


___

## **Description**
- Added the ability to specify the instruction set architecture for AWS Lambda functions, supporting both `[x86_64]` and `[arm64]`.
- Updated the Terraform provider and SDK to handle the new `architectures` field during Lambda function creation and updates.
- Ensured compatibility with existing configurations by making the `architectures` field optional.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_lambda_function.go</strong><dd><code>Add Architecture Support for AWS Lambda Functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_aws_lambda_function.go

<li>Added support for specifying the architecture of AWS Lambda functions.<br> <li> Allows setting the architecture to either <code>[x86_64]</code> or <code>[arm64]</code>.<br> <li> Ensures the architecture setting is considered during Lambda function <br>creation and updates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/449/files#diff-c13f14fb2a32c7d12b7beb43bd7a8d80d643b446a7def447c9774e170bb9e9e2">+18/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aws_lambda_function.go</strong><dd><code>SDK Support for Lambda Function Architectures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/aws_lambda_function.go

<li>Introduced <code>Architectures</code> field in Lambda function related structs.<br> <li> Allows setting and updating the architecture of Lambda functions via <br>SDK.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/449/files#diff-481201c30d6877a01e9dd350d11edce52e01e472cfab7e6b6ecaffca4ed8f6e2">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

