### PR TITLE
DUPLO 11726 removed use_launch_template attribute form duplocloud_asg_profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 markdown
+### Enhanced
+- Removed handling and documentation for the `use_launch_template` attribute from the ASG profile resource, aligning with schema updates.
+
+markdown
 ## 2024-04-08
 
 ### Documentation

--- a/docs/data-sources/asg_profiles.md
+++ b/docs/data-sources/asg_profiles.md
@@ -54,7 +54,6 @@ Read-Only:
 - `prepend_user_data` (Boolean)
 - `tags` (List of Object) (see [below for nested schema](#nestedobjatt--asg_profiles--tags))
 - `tenant_id` (String)
-- `use_launch_template` (Boolean)
 - `use_spot_instances` (Boolean)
 - `user_account` (String)
 - `volume` (List of Object) (see [below for nested schema](#nestedobjatt--asg_profiles--volume))

--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -75,7 +75,6 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 - `prepend_user_data` (Boolean) Bootstrap an EKS host with Duplo's user data, prepending it to custom user data if also provided. Defaults to `false`.
 - `tags` (Block List) (see [below for nested schema](#nestedblock--tags))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `use_launch_template` (Boolean) Whether or not to use a launch template.
 - `use_spot_instances` (Boolean) Whether or not to use spot instances. Defaults to `false`.
 - `user_account` (String) The name of the tenant that the host will be created in.
 - `volume` (Block List) (see [below for nested schema](#nestedblock--volume))

--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -44,13 +44,6 @@ func autoscalingGroupSchema() map[string]*schema.Schema {
 		Computed:    true,
 	}
 
-	awsASGSchema["use_launch_template"] = &schema.Schema{
-		Description: "Whether or not to use a launch template.",
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Computed:    true,
-	}
-
 	awsASGSchema["use_spot_instances"] = &schema.Schema{
 		Description: "Whether or not to use spot instances.",
 		Type:        schema.TypeBool,
@@ -359,7 +352,6 @@ func asgProfileToState(d *schema.ResourceData, duplo *duplosdk.DuploAsgProfile) 
 	d.Set("instance_count", duplo.DesiredCapacity)
 	d.Set("min_instance_count", duplo.MinSize)
 	d.Set("max_instance_count", duplo.MaxSize)
-	d.Set("use_launch_template", duplo.UseLaunchTemplate)
 	d.Set("use_spot_instances", duplo.UseSpotInstances)
 	d.Set("max_spot_price", duplo.MaxSpotPrice)
 	d.Set("fullname", duplo.FriendlyName)
@@ -416,7 +408,6 @@ func expandAsgProfile(d *schema.ResourceData) *duplosdk.DuploAsgProfile {
 		DesiredCapacity:     d.Get("instance_count").(int),
 		MinSize:             d.Get("min_instance_count").(int),
 		MaxSize:             d.Get("max_instance_count").(int),
-		UseLaunchTemplate:   d.Get("use_launch_template").(bool),
 		UseSpotInstances:    d.Get("use_spot_instances").(bool),
 		MaxSpotPrice:        d.Get("max_spot_price").(string),
 	}

--- a/duplosdk/asg.go
+++ b/duplosdk/asg.go
@@ -32,7 +32,6 @@ type DuploAsgProfile struct {
 	Status              string                             `json:"Status,omitempty"`
 	Tags                *[]DuploKeyStringValue             `json:"Tags,omitempty"`
 	TenantId            string                             `json:"TenantId,omitempty"`
-	UseLaunchTemplate   bool                               `json:"UseLaunchTemplate"`
 	UseSpotInstances    bool                               `json:"UseSpotInstances,omitempty"`
 	Volumes             *[]DuploNativeHostVolume           `json:"Volumes,omitempty"`
 	Zone                int                                `json:"Zone"`


### PR DESCRIPTION
## **User description**
## Overview

Removed schema attribute use_launch_template
## Summary of changes
Removed schema attribute use_launch_template from duplocloud_asg_profile resource

This PR does the following:

- Removed schema attribute use_launch_template from duplocloud_asg_profile resource
 
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
enhancement, documentation


___

## **Description**
- Removed the `use_launch_template` attribute from the autoscaling group schema and related documentation.
- Updated `DuploAsgProfile` struct to exclude the `UseLaunchTemplate` field.
- Updated documentation in both data sources and resources to reflect the removal of `use_launch_template`.
- Added changelog entry for the removal of `use_launch_template` handling and documentation.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_asg_profile.go</strong><dd><code>Remove `use_launch_template` Attribute from ASG Profile Resource</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_asg_profile.go

<li>Removed the <code>use_launch_template</code> attribute from the autoscaling group <br>schema.<br> <li> Updated state and expand functions to exclude <code>use_launch_template</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/485/files#diff-f58c7134634373bfbd4607fa72e0d5fb28a0da60d136394bacd5671ea75c8346">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>asg.go</strong><dd><code>Update DuploAsgProfile Struct to Exclude `UseLaunchTemplate`</code></dd></summary>
<hr>
      
duplosdk/asg.go

<li>Removed the <code>UseLaunchTemplate</code> field from the <code>DuploAsgProfile</code> struct.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/485/files#diff-b9e34e160487d98157b8b887377449bc8b90d93a1d7640c770a57ab0a7ca5507">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update Changelog for Removal of `use_launch_template`</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
CHANGELOG.md

<li>Added entry about removing <code>use_launch_template</code> handling and <br>documentation.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/485/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>asg_profiles.md</strong><dd><code>Update ASG Profiles Data Source Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/data-sources/asg_profiles.md

- Removed documentation related to `use_launch_template`.



</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/485/files#diff-52b39cccffadb88ed9ceb2dfa500b366c11f840a94fb3ef00945abf6875916b0">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>asg_profile.md</strong><dd><code>Update ASG Profile Resource Documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
docs/resources/asg_profile.md

- Removed `use_launch_template` from the resource documentation.



</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/485/files#diff-0b0507a0a18d1275d81b42d11e06ba436e7ef85ec5c0cb56cc83b8e6381c2909">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

