### PR TITLE
DUPLO-17370 Unable to create duplocloud_aws_dynamodb_table_v2 resource.

### DIFF
--- a/docs/resources/aws_dynamodb_table_v2.md
+++ b/docs/resources/aws_dynamodb_table_v2.md
@@ -102,6 +102,7 @@ resource "duplocloud_aws_dynamodb_table_v2" "tst-dynamodb-table" {
 ### Read-Only
 
 - `arn` (String) The ARN of the dynamodb table.
+- `fullname` (String) The name of the table, this needs to be unique within a region.
 - `id` (String) The ID of this resource.
 - `status` (String) The status of the dynamodb table.
 - `stream_arn` (String)

--- a/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
+++ b/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
@@ -452,7 +452,9 @@ func resourceAwsDynamoDBTableUpdateV2(ctx context.Context, d *schema.ResourceDat
 	tenantID := d.Get("tenant_id").(string)
 	fullname := d.Get("fullname").(string)
 	_, name, err := parseAwsDynamoDBTableIdParts(d.Id())
-
+	if err != nil {
+		return diag.FromErr(err)
+	}
 	log.Printf("[TRACE] resourceAwsDynamoDBTableCreateOrUpdateV2(%s, %s): start", tenantID, name)
 
 	c := m.(*duplosdk.Client)

--- a/duplosdk/utils.go
+++ b/duplosdk/utils.go
@@ -28,6 +28,10 @@ func (c *Client) GetDuploServicesNameWithAws(tenantID, name string) (string, Cli
 	return c.GetResourceName("duploservices", tenantID, name, true)
 }
 
+func (c *Client) GetDuploServicesNameWithAwsDynamoDbV2(tenantID, name string) (string, ClientError) {
+	return c.GetResourceName("duploservices", tenantID, name, false)
+}
+
 // GetDuploServicesName builds a duplo resource name, given a tenant ID.
 func (c *Client) GetDuploServicesName(tenantID, name string) (string, ClientError) {
 	return c.GetResourceName("duploservices", tenantID, name, false)


### PR DESCRIPTION
## Overview

Fixed creation issue for `duplocloud_aws_dynamodb_table_v2` resource due to fixes related to dynamo table name
## Summary of changes

This PR does the following:

- Added `fullname` computed attribute to hold table name with duplo prefix
- Fixed create and update context, setting resource Id as tenant-id/fullname

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
