### PR TITLE
DUPLO 14752 GCP:CloudSQL: Force replacement should not be shown for database version upgrade

### DIFF
--- a/duplocloud/resource_duplo_gcp_sql_database.go
+++ b/duplocloud/resource_duplo_gcp_sql_database.go
@@ -46,22 +46,9 @@ func gcpSqlDBInstanceSchema() map[string]*schema.Schema {
 				"`POSTGRES_11`,`POSTGRES_12`, `POSTGRES_13`, `POSTGRES_14`, `POSTGRES_15`, `SQLSERVER_2017_STANDARD`,`SQLSERVER_2017_ENTERPRISE`," +
 				"`SQLSERVER_2017_EXPRESS`, `SQLSERVER_2017_WEB`.`SQLSERVER_2019_STANDARD`, `SQLSERVER_2019_ENTERPRISE`, `SQLSERVER_2019_EXPRESS`," +
 				"`SQLSERVER_2019_WEB`.[Database Version Policies](https://cloud.google.com/sql/docs/db-versions)includes an up-to-date reference of supported versions.",
-			Type:     schema.TypeString,
-			Required: true,
-			//ForceNew:     true,
+			Type:         schema.TypeString,
+			Required:     true,
 			ValidateFunc: validation.StringInSlice(supportedGcpSQLDBVersions(), false),
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				// Suppress diff if both database name and version are the same
-				oldParts := strings.Split(old, "_")
-				newParts := strings.Split(new, "_")
-				if oldParts[0] == newParts[0] && oldParts[1] == newParts[1] {
-					if len(oldParts) > 2 && len(newParts) > 2 && oldParts[2] != newParts[2] {
-						return false
-					}
-					return true
-				}
-				return false
-			},
 		},
 
 		"tier": {


### PR DESCRIPTION
## Overview

This PR handles state difference on GCP cloud sql resource creation or update of database_version. For version change in-place update would be carried out for database change resource will be replaced
This PR does the following:

- Implemented replaceOn function of isForceNew function type which checks change of database
## Testing performed

- [ ] Using unit tests
- [ ✓] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
