### PR TITLE
Duplo 15896 kube error msg for GKE datasource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,4 @@
 markdown
-## 2024-04-05
-
-### Added
-- Introduced `allow_global_access` field for internal load balancer configurations in GKE plans.
-
-### Enhanced
-- Improved JIT access token retrieval logic with enhanced error handling for GKE datasource.
-- Updated the `DuploLbConfiguration` struct to include `AllowGlobalAccess` field for new load balancer configuration options.
-
-### Fixed
-- Added error handling for cases where a Kubernetes cluster is not enabled for a GKE plan.
 
 ## 2024-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+markdown
+## 2024-04-05
+
+### Added
+- Introduced `allow_global_access` field for internal load balancer configurations in GKE plans.
+
+### Enhanced
+- Improved JIT access token retrieval logic with enhanced error handling for GKE datasource.
+- Updated the `DuploLbConfiguration` struct to include `AllowGlobalAccess` field for new load balancer configuration options.
+
+### Fixed
+- Added error handling for cases where a Kubernetes cluster is not enabled for a GKE plan.
+
 ## 2024-04-05
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 2024-04-05
 
 ### Fixed
-- Fixed nil pointer exception while error handling for `duplocloud_eks_credentials` datasource
+- Fixed nil pointer exception while error handling for `duplocloud_eks_credentials` and `duplocloud_gke_credentials` datasource
 ## 2024-04-04
 
 ### Added

--- a/duplocloud/data_source_duplo_gke_credentials.go
+++ b/duplocloud/data_source_duplo_gke_credentials.go
@@ -55,10 +55,17 @@ func dataSourceGKECredentialsRead(d *schema.ResourceData, m interface{}) error {
 	// Get the data from Duplo.
 	planID := d.Get("plan_id").(string)
 	c := m.(*duplosdk.Client)
+	infra, err := c.InfrastructureGetConfig(planID)
+	if err != nil {
+		return fmt.Errorf("failed to get plan %s kubernetes JIT access: %s", planID, err)
+	}
+	if infra != nil && !infra.EnableK8Cluster {
+		return fmt.Errorf("no kubernetes cluster for this plan %s", planID)
 
+	}
 	// First, try the newer method of obtaining a JIT access token.
 	k8sConfig, err := c.GetPlanK8sJitAccess(planID)
-	if err != nil || !err.PossibleMissingAPI() {
+	if err != nil && !err.PossibleMissingAPI() {
 		return fmt.Errorf("failed to get plan %s kubernetes JIT access: %s", planID, err)
 	}
 

--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -149,11 +149,6 @@ func duploLbConfigSchema() map[string]*schema.Schema {
 			Type:        schema.TypeInt,
 			Computed:    true,
 		},
-		"allow_global_access": {
-			Description: "Applicable for internal lb.",
-			Type:        schema.TypeBool,
-			Optional:    true,
-		},
 	}
 }
 
@@ -343,9 +338,7 @@ func resourceDuploServiceLBConfigsCreateOrUpdate(ctx context.Context, d *schema.
 				if v, ok := lbc["custom_cidr"]; ok && v != nil && len(v.([]interface{})) > 0 && item.LbType == 6 {
 					item.CustomCidrs = expandStringList(v.([]interface{}))
 				}
-				if item.IsInternal {
-					item.AllowGlobalAccess = lbc["allow_global_access"].(bool)
-				}
+
 				list = append(list, item)
 			}
 		}

--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -149,6 +149,11 @@ func duploLbConfigSchema() map[string]*schema.Schema {
 			Type:        schema.TypeInt,
 			Computed:    true,
 		},
+		"allow_global_access": {
+			Description: "Applicable for internal lb.",
+			Type:        schema.TypeBool,
+			Optional:    true,
+		},
 	}
 }
 
@@ -337,6 +342,9 @@ func resourceDuploServiceLBConfigsCreateOrUpdate(ctx context.Context, d *schema.
 				}
 				if v, ok := lbc["custom_cidr"]; ok && v != nil && len(v.([]interface{})) > 0 && item.LbType == 6 {
 					item.CustomCidrs = expandStringList(v.([]interface{}))
+				}
+				if item.IsInternal {
+					item.AllowGlobalAccess = lbc["allow_global_access"].(bool)
 				}
 				list = append(list, item)
 			}

--- a/duplosdk/replication_controller.go
+++ b/duplosdk/replication_controller.go
@@ -103,7 +103,6 @@ type DuploLbConfiguration struct {
 	HostNames *[]string `json:"HostNames,omitempty"`
 
 	// TODO: DIPAddresses
-	AllowGlobalAccess bool `json:"AllowGlobalAccess,omitempty"`
 }
 
 // DuploPodLbConfiguration represents an LB configuration deletion request.

--- a/duplosdk/replication_controller.go
+++ b/duplosdk/replication_controller.go
@@ -103,6 +103,7 @@ type DuploLbConfiguration struct {
 	HostNames *[]string `json:"HostNames,omitempty"`
 
 	// TODO: DIPAddresses
+	AllowGlobalAccess bool `json:"AllowGlobalAccess,omitempty"`
 }
 
 // DuploPodLbConfiguration represents an LB configuration deletion request.


### PR DESCRIPTION
## **User description**
## Overview

GKE datasource exception handling for kubernetes enable for plan
## Summary of changes

This PR does the following:

- Checking kubernetes enable for gke plan
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Improved error handling in `duplocloud/data_source_duplo_gke_credentials.go` to provide clearer error messages when Kubernetes JIT access is not enabled for a plan.
- Minor code formatting adjustment in `duplocloud/resource_duplo_lbconfigs.go`.
- Updated the CHANGELOG to include the recent fixes in GKE and EKS datasource error handling.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_source_duplo_gke_credentials.go</strong><dd><code>Improved Error Handling for GKE Datasource Access</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/data_source_duplo_gke_credentials.go

<li>Added error handling for GKE datasource when Kubernetes JIT access is <br>not enabled for a plan.<br> <li> Improved error messages for clarity when accessing GKE credentials <br>fails.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/479/files#diff-6c153ed25217f2032f83b9d9099c62d4bea240c4cb86a59ff52706619f75b79a">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Miscellaneous
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_lbconfigs.go</strong><dd><code>Code Formatting in LB Configs Resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_lbconfigs.go

<li>Minor formatting change with an added newline, no functional changes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/479/files#diff-41a83bf1ecdb965c35671829b7fa60279941ef1a968e3410c2b9e2f285162e10">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Changelog Update for Datasource Error Handling Fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
CHANGELOG.md

<li>Updated the changelog to reflect the bug fix in GKE and EKS datasource <br>error handling.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/479/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

