### PR TITLE
Duplo 16117 Nodepool List Datasource Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,20 @@
 markdown
 ## 2024-04-08
 
+### Fixed
+- Fixed state not being set for GCP Node Pools data source.
+
+### Enhanced
+- Enhanced logging in GCP Node Pools data source by adding `fmt` import.
+- Changed `cgroup_mode` from `TypeString` to `TypeList` in GCP Node Pools to handle multiple values correctly.
+- Updated documentation and examples to reflect changes in data source and resource configurations for GCP Node Pools and GCP SQL Database Instances.
+
+### Documentation
+- Corrected output variable name in GCP SQL Database Instances example.
+
+markdown
+## 2024-04-08
+
 ### Documentation
 - Corrected GKE credentials documentation and Terraform example, updating references from EKS to GKE and ensuring output values accurately reflect GKE credentials.
 

--- a/docs/data-sources/gcp_node_pools.md
+++ b/docs/data-sources/gcp_node_pools.md
@@ -13,13 +13,13 @@ description: |-
 ## Example Usage
 
 ```terraform
-data "duplocloud_gcp_node_pools" "pool" {
+data "duplocloud_gcp_node_pools" "app" {
   tenant_id = "tenantid"
 }
 
 output "nodepool_output" {
   value = {
-    node_pools = data.duplocloud_gcp_node_pools.pool.node_pools
+    node_pools = data.duplocloud_gcp_node_pools.app.node_pools
   }
 }
 ```
@@ -103,7 +103,7 @@ Read-Only:
 
 Read-Only:
 
-- `cgroup_mode` (String)
+- `cgroup_mode` (List of String)
 - `sysctls` (Map of String)
 
 

