### PR TITLE
DUPLO-17377: S3 prefix support added in terraform.

### DIFF
--- a/duplocloud/resource_duplo_s3_bucket.go
+++ b/duplocloud/resource_duplo_s3_bucket.go
@@ -155,8 +155,8 @@ func resourceS3BucketRead(ctx context.Context, d *schema.ResourceData, m interfa
 	if err != nil {
 		return diag.Errorf("resourceS3BucketRead: Unable to retrieve duplo service name (tenant: %s, bucket: %s: error: %s)", tenantID, name, err)
 	}
-	if features.IsTagsBasedResourceMgmtEnabled {
-		fullName = name
+	if features != nil && features.IsTagsBasedResourceMgmtEnabled {
+		fullName = features.S3BucketNamePrefix + name
 	}
 
 	// Get the object from Duplo
@@ -188,9 +188,9 @@ func resourceS3BucketRead(ctx context.Context, d *schema.ResourceData, m interfa
 func resourceS3BucketCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	log.Printf("[TRACE] resourceS3BucketCreate ******** start")
 	name := d.Get("name").(string)
-
 	c := m.(*duplosdk.Client)
 	features, _ := c.AdminGetSystemFeatures()
+
 	s3MaxLength := 63 - MAX_DUPLOSERVICES_AND_SUFFIX_LENGTH
 	if features != nil && features.IsTagsBasedResourceMgmtEnabled {
 		s3MaxLength = 63
@@ -202,8 +202,8 @@ func resourceS3BucketCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	// prefix + name based on settings
 	fullName, errname := c.GetDuploServicesNameWithAws(tenantID, name)
-	if features.IsTagsBasedResourceMgmtEnabled {
-		fullName = name
+	if features != nil && features.IsTagsBasedResourceMgmtEnabled {
+		fullName = features.S3BucketNamePrefix + name
 	}
 	if errname != nil {
 		return diag.Errorf("resourceS3BucketCreate: Unable to retrieve duplo service name (name: %s, error: %s)", name, errname.Error())

--- a/duplosdk/admin.go
+++ b/duplosdk/admin.go
@@ -28,6 +28,7 @@ type DuploSystemFeatures struct {
 	DevopsManagerHostname          string               `json:"DevopsManagerHostname"`
 	TenantNameMaxLength            int                  `json:"TenantNameMaxLength"`
 	AzureResourcePrefix            *AzureResourcePrefix `json:"AzureResourcePrefix,omitempty"`
+	S3BucketNamePrefix             string               `json:"S3BucketNamePrefix"`
 }
 
 type AzureResourcePrefix struct {

--- a/duplosdk/tenant_aws_cloud_resources.go
+++ b/duplosdk/tenant_aws_cloud_resources.go
@@ -439,7 +439,7 @@ func (c *Client) TenantGetS3Bucket(tenantID string, name string) (*DuploS3Bucket
 	features, _ := c.AdminGetSystemFeatures()
 	fullName, err := c.GetDuploServicesNameWithAws(tenantID, name)
 	if features.IsTagsBasedResourceMgmtEnabled {
-		fullName = name
+		fullName = features.S3BucketNamePrefix + name
 	}
 	if err != nil {
 		return nil, err
@@ -592,7 +592,7 @@ func (c *Client) TenantDeleteS3Bucket(tenantID string, name string) ClientError 
 	fullName, err := c.GetDuploServicesNameWithAws(tenantID, name)
 	features, _ := c.AdminGetSystemFeatures()
 	if features.IsTagsBasedResourceMgmtEnabled {
-		fullName = name
+		fullName = features.S3BucketNamePrefix + name
 	}
 	if err != nil {
 		return err
@@ -627,7 +627,7 @@ func (c *Client) TenantApplyS3BucketSettings(tenantID string, duplo DuploS3Bucke
 	features, _ := c.AdminGetSystemFeatures()
 	fullName, err := c.GetDuploServicesNameWithAws(tenantID, duplo.Name)
 	if features.IsTagsBasedResourceMgmtEnabled {
-		fullName = duplo.Name
+		fullName = features.S3BucketNamePrefix + duplo.Name
 	}
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Overview

S3 prefix support added in terraform.

## Summary of changes

This PR does the following:

S3 prefix support added in terraform.

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
