### PR TITLE
Duplo 16118 Plugin Crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 20234-03-22
+
+### Fixed
+- Fixed plugin crash issue for user exist case related to `duplocloud_user` resource
 ## 2024-03-21
 
 ### Updated

--- a/duplocloud/resource_duplo_user.go
+++ b/duplocloud/resource_duplo_user.go
@@ -128,7 +128,7 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface
 	c := m.(*duplosdk.Client)
 	resp, err := c.UserCreate(rq)
 	if err != nil {
-		return diag.Errorf("Unable to create User '%s': %s", resp.Username, err)
+		return diag.Errorf("Unable to create User '%s': %s", userName, err)
 	}
 
 	var rp *duplosdk.DuploUser


### PR DESCRIPTION
## Overview

Plugin crash when user exist 
## Summary of changes
Olugin crashes while throwing user exist error in `duplocloud_user` resource
This PR does the following:

- Handle nil pointer exception
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