--- a/duplocloud/data_source_duplo_gcp_node_pools.go
+++ b/duplocloud/data_source_duplo_gcp_node_pools.go
@@ -181,7 +181,7 @@ func dataGcpK8NodePoolsFunctionSchema() map[string]*schema.Schema {
 			},
 		},
 		"resource_labels": {
-			Description: "The metadata key/value pairs assigned to instances in the cluster.",
+			Description: "Resource labels associated to node pool.",
 			Type:        schema.TypeMap,
 			Computed:    true,
 			Elem: &schema.Schema{

--- a/duplocloud/data_source_duplo_gcp_node_pools.go
+++ b/duplocloud/data_source_duplo_gcp_node_pools.go
@@ -180,6 +180,14 @@ func dataGcpK8NodePoolsFunctionSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
+		"resource_labels": {
+			Description: "The metadata key/value pairs assigned to instances in the cluster.",
+			Type:        schema.TypeMap,
+			Computed:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"node_pool_logging_config": {
 			Description: "Logging configuration.",
 			Type:        schema.TypeList,
@@ -415,6 +423,7 @@ func setGCPNodePoolStateFieldList(duplo *duplosdk.DuploGCPK8NodePool) map[string
 		"upgrade_settings":         gcpNodePoolUpgradeSettingToState(duplo.UpgradeSettings),
 		"accelerator":              gcpNodePoolAcceleratortoState(duplo.Accelerator),
 		"oauth_scopes":             filterOutDefaultOAuth(duplo.OauthScopes),
+		"resource_labels":          duplo.ResourceLabels,
 	}
 	// Set more complex fields next.
 	return mp

--- a/duplocloud/data_source_duplo_gcp_node_pools.go
+++ b/duplocloud/data_source_duplo_gcp_node_pools.go
@@ -2,6 +2,7 @@ package duplocloud
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"strings"
 	"terraform-provider-duplocloud/duplosdk"
@@ -95,8 +96,11 @@ func dataGcpK8NodePoolsFunctionSchema() map[string]*schema.Schema {
 				Schema: map[string]*schema.Schema{
 					"cgroup_mode": {
 						Description: "cgroupMode specifies the cgroup mode to be used on the node.",
-						Type:        schema.TypeString,
+						Type:        schema.TypeList,
 						Computed:    true,
+						Elem: &schema.Schema{
+							Type: schema.TypeString,
+						},
 					},
 					"sysctls": {
 						Description: "The Linux kernel parameters to be applied to the nodes and all pods running on the nodes.",
@@ -369,11 +373,13 @@ func dataSourceGCPNodePoolList(ctx context.Context, d *schema.ResourceData, m in
 
 	// Set simple fields first.
 	d.SetId(tenantID)
+
 	list := make([]map[string]interface{}, 0, len(*duploList))
 
 	for _, duplo := range *duploList {
 		list = append(list, setGCPNodePoolStateFieldList(&duplo))
 	}
+	fmt.Println("List ", list)
 	d.Set("node_pools", list)
 
 	log.Printf("[TRACE] dataSourceGCPNodePoolList ******** end")
@@ -382,7 +388,7 @@ func dataSourceGCPNodePoolList(ctx context.Context, d *schema.ResourceData, m in
 
 func setGCPNodePoolStateFieldList(duplo *duplosdk.DuploGCPK8NodePool) map[string]interface{} {
 	// Set simple fields first.
-	return map[string]interface{}{
+	mp := map[string]interface{}{
 		"name":                     getGCPNodePoolShortName(duplo.Name, duplo.ResourceLabels["duplo-tenant"]),
 		"fullname":                 duplo.Name,
 		"is_autoscaling_enabled":   duplo.IsAutoScalingEnabled,
@@ -411,5 +417,5 @@ func setGCPNodePoolStateFieldList(duplo *duplosdk.DuploGCPK8NodePool) map[string
 		"oauth_scopes":             filterOutDefaultOAuth(duplo.OauthScopes),
 	}
 	// Set more complex fields next.
-
+	return mp
 }

--- a/duplocloud/data_source_duplo_gcp_node_pools.go
+++ b/duplocloud/data_source_duplo_gcp_node_pools.go
@@ -2,7 +2,6 @@ package duplocloud
 
 import (
 	"context"
-	"fmt"
 	"log"
 	"strings"
 	"terraform-provider-duplocloud/duplosdk"
@@ -389,7 +388,6 @@ func dataSourceGCPNodePoolList(ctx context.Context, d *schema.ResourceData, m in
 		nodepool := setGCPNodePoolStateFieldList(&duplo)
 		list = append(list, nodepool)
 	}
-	fmt.Println("List ", list)
 	d.Set("node_pools", list)
 
 	log.Printf("[TRACE] dataSourceGCPNodePoolList ******** end")

--- a/duplocloud/data_source_duplo_gcp_node_pools.go
+++ b/duplocloud/data_source_duplo_gcp_node_pools.go
@@ -398,7 +398,7 @@ func dataSourceGCPNodePoolList(ctx context.Context, d *schema.ResourceData, m in
 
 func setGCPNodePoolStateFieldList(duplo *duplosdk.DuploGCPK8NodePool) map[string]interface{} {
 	// Set simple fields first.
-	mp := map[string]interface{}{
+	return map[string]interface{}{
 		"name":                     getGCPNodePoolShortName(duplo.Name, duplo.ResourceLabels["duplo-tenant"]),
 		"fullname":                 duplo.Name,
 		"is_autoscaling_enabled":   duplo.IsAutoScalingEnabled,
@@ -428,5 +428,4 @@ func setGCPNodePoolStateFieldList(duplo *duplosdk.DuploGCPK8NodePool) map[string
 		"resource_labels":          duplo.ResourceLabels,
 	}
 	// Set more complex fields next.
-	return mp
 }

--- a/duplocloud/resource_duplo_gcp_k8_node_pool.go
+++ b/duplocloud/resource_duplo_gcp_k8_node_pool.go
@@ -737,7 +737,7 @@ func gcpNodePoolLoggingConfigToState(loggingConfig *duplosdk.GCPLoggingConfig) [
 	if loggingConfig != nil && loggingConfig.VariantConfig != nil {
 		variant := make(map[string]interface{})
 		variant["variant"] = loggingConfig.VariantConfig.Variant
-		state["variant_config"] = []map[string]interface{}{variant}
+		state["variant_config"] = variant
 	}
 	return []map[string]interface{}{state}
 }
@@ -745,8 +745,8 @@ func gcpNodePoolLoggingConfigToState(loggingConfig *duplosdk.GCPLoggingConfig) [
 func gcpNodePoolLinuxConfigToState(linuxConfig *duplosdk.GCPLinuxNodeConfig) []map[string]interface{} {
 	state := make(map[string]interface{})
 	if linuxConfig != nil {
-		state["cgroup_mode"] = linuxConfig.CGroupMode
-		state["systctls"] = linuxConfig.SysCtls
+		state["cgroup_mode"] = []string{linuxConfig.CGroupMode}
+		state["sysctls"] = linuxConfig.SysCtls
 	}
 	return []map[string]interface{}{state}
 }

--- a/examples/data-sources/duplocloud_gcp_node_pools/data-source.tf
+++ b/examples/data-sources/duplocloud_gcp_node_pools/data-source.tf
@@ -1,10 +1,10 @@
-data "duplocloud_gcp_node_pools" "pool" {
+data "duplocloud_gcp_node_pools" "app" {
   tenant_id = "tenantid"
 }
 
 output "nodepool_output" {
   value = {
-    node_pools = data.duplocloud_gcp_node_pools.pool.node_pools
+    node_pools = data.duplocloud_gcp_node_pools.app.node_pools
   }
 }
  

--- a/examples/data-sources/duplocloud_gcp_sqls/data-source.tf
+++ b/examples/data-sources/duplocloud_gcp_sqls/data-source.tf
@@ -4,7 +4,7 @@ data "duplocloud_gcp_sql_database_instances" "app" {
 
 output "sql_output" {
   value = {
-    sqls = data.duplocloud_gcp_sql_database_instances.app.sqls
+    databases = data.duplocloud_gcp_sql_database_instances.app.databases
   }
 }
 


### PR DESCRIPTION
## **User description**
## Overview

Fixed listing of Nodepools 
## Summary of changes

This PR does the following:

- updated document
- Fixed State not getting set for data source of node pools datasource

## Testing performed

- [ ] Using unit tests
- [ ✓] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
bug_fix, enhancement, documentation


___

## **Description**
- Enhanced logging and corrected data handling in GCP Node Pools data source.
- Fixed `cgroup_mode` field type and state setting in GCP Node Pools and K8 Node Pool resource.
- Updated documentation and examples for GCP Node Pools and SQL Database Instances.
- Documented recent fixes and enhancements in the CHANGELOG.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_source_duplo_gcp_node_pools.go</strong><dd><code>Enhancements and Fixes in GCP Node Pools Data Source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/data_source_duplo_gcp_node_pools.go

<li>Added <code>fmt</code> import for enhanced logging.<br> <li> Changed <code>cgroup_mode</code> field type from <code>TypeString</code> to <code>TypeList</code> to <br>correctly handle multiple values.<br> <li> Updated the <code>dataSourceGCPNodePoolList</code> function to set the <code>node_pools</code> <br>state with enhanced logging.<br> <li> Modified <code>setGCPNodePoolStateFieldList</code> function to return a map for <br>node pool state setting.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/484/files#diff-285fb8b911ee2c3a8d8a815331606e4bd2d7ed57c16824ef0583458c4edb7b46">+9/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>data-source.tf</strong><dd><code>Example Update for GCP Node Pools Data Source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
examples/data-sources/duplocloud_gcp_node_pools/data-source.tf

<li>Updated data source name in the example from <code>pool</code> to <code>app</code>.<br> <li> Adjusted output variable to match the updated data source name.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/484/files#diff-9f1a6ae2c2088befdb15ee89dba1042d8e3273f61ee4d13c218faddc567879eb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug_fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_gcp_k8_node_pool.go</strong><dd><code>Fixes in GCP K8 Node Pool Resource Configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_gcp_k8_node_pool.go

<li>Adjusted <code>gcpNodePoolLoggingConfigToState</code> to correctly map <br><code>variant_config</code>.<br> <li> Updated <code>gcpNodePoolLinuxConfigToState</code> to handle <code>cgroup_mode</code> as a list <br>and correct <code>sysctls</code> key.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/484/files#diff-bc0cc4a27038eb399598c526fd7148bd7cd9349310b06235a990a5f2cac1eaf9">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Updated CHANGELOG for Node Pools and SQL Database Instances Fixes</code></dd></summary>
<hr>
      
CHANGELOG.md

<li>Documented fixes and enhancements related to GCP Node Pools data <br>source.<br> <li> Updated documentation for GCP SQL Database Instances.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/484/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+14/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gcp_node_pools.md</strong><dd><code>Documentation Update for GCP Node Pools Data Source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/data-sources/gcp_node_pools.md

<li>Updated example usage to reflect changes in data source naming.<br> <li> Corrected documentation to match the new <code>cgroup_mode</code> data type as a <br>list.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/484/files#diff-aa56a3663198f893bc2495cf99a881cc73513cb1fb4219d80ef7c5bbc572f237">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>data-source.tf</strong><dd><code>Example Correction for GCP SQL Database Instances</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
examples/data-sources/duplocloud_gcp_sqls/data-source.tf

- Corrected output variable name from `sqls` to `databases`.



</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/484/files#diff-39978ab10934b71184364363d119915d9def083f9c4e76b1aa04911d22494f4d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

