### PR TITLE
DUPLO-17038 No change Bug fix

### DIFF
--- a/duplocloud/data_source_duplo_gcp_node_pools.go
+++ b/duplocloud/data_source_duplo_gcp_node_pools.go
@@ -423,7 +423,7 @@ func setGCPNodePoolStateFieldList(duplo *duplosdk.DuploGCPK8NodePool) map[string
 		"upgrade_settings":         gcpNodePoolUpgradeSettingToState(duplo.UpgradeSettings),
 		"accelerator":              gcpNodePoolAcceleratortoState(duplo.Accelerator),
 		"oauth_scopes":             filterOutDefaultOAuth(duplo.OauthScopes),
-		"resource_labels":          duplo.ResourceLabels,
+		"resource_labels":          filterOutDefaultResourceLabels(duplo.ResourceLabels),
 	}
 	// Set more complex fields next.
 }

--- a/duplocloud/resource_duplo_gcp_k8_node_pool.go
+++ b/duplocloud/resource_duplo_gcp_k8_node_pool.go
@@ -726,7 +726,7 @@ func setGCPNodePoolStateField(d *schema.ResourceData, duplo *duplosdk.DuploGCPK8
 	d.Set("upgrade_settings", gcpNodePoolUpgradeSettingToState(duplo.UpgradeSettings))
 	d.Set("accelerator", gcpNodePoolAcceleratortoState(duplo.Accelerator))
 	d.Set("oauth_scopes", filterOutDefaultOAuth(duplo.OauthScopes))
-	d.Set("resource_labels", duplo.ResourceLabels)
+	d.Set("resource_labels", filterOutDefaultResourceLabels(duplo.ResourceLabels))
 	// Set more complex fields next.
 
 }
@@ -1066,4 +1066,9 @@ func filterOutDefaultOAuth(oAuths []string) []string {
 		}
 	}
 	return filters
+}
+
+func filterOutDefaultResourceLabels(labels map[string]string) map[string]string {
+	delete(labels, "duplo-tenant")
+	return labels
 }


### PR DESCRIPTION
## Overview

Bug fix related to `resource_labels` showing state difference on no change for `duplocloud_gcp_node_pool` resource
## Summary of changes

This PR does the following:

- Filtering default resource label before setting values to tf state
- ...

## Testing performed

- [ ] Using unit tests
- [✓ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
