### PR TITLE
DUPLO 17175 GCP:duplocloud_gcp_scheduler_job with app_engine_target - plugin crash

### DIFF
--- a/duplocloud/resource_duplo_gcp_scheduler_job.go
+++ b/duplocloud/resource_duplo_gcp_scheduler_job.go
@@ -388,7 +388,6 @@ func resourceGcpSchedulerJobDelete(ctx context.Context, d *schema.ResourceData, 
 	log.Printf("[TRACE] resourceGcpSchedulerJobDelete ******** end")
 	return nil
 }
-
 func resourceGcpSchedulerJobSetData(d *schema.ResourceData, tenantID string, name string, duplo *duplosdk.DuploGcpSchedulerJob) {
 	d.Set("tenant_id", tenantID)
 	d.Set("name", name)
@@ -411,8 +410,8 @@ func resourceGcpSchedulerJobSetData(d *schema.ResourceData, tenantID string, nam
 		})
 	} else if duplo.TargetType == duplosdk.GcpSchedulerJob_TargetType_HttpTarget {
 		m := map[string]interface{}{
-			"method":  flattenGcpSchedulerJobHttpMethod(duplo.HTTPTarget.HTTPMethod),
-			"headers": flattenStringMap(duplo.HTTPTarget.Headers),
+			"method":  flattenGcpSchedulerJobHttpMethod(duplo.AppEngineTarget.HTTPMethod),
+			"headers": flattenStringMap(duplo.AppEngineTarget.Headers),
 			"body":    duplo.AnyHTTPTargetBody,
 			"uri":     duplo.HTTPTarget.URI,
 		}
@@ -440,8 +439,8 @@ func resourceGcpSchedulerJobSetData(d *schema.ResourceData, tenantID string, nam
 		d.Set("http_target", []interface{}{m})
 	} else if duplo.TargetType == duplosdk.GcpSchedulerJob_TargetType_AppEngineHttpTarget {
 		m := map[string]interface{}{
-			"method":       flattenGcpSchedulerJobHttpMethod(duplo.HTTPTarget.HTTPMethod),
-			"headers":      flattenStringMap(duplo.HTTPTarget.Headers),
+			"method":       flattenGcpSchedulerJobHttpMethod(duplo.AppEngineTarget.HTTPMethod),
+			"headers":      flattenStringMap(duplo.AppEngineTarget.Headers),
 			"body":         duplo.AnyHTTPTargetBody,
 			"relative_uri": duplo.AppEngineTarget.RelativeURI,
 		}


### PR DESCRIPTION
## Overview

Fixed `duplocloud_gcp_scheduler_job` plugin crash for app_engine_target 

This PR does the following:

- Replaced initialisation of attribute from HTTPTarget to AppEngineTarget
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...