### PR TITLE
DUPLO-14760 Mandatory field "Root Password" for database creation is missing for Cloud SQL databases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2024-04-04
+
+### Added
+- Added support to pass `root_password` for `duplocloud_gcp_sql_database_instance` resource
 ## 2024-03-29
 
 ### Enhanced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+No update is needed for the CHANGELOG.md file based on the provided PR information, as the changes mentioned are already reflected in the current version of the document.
+
 ## 2024-04-04
 
 ### Added

--- a/docs/resources/gcp_sql_database_instance.md
+++ b/docs/resources/gcp_sql_database_instance.md
@@ -45,7 +45,7 @@ resource "duplocloud_gcp_sql_database_instance" "sql_instance" {
 
 - `disk_size` (Number) The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB.
 - `labels` (Map of String) Map of string keys and values that can be used to organize and categorize this resource.
-- `root_password` (String) root password for specific database versions
+- `root_password` (String) Provide root password for specific database versions.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `wait_until_ready` (Boolean) Whether or not to wait until sql database instance to be ready, after creation. Defaults to `true`.
 

--- a/docs/resources/gcp_sql_database_instance.md
+++ b/docs/resources/gcp_sql_database_instance.md
@@ -45,6 +45,7 @@ resource "duplocloud_gcp_sql_database_instance" "sql_instance" {
 
 - `disk_size` (Number) The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB.
 - `labels` (Map of String) Map of string keys and values that can be used to organize and categorize this resource.
+- `root_password` (String) root password for specific database versions
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `wait_until_ready` (Boolean) Whether or not to wait until sql database instance to be ready, after creation. Defaults to `true`.
 

--- a/duplocloud/resource_duplo_gcp_sql_database.go
+++ b/duplocloud/resource_duplo_gcp_sql_database.go
@@ -78,9 +78,10 @@ func gcpSqlDBInstanceSchema() map[string]*schema.Schema {
 			Default:     true,
 		},
 		"root_password": {
-			Description: "root password for specific database versions",
+			Description: "Provide root password for specific database versions.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 	}
 }

--- a/duplosdk/gcp_sql_database.go
+++ b/duplosdk/gcp_sql_database.go
@@ -75,6 +75,7 @@ type DuploGCPSqlDBInstance struct {
 	ResourceType    int               `json:"ResourceType,omitempty"`
 	Labels          map[string]string `json:"labels,omitempty"`
 	SelfLink        string            `json:"SelfLink,omitempty"`
+	RootPassword    string            `json:"RootPassword,omitempty"`
 }
 
 func (c *Client) GCPSqlDBInstanceCreate(tenantID string, rq *DuploGCPSqlDBInstance) (*DuploGCPSqlDBInstance, ClientError) {


### PR DESCRIPTION
## **User description**
## Overview

Add support for root password
## Summary of changes
added support for password for gcp sql resource
This PR does the following:

- Added support for root password passing
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
enhancement, documentation


___

## **Description**
- Added support for specifying a root password for GCP SQL database instances, enhancing security and customization.
- Implemented logic to require a root password for certain SQL Server versions, improving compliance with best practices.
- Updated SDK to support root password management for GCP SQL databases.
- Updated documentation and changelog to reflect the new feature and its usage.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_gcp_sql_database.go</strong><dd><code>Add Root Password Support for GCP SQL Database Instances</code>&nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_gcp_sql_database.go

<li>Added <code>root_password</code> field to the GCP SQL database schema.<br> <li> Implemented <code>checkPasswordNeeded</code> function to determine if a root <br>password is required based on the database version.<br> <li> Enforced root password requirement during resource creation if <br>applicable.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/475/files#diff-5e2b59a959de92a468b84aa15f4066eb662d23e4c9a0e8ef04fca002d5235831">+27/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gcp_sql_database.go</strong><dd><code>SDK Support for GCP SQL Database Root Password</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/gcp_sql_database.go

<li>Added <code>RootPassword</code> field to <code>DuploGCPSqlDBInstance</code> struct to support <br>root password management.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/475/files#diff-ef4280fb2cddb49187c078fc9a79d10c1b8a94e27286a2e4c718da2d320ac2d8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update Changelog for Root Password Support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
CHANGELOG.md

<li>Updated the changelog to include the addition of root password support <br>for GCP SQL database instances.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/475/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+16/-15</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gcp_sql_database_instance.md</strong><dd><code>Document Root Password Parameter for GCP SQL Database Instances</code></dd></summary>
<hr>
      
docs/resources/gcp_sql_database_instance.md

<li>Documented the <code>root_password</code> optional parameter for GCP SQL database <br>instances.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/475/files#diff-5695da959b1954953ab1c73c64b4a4fc96c884d73e08e5119eb6b6b67d008b6f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

