### PR TITLE
DUPLO 16595 Bug fix on update of taskdefnition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-04-15
+
+### Fixed
+- Fixed an issue in `duplocloud_ecs_task_definition` update process by marking the `task_definition` field with `ForceNew` in `duplocloud_ecs_service.go`, ensuring the ECS service resource is recreated when the task definition is updated.
+
 ## 2024-04-09
 
 ### Fixed

--- a/duplocloud/resource_duplo_ecs_service.go
+++ b/duplocloud/resource_duplo_ecs_service.go
@@ -35,6 +35,7 @@ func ecsServiceSchema() map[string]*schema.Schema {
 			Description: "The ARN of the task definition to use.",
 			Type:        schema.TypeString,
 			Required:    true,
+			ForceNew:    true,
 		},
 		"replicas": {
 			Description: "The number of container replicas to create.",


### PR DESCRIPTION
## **User description**
## Overview

This PR has fix for error related to `duplocloud_ecs_task_definition` resource update.

## Summary of changes
Now on update of task_definition
exisiting service related to task_definition is getting destroyed
task_definition getting destroyed
task_definition got created
service related to task_definition got created

This PR does the following:

- Made arn field force new. Which helps in updating task-definition along with associated service
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
bug_fix, enhancement


___

## **Description**
- Marked the `task_definition` field in `duplocloud_ecs_service.go` with `ForceNew` to ensure that the ECS service is recreated when the task definition is updated.
- Updated the CHANGELOG to document the fix applied to the ECS service update process.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_ecs_service.go</strong><dd><code>Force recreation of ECS service on task definition update</code></dd></summary>
<hr>
      
duplocloud/resource_duplo_ecs_service.go

<li>Marked the <code>task_definition</code> field with <code>ForceNew</code> to trigger resource <br>recreation on updates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/496/files#diff-abe746fefa6af73ac3b6be31a7bc1f98878133e2bab5c4922755ea880804b13b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update CHANGELOG for ECS service recreation fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
CHANGELOG.md

<li>Added an entry under the "Fixed" section for the update in <br><code>duplocloud_ecs_service.go</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/496/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+28/-21</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

