### PR TITLE
DUPLO-17011 Suppress unsupported group parameter on update context for rds

### DIFF
--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -144,6 +144,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 				validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "DB parameter group name cannot end with a hyphen"),
 				validation.StringDoesNotMatch(regexp.MustCompile(`--`), "DB parameter group name cannot contain two hyphens"),
 			),
+			DiffSuppressFunc: diffSuppressWhenNotCreating,
 		},
 		"cluster_parameter_group_name": {
 			Description: "Parameter group associated with this instance's DB Cluster.",
@@ -156,6 +157,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 				validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "DB parameter group name cannot end with a hyphen"),
 				validation.StringDoesNotMatch(regexp.MustCompile(`--`), "DB parameter group name cannot contain two hyphens"),
 			),
+			DiffSuppressFunc: diffSuppressWhenNotCreating,
 		},
 		"store_details_in_secret_manager": {
 			Description: "Whether or not to store RDS details in the AWS secrets manager.",


### PR DESCRIPTION
Suppress `parameter_group_name` and `cluster_parameter_group_name` schema attribute on update context for `duplocloud_rds_instance`

## Summary of changes

This PR does the following:

- Added suppress difference function for `group_parameter_name` and `cluster_group_parameter_name` schema attribute

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
