### PR TITLE
DUPLO-16209 TF S3 bucket resource: `duplo_lifecycle_owner':'duplo` tag is not getting added to S3 

### DIFF
--- a/docs/data-sources/gcp_node_pool.md
+++ b/docs/data-sources/gcp_node_pool.md
@@ -17,12 +17,12 @@ description: |-
 
 ### Required
 
-- `tenant_id` (String) The GUID of the tenant that the node pool will be created in.
+- `name` (String) The short name of the node pool.
+- `tenant_id` (String) The GUID of the tenant that the node pool will be associated with.
 
 ### Optional
 
 - `accelerator` (Block List) (see [below for nested schema](#nestedblock--accelerator))
-- `name` (String) The short name of the node pool.
 
 ### Read-Only
 

--- a/docs/data-sources/gcp_node_pools.md
+++ b/docs/data-sources/gcp_node_pools.md
@@ -51,7 +51,6 @@ Read-Only:
 - `spot` (Boolean)
 - `tags` (List of String)
 - `taints` (List of Object) (see [below for nested schema](#nestedobjatt--node_pools--taints))
-- `tenant_id` (String)
 - `total_max_node_count` (Number)
 - `total_min_node_count` (Number)
 - `upgrade_settings` (List of Object) (see [below for nested schema](#nestedobjatt--node_pools--upgrade_settings))

--- a/docs/resources/aws_cloudfront_distribution.md
+++ b/docs/resources/aws_cloudfront_distribution.md
@@ -147,17 +147,15 @@ Required:
 
 Optional:
 
-- `cache_policy_id` (String)
-     
-  | Policy Name                                   | Policy ID                             |
-  |-----------------------------------------------|---------------------------------------|
-  | [Amplify](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html)| 2e54312d-136d-493c-8eb9-    b001f22f67d2 |
-  | [CachingDisabled](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html)| 4135ea2d-6df8-44a3-9df3-4b5a84be39ad |
-  | [CachingOptimized](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html)| 658327ea-f89d-4fab-a63d-7e88639e58f6 |
-  | [CachingOptimizedForUncompressedObjects](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html)| b2884449-e4de-46a7-ac36-70bc7f1ddd6d |
-  | [Elemental-MediaPackage](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html)| 08627262-05a9-4f76-9ded-b50ca2e3a84f |
- 
-
+- `cache_policy_id` (String) <br />						
+| Policy name                                                                                                                                                                                  | Policy Id                            |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------|
+| [Amplify](#https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-policy-amplify)                                                | 2e54312d-136d-493c-8eb9-b001f22f67d2 |
+| [CachingDisabled](#https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-policy-caching-disabled)                               | 4135ea2d-6df8-44a3-9df3-4b5a84be39ad |
+| [CachingOptimized](#https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-caching-optimized)                                    | 658327ea-f89d-4fab-a63d-7e88639e58f6 |
+| [CachingOptimizedForUncompressedObjects](#https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-caching-optimized-uncompressed) | b2884449-e4de-46a7-ac36-70bc7f1ddd6d |
+| [Elemental-MediaPackage](#https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/using-managed-cache-policies.html#managed-cache-policy-mediapackage)                            | 08627262-05a9-4f76-9ded-b50ca2e3a84f |
+<br />
 - `compress` (Boolean) Defaults to `false`.
 - `default_ttl` (Number) default time to live: Not required when cache_policy_id is set
 - `field_level_encryption_id` (String)

--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -70,6 +70,7 @@ resource "duplocloud_s3_bucket" "mydata" {
 
 - `allow_public_access` (Boolean) Whether or not to remove the public access block from the bucket.
 - `default_encryption` (Block List, Max: 1) Default encryption settings for objects uploaded to the bucket. (see [below for nested schema](#nestedblock--default_encryption))
+- `duplo_lifecycle_owner` (String) duplo lifecycle owner name tag
 - `enable_access_logs` (Boolean) Whether or not to enable access logs.  When enabled, Duplo will send access logs to a centralized S3 bucket per plan.
 - `enable_versioning` (Boolean) Whether or not to enable versioning.
 - `managed_policies` (List of String) Duplo can manage your S3 bucket policy for you, based on simple list of policy keywords:

--- a/duplocloud/resource_duplo_s3_bucket.go
+++ b/duplocloud/resource_duplo_s3_bucket.go
@@ -114,6 +114,12 @@ func s3BucketSchema() map[string]*schema.Schema {
 			Elem:     &schema.Schema{Type: schema.TypeString},
 		},
 		"tags": awsTagsKeyValueSchemaComputed(),
+		"duplo_lifecycle_owner": {
+			Description: "duplo lifecycle owner name tag",
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+		},
 	}
 }
 
@@ -462,7 +468,10 @@ func fillS3BucketRequest(duploObject *duplosdk.DuploS3BucketSettingsRequest, d *
 	if v, ok := getAsStringArray(d, "managed_policies"); ok && v != nil {
 		duploObject.Policies = *v
 	}
-
+	duploObject.ResourceTags = make(map[string]string)
+	if v, ok := d.GetOk("duplo_lifecycle_owner"); ok && v != nil {
+		duploObject.ResourceTags["duplo_lifecycle_owner"] = v.(string)
+	}
 	log.Printf("[TRACE] fillS3BucketRequest ******** end")
 	return nil
 }

--- a/duplosdk/tenant_aws_cloud_resources.go
+++ b/duplosdk/tenant_aws_cloud_resources.go
@@ -217,13 +217,14 @@ type DuploS3BucketRequest struct {
 
 // DuploS3BucketSettingsRequest represents a request to create an S3 bucket resource
 type DuploS3BucketSettingsRequest struct {
-	Name              string   `json:"Name,omitempty"`
-	Region            string   `json:"Region,omitempty"`
-	EnableVersioning  bool     `json:"EnableVersioning,omitempty"`
-	EnableAccessLogs  bool     `json:"EnableAccessLogs,omitempty"`
-	AllowPublicAccess bool     `json:"AllowPublicAccess,omitempty"`
-	DefaultEncryption string   `json:"DefaultEncryption,omitempty"`
-	Policies          []string `json:"Policies,omitempty"`
+	Name              string            `json:"Name,omitempty"`
+	Region            string            `json:"Region,omitempty"`
+	EnableVersioning  bool              `json:"EnableVersioning,omitempty"`
+	EnableAccessLogs  bool              `json:"EnableAccessLogs,omitempty"`
+	AllowPublicAccess bool              `json:"AllowPublicAccess,omitempty"`
+	DefaultEncryption string            `json:"DefaultEncryption,omitempty"`
+	Policies          []string          `json:"Policies,omitempty"`
+	ResourceTags      map[string]string `json:"ResourceTags,omitempty"`
 }
 
 // DuploKafkaEbsStorageInfo represents a Kafka cluster's EBS storage info


### PR DESCRIPTION
## Overview

Added support to add duplo_lifecycle_owner to `duplocloud_s3_bucket` resource
## Summary of changes

This PR does the following:

- Added duplo_lifecycle_owner attribute to schema
- Added attribute ResourceTags to request body
- Updated docs
## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...
