### PR TITLE
Duplo 16115 schema fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2023-03-26
+
+### Fixed
+- Fixed `duplocloud_s3_bucket` resource creation issue
 ## 20234-03-22
 
 ### Fixed

--- a/duplocloud/data_source_duplo_gcp_node_pool.go
+++ b/duplocloud/data_source_duplo_gcp_node_pool.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func dataSourceGCPNodePool() *schema.Resource {
@@ -16,6 +17,326 @@ func dataSourceGCPNodePool() *schema.Resource {
 
 		ReadContext: dataSourceGCPNodePoolRead,
 		Schema:      dataGcpK8NodePoolFunctionSchema(),
+	}
+}
+
+func dataGcpK8NodePoolFunctionSchema() map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"tenant_id": {
+			Description:  "The GUID of the tenant that the node pool will be associated with.",
+			Type:         schema.TypeString,
+			Required:     true,
+			ValidateFunc: validation.IsUUID,
+		},
+		"name": {
+			Description: "The short name of the node pool.",
+			Type:        schema.TypeString,
+			Required:    true,
+		},
+		"fullname": {
+			Description: "The full name of the node pool.",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"machine_type": {
+			Description: `The name of a Google Compute Engine machine type.
+				If unspecified, the default machine type is e2-medium.`,
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"disc_size_gb": {
+			Description: `Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB.
+				If unspecified, the default disk size is 100GB.`,
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"image_type": {
+			Description: "The image type to use for this node. Note that for a given image type, the latest version of it will be used",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"tags": {
+			Description: `The list of instance tags applied to all nodes.
+				Tags are used to identify valid sources or targets for network firewalls and are specified by the client during cluster or node pool creation.
+				Each tag within the list must comply with RFC1035.`,
+			Type:     schema.TypeList,
+			Computed: true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"disc_type": {
+			Description: `Type of the disk attached to each node
+				If unspecified, the default disk type is 'pd-standard'`,
+			Type:     schema.TypeString,
+			Computed: true,
+		},
+		"spot": {
+			Description: "Spot flag for enabling Spot VM",
+			Type:        schema.TypeBool,
+			Computed:    true,
+		},
+
+		"linux_node_config": {
+			Description: "Parameters that can be configured on Linux nodes",
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"cgroup_mode": {
+						Description: "cgroupMode specifies the cgroup mode to be used on the node.",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"sysctls": {
+						Description: "The Linux kernel parameters to be applied to the nodes and all pods running on the nodes.",
+						Type:        schema.TypeMap,
+						Computed:    true,
+						Elem: &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+
+		"labels": {
+			Description: "The map of Kubernetes labels (key/value pairs) to be applied to each node.",
+			Type:        schema.TypeMap,
+			Computed:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"is_autoscaling_enabled": {
+			Description: "Is autoscaling enabled for this node pool.",
+			Type:        schema.TypeBool,
+			Computed:    true,
+		},
+
+		"location_policy": {
+			Description: "Update strategy of the node pool.",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"initial_node_count": {
+			Description: "The initial node count for the pool",
+			Type:        schema.TypeInt,
+			Computed:    true,
+		},
+
+		"max_node_count": {
+			Description: "Maximum number of nodes for one location in the NodePool. Must be >= minNodeCount.",
+			Type:        schema.TypeInt,
+			Computed:    true,
+		},
+
+		"min_node_count": {
+			Description: "Minimum number of nodes for one location in the NodePool. Must be >= 1 and <= maxNodeCount.",
+			Type:        schema.TypeInt,
+			Computed:    true,
+		},
+
+		"total_max_node_count": {
+			Description: "Maximum number of nodes for one location in the NodePool. Must be >= minNodeCount.",
+			Type:        schema.TypeInt,
+			Computed:    true,
+		},
+		"total_min_node_count": {
+			Description: "Minimum number of nodes for one location in the NodePool. Must be >= 1 and <= maxNodeCount.",
+			Type:        schema.TypeInt,
+			Computed:    true,
+		},
+		"auto_upgrade": {
+			Description: "Whether the nodes will be automatically upgraded.",
+			Type:        schema.TypeBool,
+			Computed:    true,
+		},
+		"auto_repair": {
+			Description: "Whether the nodes will be automatically repaired.",
+			Type:        schema.TypeBool,
+			Computed:    true,
+		},
+		"metadata": {
+			Description: "The metadata key/value pairs assigned to instances in the cluster.",
+			Type:        schema.TypeMap,
+			Computed:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+		"node_pool_logging_config": {
+			Description: "Logging configuration.",
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"variant_config": {
+						Type:     schema.TypeMap,
+						Computed: true,
+						Elem: &schema.Schema{
+							Type:     schema.TypeString,
+							Optional: true,
+						},
+					},
+				},
+			},
+		},
+		"oauth_scopes": {
+			Description: "The set of Google API scopes to be made available on all of the node VMs under the default service account.",
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
+
+		"zones": {
+			Description: "The list of Google Compute Engine zones in which the NodePool's nodes should be located.",
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString}, // Define the type for each element in the list
+		},
+		"upgrade_settings": {
+			Description: "Upgrade settings control disruption and speed of the upgrade.",
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"strategy": {
+						Description: "Update strategy of the node pool.",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"max_surge": {
+						Description: "",
+						Type:        schema.TypeInt,
+						Computed:    true,
+					},
+					"max_unavailable": {
+						Description: "",
+						Type:        schema.TypeInt,
+						Computed:    true,
+					},
+					"blue_green_settings": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Computed: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"standard_rollout_policy": {
+									Type:     schema.TypeList,
+									Optional: true,
+									Elem: &schema.Resource{
+										Schema: map[string]*schema.Schema{
+											"batch_percentage": {
+												Type:     schema.TypeFloat,
+												Computed: true,
+											},
+											"batch_node_count": {
+												Type:     schema.TypeInt,
+												Computed: true,
+											},
+											"batch_soak_duration": {
+												Type:     schema.TypeString,
+												Computed: true,
+											},
+										},
+									},
+								},
+								"node_pool_soak_duration": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+
+		"taints": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"key": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"value": {
+						Type:     schema.TypeString,
+						Computed: true,
+					},
+					"effect": {
+						Description: "Update strategy of the node pool.",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+				},
+			},
+		},
+		"accelerator": {
+			Type:     schema.TypeList,
+			Optional: true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"accelerator_count": {
+						Description: "The number of the accelerator cards exposed to an instance.",
+						Type:        schema.TypeString,
+						Optional:    true,
+						Computed:    true,
+					},
+					"accelerator_type": {
+						Description: "The accelerator type resource name.",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"gpu_partition_size": {
+						Description: "Size of partitions to create on the GPU",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"max_time_shared_clients_per_gpu": {
+						Description: "The number of time-shared GPU resources to expose for each physical GPU.",
+						Type:        schema.TypeString,
+						Computed:    true,
+					},
+					"gpu_sharing_config": {
+						Type:     schema.TypeList,
+						Optional: true,
+						Computed: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"max_shared_clients_per_gpu": {
+									Description: "The max number of containers that can share a physical GPU.",
+									Type:        schema.TypeString,
+									Computed:    true,
+								},
+								"gpu_sharing_strategy": {
+									Description: "The configuration for GPU sharing options.",
+									Type:        schema.TypeString,
+									Computed:    true,
+								},
+							},
+						},
+					},
+					"gpu_driver_installation_config": {
+						Type:     schema.TypeList,
+						Computed: true,
+						Elem: &schema.Resource{
+							Schema: map[string]*schema.Schema{
+								"gpu_driver_version": {
+									Type:     schema.TypeString,
+									Computed: true,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 }
 

--- a/duplocloud/data_source_duplo_gcp_node_pools.go
+++ b/duplocloud/data_source_duplo_gcp_node_pools.go
@@ -28,21 +28,15 @@ func dataSourceGCPNodePools() *schema.Resource {
 				Type:     schema.TypeList,
 				Computed: true,
 				Elem: &schema.Resource{
-					Schema: dataGcpK8NodePoolFunctionSchema(),
+					Schema: dataGcpK8NodePoolsFunctionSchema(),
 				},
 			},
 		},
 	}
 }
 
-func dataGcpK8NodePoolFunctionSchema() map[string]*schema.Schema {
+func dataGcpK8NodePoolsFunctionSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
-		"tenant_id": {
-			Description:  "The GUID of the tenant that the node pool will be created in.",
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: validation.IsUUID,
-		},
 		"name": {
 			Description: "The short name of the node pool.",
 			Type:        schema.TypeString,


### PR DESCRIPTION
## Overview

Schema fix
## Summary of changes
Schema fix for datasource for node pool
This PR does the following:

- Schema fix for `duplocloud_gcp_node_pool` data source
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
