### PR TITLE
DUPLO 17015 Add support for enable_iam_auth in rds_instance

### DIFF
--- a/docs/data-sources/gcp_node_pool.md
+++ b/docs/data-sources/gcp_node_pool.md
@@ -66,6 +66,7 @@ output "nodepool_output" {
 - `min_node_count` (Number) Minimum number of nodes for one location in the NodePool. Must be >= 1 and <= maxNodeCount.
 - `node_pool_logging_config` (List of Object) Logging configuration. (see [below for nested schema](#nestedatt--node_pool_logging_config))
 - `oauth_scopes` (List of String) The set of Google API scopes to be made available on all of the node VMs under the default service account.
+- `resource_labels` (Map of String) Resource labels associated to node pool
 - `spot` (Boolean) Spot flag for enabling Spot VM
 - `tags` (List of String) The list of instance tags applied to all nodes.
 				Tags are used to identify valid sources or targets for network firewalls and are specified by the client during cluster or node pool creation.

--- a/docs/resources/aws_elasticsearch.md
+++ b/docs/resources/aws_elasticsearch.md
@@ -78,6 +78,7 @@ Optional:
 - `dedicated_master_type` (String) Defaults to `t2.small.elasticsearch`.
 - `instance_count` (Number) Defaults to `1`.
 - `instance_type` (String) Defaults to `t2.small.elasticsearch`.
+- `multi_az_with_standby_enabled` (Boolean)
 - `warm_count` (Number)
 - `warm_enabled` (Boolean)
 - `warm_type` (String)

--- a/docs/resources/gcp_node_pool.md
+++ b/docs/resources/gcp_node_pool.md
@@ -85,6 +85,7 @@ resource "duplocloud_gcp_node_pool" "node_pool" {
 - `min_node_count` (Number) Minimum number of nodes for one location in the NodePool. Must be >= 1 and <= maxNodeCount.
 - `node_pool_logging_config` (Block List) Logging configuration. (see [below for nested schema](#nestedblock--node_pool_logging_config))
 - `oauth_scopes` (List of String) The set of Google API scopes to be made available on all of the node VMs under the default service account.
+- `resource_labels` (Map of String) Resource labels associated to node pool
 - `spot` (Boolean) Spot flag for enabling Spot VM
 - `tags` (List of String) The list of instance tags applied to all nodes.
 				Tags are used to identify valid sources or targets for network firewalls and are specified by the client during cluster or node pool creation.

--- a/docs/resources/plan_settings.md
+++ b/docs/resources/plan_settings.md
@@ -35,6 +35,7 @@ resource "duplocloud_plan_settings" "myplanSettings" {
 
 - `dns_setting` (Block List, Max: 1) (see [below for nested schema](#nestedblock--dns_setting))
 - `metadata` (Block List) A list of metadata for the plan to manage. (see [below for nested schema](#nestedblock--metadata))
+- `specified_metadata` (List of String) A list of metadata being managed by this resource.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `unrestricted_ext_lb` (Boolean)
 
@@ -42,7 +43,6 @@ resource "duplocloud_plan_settings" "myplanSettings" {
 
 - `all_metadata` (List of Object) A complete list of metadata for this plan, even ones not being managed by this resource. (see [below for nested schema](#nestedatt--all_metadata))
 - `id` (String) The ID of this resource.
-- `specified_metadata` (List of String) A list of metadata being managed by this resource.
 
 <a id="nestedblock--dns_setting"></a>
 ### Nested Schema for `dns_setting`

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -89,6 +89,7 @@ See AWS documentation for the [available instance types](https://aws.amazon.com/
 - `cluster_parameter_group_name` (String) Parameter group associated with this instance's DB Cluster.
 - `db_subnet_group_name` (String) Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group.
 - `deletion_protection` (Boolean) If the DB instance should have deletion protection enabled.The database can't be deleted when this value is set to `true`. This setting is not applicable for document db cluster instance. Defaults to `false`.
+- `enable_iam_auth` (Boolean) Whether or not to enable the RDS IAM authentication.
 - `enable_logging` (Boolean) Whether or not to enable the RDS instance logging. This setting is not applicable for document db cluster instance.
 - `encrypt_storage` (Boolean) Whether or not to encrypt the RDS instance storage.
 - `engine_version` (String) The database engine version to use the for the RDS instance.

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -267,6 +267,12 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			Optional: true,
 			Default:  false,
 		},
+		"enable_iam_auth": {
+			Description: "Whether or not to enable the RDS IAM authentication.",
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+		},
 	}
 }
 
@@ -655,6 +661,7 @@ func rdsInstanceFromState(d *schema.ResourceData) (*duplosdk.DuploRdsInstance, e
 	duploObject.InstanceStatus = d.Get("instance_status").(string)
 	duploObject.SkipFinalSnapshot = d.Get("skip_final_snapshot").(bool)
 	duploObject.StoreDetailsInSecretManager = d.Get("store_details_in_secret_manager").(bool)
+	duploObject.EnableIamAuth = d.Get("enable_iam_auth").(bool)
 	if v, ok := d.GetOk("v2_scaling_configuration"); ok {
 		duploObject.V2ScalingConfiguration = expandV2ScalingConfiguration(v.([]interface{}))
 	}
@@ -732,7 +739,7 @@ func rdsInstanceToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Resour
 	jo["instance_status"] = duploObject.InstanceStatus
 	jo["skip_final_snapshot"] = duploObject.SkipFinalSnapshot
 	jo["store_details_in_secret_manager"] = duploObject.StoreDetailsInSecretManager
-
+	jo["enable_iam_auth"] = duploObject.EnableIamAuth
 	if duploObject.V2ScalingConfiguration != nil && duploObject.V2ScalingConfiguration.MinCapacity != 0 {
 		d.Set("v2_scaling_configuration", []map[string]interface{}{{
 			"min_capacity": duploObject.V2ScalingConfiguration.MinCapacity,

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -59,6 +59,7 @@ type DuploRdsInstance struct {
 	DBSubnetGroupName           string                  `json:"DBSubnetGroupName,omitempty"`
 	V2ScalingConfiguration      *V2ScalingConfiguration `json:"V2ScalingConfiguration,omitempty"`
 	AvailabilityZone            string                  `json:"AvailabilityZone,omitempty"`
+	EnableIamAuth               bool                    `json:"EnableIamAuth"`
 }
 
 type V2ScalingConfiguration struct {


### PR DESCRIPTION

Added support to `enable_iam_auth` attribute in `duplocloud_rds_instance`
This PR does the following:

- Sets enable_iam_auth on create for duplocloud_rds_instance
## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...
