### PR TITLE
DUPLO-16633 dynamodb_table_v2: Not able to update "delete_protection_enabled" value

### DIFF
--- a/duplosdk/aws_dynamo_db.go
+++ b/duplosdk/aws_dynamo_db.go
@@ -141,7 +141,7 @@ type DuploDynamoDBTableV2BillingModeSummary struct {
 type DuploDynamoDBTableRequestV2 struct {
 	TableName                 string                                      `json:"TableName"`
 	BillingMode               string                                      `json:"BillingMode,omitempty"`
-	DeletionProtectionEnabled bool                                        `json:"DeletionProtectionEnabled,omitempty"`
+	DeletionProtectionEnabled bool                                        `json:"DeletionProtectionEnabled"`
 	Tags                      *[]DuploKeyStringValue                      `json:"Tags,omitempty"`
 	KeySchema                 *[]DuploDynamoDBKeySchemaV2                 `json:"KeySchema,omitempty"`
 	AttributeDefinitions      *[]DuploDynamoDBAttributeDefinionV2         `json:"AttributeDefinitions,omitempty"`


### PR DESCRIPTION
## Overview

This PR fixes updation issue related to deletion_protection_enabled attribute for `duplocloud_aws_dynamodb_table_v2` resource
## Summary of changes

This PR does the following:

- If there is change in deletion_protection_enabled attribute an separate request specific to updating this field is sent
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
