### PR TITLE
DUPLO-16672: Azure TF> duplocloud_azure_virtual_machine resource apply fails with an error when prefixes are enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2024-04-04
+
+### Added
+- Introduced support for custom prefixes in Azure VM names for flexible naming conventions.
+- Added a `fullname` attribute to Azure VM resources for enhanced traceability and management.
+
+### Enhanced
+- Updated Azure VM resource documentation to include the `fullname` attribute.
+- Improved logging and resource management to handle the `fullname` of Azure VMs across operations.
+
+### Fixed
+- Resolved issues with Azure VM operations (create, read, update, delete) to correctly handle the `fullname`.
+
 ## 2024-03-29
 
 ### Enhanced

--- a/docs/resources/azure_virtual_machine.md
+++ b/docs/resources/azure_virtual_machine.md
@@ -82,6 +82,7 @@ resource "duplocloud_azure_virtual_machine" "az_vm" {
 
 ### Read-Only
 
+- `fullname` (String) The full name of the host.
 - `id` (String) The ID of this resource.
 - `instance_id` (String) The Azure Virtual Machine ID of the host.
 - `status` (String) The current status of the host.


### PR DESCRIPTION
## **User description**
## Overview

DUPLO-16672  fixed.

## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced support for custom prefixes in Azure VM names to allow for more flexible naming conventions.
- Added a new `fullname` attribute to Azure VM resources to store the full name of the VM, enhancing traceability and management.
- Updated the Azure VM resource documentation to include the new `fullname` attribute.
- Fixed logging and resource management to correctly handle the `fullname` of Azure VMs across create, read, update, and delete operations.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_azure_virtual_machine.go</strong><dd><code>Support Custom Prefixes for Azure VM Names and Introduce Fullname </code><br><code>Attribute</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_azure_virtual_machine.go

<li>Added support for custom prefixes in Azure VM names.<br> <li> Introduced <code>fullname</code> attribute to store the full name of the Azure VM.<br> <li> Updated logging to include <code>fullname</code> for better traceability.<br> <li> Ensured that Azure VM operations (create, read, update, delete) handle <br>the <code>fullname</code> correctly.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/476/files#diff-865b343e25bf926418366c3b3d4e035a03701eaf40033dac5d38e53c5a6c2de9">+41/-17</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>azure_virtual_machine.md</strong><dd><code>Document Fullname Attribute for Azure VM Resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/resources/azure_virtual_machine.md

<li>Documented the new <code>fullname</code> read-only attribute for Azure VM <br>resources.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/476/files#diff-adda79eb919dc758939461a2c18489c6c73f5f673068f4207c1cf7a131cfce7f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

