### PR TITLE
DUPLO-15011: TF Force recreate tf resource when volume mapping is modified for duplo service in terraform (contextual)

### DIFF
--- a/docs/resources/duplo_service.md
+++ b/docs/resources/duplo_service.md
@@ -60,6 +60,18 @@ resource "duplocloud_duplo_service" "myservice" {
     NetworkMode = "host",
     CapAdd      = ["NET_ADMIN"]
   })
+
+  force_recreate_on_volumes_change = true
+  volumes = jsonencode(
+      [
+        {
+          AccessMode : "ReadWriteOnce",
+          Name : "${local.svs_frontend_name}-${local.tenant_name}",
+          Path : "/tmp/test2",
+          Size : "2Gi"
+        }
+      ]
+  )
 }
 
 # Example 4:  Deploy NGINX with host networking and env vars, using Duplo's EKS agent


### PR DESCRIPTION


## Overview

DUPLO-15011: TF Force recreate tf resource when volume mapping is modified for duplo service in terraform (contextual)

## Summary of changes

This PR does the following:

- CustomizeDiff to forceNew on => changes to volumes + force_recreate_on_volumes_change = true
- ...

## Testing performed

- [ ] Using unit tests
- [X] Manually, on my local system
- [X] Manually, on a remote test system

## Describe any breaking changes

- None
