### PR TITLE
DUPLO 17150 duplocloud_ecs_task_definition: Terraform shows difference in plan with no changes if Family name is provided without duplo prefix

### DIFF
--- a/duplocloud/diff_utils.go
+++ b/duplocloud/diff_utils.go
@@ -9,7 +9,6 @@ import (
 	"hash/fnv"
 	"reflect"
 	"regexp"
-	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -176,15 +175,4 @@ func diffStringMaps(oldMap, newMap map[string]interface{}) (map[string]*string, 
 	}
 
 	return create, remove
-}
-
-func diffSuppressIgnoreDuploPrefix(k, old, new string, d *schema.ResourceData) bool {
-	oldStr, newStr := "", ""
-	if d.HasChange(k) {
-		old, new := d.GetChange(k)
-		oldStr = old.(string)
-		newStr = new.(string)
-		return !strings.Contains(oldStr, newStr)
-	}
-	return true
 }

--- a/duplocloud/diff_utils.go
+++ b/duplocloud/diff_utils.go
@@ -9,6 +9,7 @@ import (
 	"hash/fnv"
 	"reflect"
 	"regexp"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -175,4 +176,15 @@ func diffStringMaps(oldMap, newMap map[string]interface{}) (map[string]*string, 
 	}
 
 	return create, remove
+}
+
+func diffSuppressIgnoreDuploPrefix(k, old, new string, d *schema.ResourceData) bool {
+	oldStr, newStr := "", ""
+	if d.HasChange(k) {
+		old, new := d.GetChange(k)
+		oldStr = old.(string)
+		newStr = new.(string)
+		return !strings.Contains(oldStr, newStr)
+	}
+	return true
 }

--- a/duplocloud/resource_duplo_ecs_task_definition.go
+++ b/duplocloud/resource_duplo_ecs_task_definition.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/ucarion/jcs"
@@ -33,14 +32,12 @@ func ecsTaskDefinitionSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			ForceNew:    true,
-			//DiffSuppressFunc: diffSuppressIgnoreDuploPrefix,
 		},
-		//	"full_family": {
-		//		Description: "The name of the task definition to create.",
-		//		Type:        schema.TypeString,
-		//		Computed:    true,
-		//		//	DiffSuppressFunc: diffSuppressIgnoreDuploPrefix,
-		//	},
+		"full_family_name": {
+			Description: "The name of the task definition to create.",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"revision": {
 			Description: "The current revision of the task definition.",
 			Type:        schema.TypeInt,
@@ -250,14 +247,6 @@ func resourceDuploEcsTaskDefinition() *schema.Resource {
 			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
 		Schema: ecsTaskDefinitionSchema(),
-		CustomizeDiff: customdiff.All(
-			customdiff.ForceNewIfChange("family", func(ctx context.Context, old, new, meta interface{}) bool {
-				oldStr := old.(string)
-				newStr := new.(string)
-				log.Println("OLD ", oldStr, " NEW ", newStr, " ", !strings.Contains(oldStr, newStr))
-
-				return !strings.Contains(oldStr, newStr)
-			})),
 	}
 }
 
@@ -395,7 +384,7 @@ func flattenEcsTaskDefinition(duplo *duplosdk.DuploEcsTaskDef, d *schema.Resourc
 
 	// First, convert things into simple scalars
 	d.Set("tenant_id", duplo.TenantID)
-	d.Set("family", duplo.Family)
+	d.Set("full_family_name", duplo.Family)
 	d.Set("revision", duplo.Revision)
 	d.Set("arn", duplo.Arn)
 	d.Set("cpu", duplo.CPU)


### PR DESCRIPTION
## Overview

fix for `family` attribute of `duplocloud_ecs_task_definition` resource shows resource replacement on no change
## Summary of changes

This PR does the following:

- Introduced new attribute `full_family_name` as computed attribute which will hold family name with duplo prefix which will avoid replacement if no change in family attribute due to duplo prefix

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
