### PR TITLE
DUPLO 17067 TFstate update fix 

### DIFF
--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -505,6 +505,7 @@ func flattenDuploServiceLbConfiguration(lb *duplosdk.DuploLbConfiguration) map[s
 		"extra_selector_label":        keyValueToState("extra_selector_label", lb.ExtraSelectorLabels),
 		"target_group_arn":            lb.TgArn,
 		"custom_cidr":                 lb.CustomCidrs,
+		"allow_global_access":         lb.AllowGlobalAccess,
 	}
 
 	if lb.LbType == 5 && lb.HostNames != nil && len(*lb.HostNames) > 0 {


### PR DESCRIPTION
## Overview

Bug fix for tfstate not getting update for `allow_global_access` schema attribute for `duplocloud_duplo_service_lbconfigs` resource
This PR does the following:

- PR sets value for `allow_global_access` during read

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
