### PR TITLE
Duplo-16960 Added snapshot attribute support for echache instance

### DIFF
--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -60,6 +60,9 @@ See AWS documentation for the [available Redis instance types](https://docs.aws.
 - `number_of_shards` (Number) The number of shards to create.
 - `parameter_group_name` (String) The REDIS parameter group to supply.
 - `replicas` (Number) The number of replicas to create. Defaults to `1`.
+- `snapshot_arn` (String) Specify the ARN of a Redis RDB snapshot file stored in Amazon S3.
+- `snapshot_name` (String) Select the snapshot/backup you want to use for creating redis.
+- `snapshot_retention_limit` (Number) Specify retention limit in days. Accepted values - 1-35.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/duplosdk/ecache_instance.go
+++ b/duplosdk/ecache_instance.go
@@ -12,21 +12,24 @@ type DuploEcacheInstance struct {
 	// NOTE: The Name field does not come from the backend - we synthesize it
 	Name string `json:"Name"`
 
-	Identifier          string `json:"Identifier"`
-	Arn                 string `json:"Arn"`
-	Endpoint            string `json:"Endpoint,omitempty"`
-	CacheType           int    `json:"CacheType,omitempty"`
-	EngineVersion       string `json:"EngineVersion,omitempty"`
-	Size                string `json:"Size,omitempty"`
-	Replicas            int    `json:"Replicas,omitempty"`
-	EncryptionAtRest    bool   `json:"EnableEncryptionAtRest,omitempty"`
-	EncryptionInTransit bool   `json:"EnableEncryptionAtTransit,omitempty"`
-	KMSKeyID            string `json:"KmsKeyId,omitempty"`
-	AuthToken           string `json:"AuthToken,omitempty"`
-	ParameterGroupName  string `json:"ParameterGroupName,omitempty"`
-	InstanceStatus      string `json:"InstanceStatus,omitempty"`
-	EnableClusterMode   bool   `json:"ClusteringEnabled,omitempty"`
-	NumberOfShards      int    `json:"NoOfShards,omitempty"`
+	Identifier             string `json:"Identifier"`
+	Arn                    string `json:"Arn"`
+	Endpoint               string `json:"Endpoint,omitempty"`
+	CacheType              int    `json:"CacheType,omitempty"`
+	EngineVersion          string `json:"EngineVersion,omitempty"`
+	Size                   string `json:"Size,omitempty"`
+	Replicas               int    `json:"Replicas,omitempty"`
+	EncryptionAtRest       bool   `json:"EnableEncryptionAtRest,omitempty"`
+	EncryptionInTransit    bool   `json:"EnableEncryptionAtTransit,omitempty"`
+	KMSKeyID               string `json:"KmsKeyId,omitempty"`
+	AuthToken              string `json:"AuthToken,omitempty"`
+	ParameterGroupName     string `json:"ParameterGroupName,omitempty"`
+	InstanceStatus         string `json:"InstanceStatus,omitempty"`
+	EnableClusterMode      bool   `json:"ClusteringEnabled,omitempty"`
+	NumberOfShards         int    `json:"NoOfShards,omitempty"`
+	SnapshotName           string
+	SnapshotArn            string
+	SnapshotRetentionLimit int
 }
 
 /*************************************************


### PR DESCRIPTION
## Overview

Added support for attribute `snapshot_name`, `snapshot_arns`, `snapshot_retention_limit` for `duplocloud_ecache_instance`
## Summary of changes

This PR does the following:

- Added snapshot attribute snapshot_name, snapshot_arns (conflicts with snapshot_name) and snapshot_retention_limit 
- Updated docs

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
