### PR TITLE
DUPLO-9842 Update to Github Actions

### DIFF
--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Go
         uses: actions/setup-go@v5
@@ -22,7 +22,7 @@ jobs:
           cache: false
       - 
         name: Run linting
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v5
         with:
           only-new-issues: true  # Only show new issues for pull requests.
           args: --timeout=5m

--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
       -
         name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.20.0'
           cache: false
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.20.0'
           cache: false

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v4
       -
         name: Set up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.20.0'
       -

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Set up Go
         uses: actions/setup-go@v4

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: master                 # Always finish releases from the "merged to" master
           fetch-depth: 0
@@ -41,7 +41,7 @@ jobs:
       - finish-release
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: develop
           fetch-depth: 0

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       -
         name: Unshallow
         run: git fetch --prune --unshallow

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -15,7 +15,7 @@ jobs:
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '^1.20.0'
       -

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: develop                # Always release from develop
           fetch-depth: 0


### PR DESCRIPTION
## Overview

Updated GitHub actions that used node@16.

## Summary of changes

This PR does the following:

- `actions/checkout@v3` -> @v4
- `agolangci/golangci-lint-action@v3` -> @v5
- `actions/setup-go@v4`  -> @v5

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes
