### PR TITLE
DUPLO-17034 Mount targets details are missing in TF state file

### DIFF
--- a/duplosdk/aws_efs.go
+++ b/duplosdk/aws_efs.go
@@ -41,6 +41,15 @@ type DuploEFSGetResp struct {
 	SizeInBytes                  *EFSSizeInBytes        `json:"SizeInBytes,omitempty"`
 	Tags                         *[]DuploKeyStringValue `json:"Tags,omitempty"`
 	ThroughputMode               *DuploStringValue      `json:"ThroughputMode,omitempty"`
+	MountTarget                  *[]MountTarget         `json:"-"`
+}
+
+type MountTarget struct {
+	IP               string         `json:"IpAddress"`
+	AvailabilityZone string         `json:"AvailabilityZoneName"`
+	SubnetId         string         `json:"SubnetId"`
+	LifeCycleState   LifeCycleState `json:"LifeCycleState"`
+	MountTargetId    string         `json:"MountTargetId"`
 }
 
 /*************************************************
@@ -84,6 +93,16 @@ func (c *Client) DuploEFSDelete(tenantID string, efsId string) (*DuploEFSGetResp
 	err := c.deleteAPI(
 		fmt.Sprintf("DuploEFSDelete(%s, %s)", tenantID, efsId),
 		fmt.Sprintf("v3/subscriptions/%s/aws/efs/%s", tenantID, efsId),
+		&rp,
+	)
+	return &rp, err
+}
+
+func (c *Client) DuploAWsMountTargetGet(tenantID string, efsId string) (*[]MountTarget, ClientError) {
+	rp := []MountTarget{}
+	err := c.getAPI(
+		fmt.Sprintf("DuploEFSGet(%s, %s)", tenantID, efsId),
+		fmt.Sprintf("v3/subscriptions/%s/aws/efs_mount_targets/%s", tenantID, efsId),
 		&rp,
 	)
 	return &rp, err

--- a/duplosdk/aws_efs_lifecycle_policy.go
+++ b/duplosdk/aws_efs_lifecycle_policy.go
@@ -10,6 +10,10 @@ type LifecyclePolicy struct {
 	TransitionToPrimaryStorageClass *DuploStringValue `json:"TransitionToPrimaryStorageClass"`
 }
 
+type LifeCycleState struct {
+	Value string `json:"value"`
+}
+
 type PutLifecycleConfigurationInput struct {
 	FileSystemId      string             `json:"FileSystemId"`
 	LifecyclePolicies []*LifecyclePolicy `json:"LifecyclePolicies"`


### PR DESCRIPTION
## **User description**
Fix for `mount_targets` details are missing in TF state file for `duplocloud_aws_efs_file_system` resource

This PR does the following:

- Added API that returns details for `mount_targets` schema attribute for resource `duplocloud_aws_efs_file_system`
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

## **Type**
enhancement


___

## **Description**
- Added support for retrieving and displaying mount target details in the `duplocloud_aws_efs_file_system` resource.
- Introduced new data structures in the SDK to handle mount target and lifecycle state information.
- Enhanced the EFS resource read function to fetch and set mount target details from the API.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_efs_file_system.go</strong><dd><code>Enhance EFS resource with mount target details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_aws_efs_file_system.go

<li>Added <code>mount_targets</code> attribute to the EFS resource schema.<br> <li> Implemented retrieval and setting of mount target details in the EFS <br>read function.<br> <li> Added a helper function <code>flattenMounts</code> to format mount target data.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/509/files#diff-7d78cc8cb996471fa7b6797110f58dd9a8363df9a5a7eaa7637ef75edc75878b">+53/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aws_efs.go</strong><dd><code>Add mount target support in Duplo SDK</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/aws_efs.go

<li>Added <code>MountTarget</code> struct to represent mount target details.<br> <li> Implemented <code>DuploAWsMountTargetGet</code> function to fetch mount target <br>details.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/509/files#diff-d2615035ebb33886d4e9fab5b09ad6ea06c06779b9f717cce3b86f86291e5b42">+19/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aws_efs_lifecycle_policy.go</strong><dd><code>Add lifecycle state struct for EFS</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/aws_efs_lifecycle_policy.go

<li>Added <code>LifeCycleState</code> struct to represent the lifecycle state of a <br>mount target.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/509/files#diff-845de39655ee678d5bcf91fd14ec9a935bf5cd0c43c6fb0747d1467a472a5b8b">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

