### PR TITLE
DUPLO-17143 Fix resource type in example of resource “duplocloud_gcp_scheduler_job”. Change type “duploscheduler_gcp_scheduler_job” to “duplocloud_gcp_scheduler_job”

### DIFF
--- a/docs/resources/gcp_scheduler_job.md
+++ b/docs/resources/gcp_scheduler_job.md
@@ -19,7 +19,7 @@ resource "duplocloud_tenant" "myapp" {
 }
 
 // A simple scheduler job with an HTTPS target, running at 9 am daily.
-resource "duploscheduler_gcp_scheduler_job" "myjob" {
+resource "duplocloud_gcp_scheduler_job" "myjob" {
   tenant_id = duplocloud_tenant.myapp.tenant_id
 
   name = "myjob"

--- a/examples/resources/duplocloud_gcp_scheduler_job/resource.tf
+++ b/examples/resources/duplocloud_gcp_scheduler_job/resource.tf
@@ -4,7 +4,7 @@ resource "duplocloud_tenant" "myapp" {
 }
 
 // A simple scheduler job with an HTTPS target, running at 9 am daily.
-resource "duploscheduler_gcp_scheduler_job" "myjob" {
+resource "duplocloud_gcp_scheduler_job" "myjob" {
   tenant_id = duplocloud_tenant.myapp.tenant_id
 
   name = "myjob"


### PR DESCRIPTION
## Overview

Fixed doc for  resource `duplocloud_gcp_scheduler_job` resource

This PR does the following:

- Fixed example of `duplocloud_gcp_scheduler_job` resource
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
