### PR TITLE
DUPLO 17038  Support for ResourceLabels for duplocloud_gcp_node_pool tf resource

### DIFF
--- a/duplocloud/data_source_duplo_gcp_node_pool.go
+++ b/duplocloud/data_source_duplo_gcp_node_pool.go
@@ -191,7 +191,14 @@ func dataGcpK8NodePoolFunctionSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
-
+		"resource_labels": {
+			Description: "Resource labels associated to node pool",
+			Type:        schema.TypeMap,
+			Computed:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"zones": {
 			Description: "The list of Google Compute Engine zones in which the NodePool's nodes should be located.",
 			Type:        schema.TypeList,

--- a/duplocloud/data_source_duplo_gcp_node_pools.go
+++ b/duplocloud/data_source_duplo_gcp_node_pools.go
@@ -119,6 +119,14 @@ func dataGcpK8NodePoolsFunctionSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
+		"resource_labels": {
+			Description: "Resource labels associated to node pool",
+			Type:        schema.TypeMap,
+			Computed:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"is_autoscaling_enabled": {
 			Description: "Is autoscaling enabled for this node pool.",
 			Type:        schema.TypeBool,
@@ -372,7 +380,8 @@ func dataSourceGCPNodePoolList(ctx context.Context, d *schema.ResourceData, m in
 	list := make([]map[string]interface{}, 0, len(*duploList))
 
 	for _, duplo := range *duploList {
-		list = append(list, setGCPNodePoolStateFieldList(&duplo))
+		nodepool := setGCPNodePoolStateFieldList(&duplo)
+		list = append(list, nodepool)
 	}
 	d.Set("node_pools", list)
 
@@ -409,6 +418,7 @@ func setGCPNodePoolStateFieldList(duplo *duplosdk.DuploGCPK8NodePool) map[string
 		"upgrade_settings":         gcpNodePoolUpgradeSettingToState(duplo.UpgradeSettings),
 		"accelerator":              gcpNodePoolAcceleratortoState(duplo.Accelerator),
 		"oauth_scopes":             filterOutDefaultOAuth(duplo.OauthScopes),
+		"resource_labels":          duplo.ResourceLabels,
 	}
 	// Set more complex fields next.
 

--- a/duplocloud/data_source_duplo_gcp_node_pools.go
+++ b/duplocloud/data_source_duplo_gcp_node_pools.go
@@ -119,14 +119,7 @@ func dataGcpK8NodePoolsFunctionSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
-		"resource_labels": {
-			Description: "Resource labels associated to node pool",
-			Type:        schema.TypeMap,
-			Computed:    true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-		},
+
 		"is_autoscaling_enabled": {
 			Description: "Is autoscaling enabled for this node pool.",
 			Type:        schema.TypeBool,
@@ -418,7 +411,6 @@ func setGCPNodePoolStateFieldList(duplo *duplosdk.DuploGCPK8NodePool) map[string
 		"upgrade_settings":         gcpNodePoolUpgradeSettingToState(duplo.UpgradeSettings),
 		"accelerator":              gcpNodePoolAcceleratortoState(duplo.Accelerator),
 		"oauth_scopes":             filterOutDefaultOAuth(duplo.OauthScopes),
-		"resource_labels":          duplo.ResourceLabels,
 	}
 	// Set more complex fields next.
 

--- a/duplocloud/resource_duplo_gcp_k8_node_pool.go
+++ b/duplocloud/resource_duplo_gcp_k8_node_pool.go
@@ -584,10 +584,6 @@ func expandGCPNodePoolConfig(d *schema.ResourceData, req *duplosdk.DuploGCPK8Nod
 		req.Metadata = metadata
 	}
 
-	if val, ok := d.Get("metadata").(map[string]string); ok {
-		req.Metadata = val
-	}
-
 	if val, ok := d.Get("resource_labels").(map[string]interface{}); ok {
 		resourceLabels := make(map[string]string)
 		for key, value := range val {

--- a/duplocloud/resource_duplo_gcp_k8_node_pool.go
+++ b/duplocloud/resource_duplo_gcp_k8_node_pool.go
@@ -222,7 +222,15 @@ func gcpK8NodePoolFunctionSchema() map[string]*schema.Schema {
 				Type: schema.TypeString,
 			},
 		},
-
+		"resource_labels": {
+			Description: "Resource labels associated to node pool",
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+		},
 		"zones": {
 			Description: "The list of Google Compute Engine zones in which the NodePool's nodes should be located.",
 			Type:        schema.TypeList,
@@ -566,9 +574,28 @@ func expandGCPNodePoolConfig(d *schema.ResourceData, req *duplosdk.DuploGCPK8Nod
 
 		}
 	}
+	if val, ok := d.Get("metadata").(map[string]interface{}); ok {
+		metadata := make(map[string]string)
+		for key, value := range val {
+			if strVal, ok := value.(string); ok {
+				metadata[key] = strVal
+			}
+		}
+		req.Metadata = metadata
+	}
 
 	if val, ok := d.Get("metadata").(map[string]string); ok {
 		req.Metadata = val
+	}
+
+	if val, ok := d.Get("resource_labels").(map[string]interface{}); ok {
+		resourceLabels := make(map[string]string)
+		for key, value := range val {
+			if strVal, ok := value.(string); ok {
+				resourceLabels[key] = strVal
+			}
+		}
+		req.ResourceLabels = resourceLabels
 	}
 	expandGCPNodePoolAccelerator(d, req)
 }
@@ -703,6 +730,7 @@ func setGCPNodePoolStateField(d *schema.ResourceData, duplo *duplosdk.DuploGCPK8
 	d.Set("upgrade_settings", gcpNodePoolUpgradeSettingToState(duplo.UpgradeSettings))
 	d.Set("accelerator", gcpNodePoolAcceleratortoState(duplo.Accelerator))
 	d.Set("oauth_scopes", filterOutDefaultOAuth(duplo.OauthScopes))
+	d.Set("resource_labels", duplo.ResourceLabels)
 	// Set more complex fields next.
 
 }
@@ -859,7 +887,7 @@ func resourceGCPK8NodePoolUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		}
 	}
-	if d.HasChange("taints") || d.HasChange("labels") || d.HasChange("tags") {
+	if d.HasChange("taints") || d.HasChange("labels") || d.HasChange("tags") || d.HasChange("resource_labels") {
 		_, err = gcpNodePoolUpdateTaintAndTags(c, tenantID, fullName, rq)
 		if err != nil {
 			return diag.Errorf("Error updating request for %s : %s", tenantID, err.Error())


### PR DESCRIPTION
## Overview

This PR contains support for adding ResourceLabels for `duplocloud_gcp_node_pool` resource
## Summary of changes

This PR does the following:

- Support added for resource creation and updation of resource_labels
- Support added for data source

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...
