### PR TITLE
DUPLO-16758/duplo-prefix

### DIFF
--- a/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
+++ b/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
@@ -24,23 +24,23 @@ func BeforeHook(fn func(ctx context.Context, d *schema.ResourceData, m interface
 			return diag.FromErr(err)
 		}
 
-		// Additional before hooks
-
 		return fn(ctx, d, m)
 	}
 }
 
 func prefixName(c *duplosdk.Client, d *schema.ResourceData) duplosdk.ClientError {
 	tenantId, name := d.Get("tenant_id").(string), d.Get("name").(string)
+
 	prefix, err := c.GetDuploServicesPrefix(tenantId)
 	if err != nil {
 		return err
 	}
 
 	if !strings.HasPrefix(name, prefix) {
-		name = prefix + name
+		name = fmt.Sprintf("%s-%s", prefix, name)
 		d.Set("name", name)
 	}
+
 	return nil
 }
 

--- a/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
+++ b/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
@@ -15,6 +15,35 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+func BeforeHook(fn func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics) func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		c := m.(*duplosdk.Client)
+
+		err := prefixName(c, d)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+
+		// Additional before hooks
+
+		return fn(ctx, d, m)
+	}
+}
+
+func prefixName(c *duplosdk.Client, d *schema.ResourceData) duplosdk.ClientError {
+	tenantId, name := d.Get("tenant_id").(string), d.Get("name").(string)
+	prefix, err := c.GetDuploServicesPrefix(tenantId)
+	if err != nil {
+		return err
+	}
+
+	if !strings.HasPrefix(name, prefix) {
+		name = prefix + name
+		d.Set("name", name)
+	}
+	return nil
+}
+
 func awsDynamoDBTableSchemaV2() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"tenant_id": {
@@ -272,10 +301,10 @@ func resourceAwsDynamoDBTableV2() *schema.Resource {
 	return &schema.Resource{
 		Description: "`duplocloud_aws_dynamodb_table_v2` manages an AWS dynamodb table in Duplo.",
 
-		ReadContext:   resourceAwsDynamoDBTableReadV2,
-		CreateContext: resourceAwsDynamoDBTableCreateV2,
-		UpdateContext: resourceAwsDynamoDBTableUpdateV2,
-		DeleteContext: resourceAwsDynamoDBTableDeleteV2,
+		ReadContext:   BeforeHook(resourceAwsDynamoDBTableReadV2),
+		CreateContext: BeforeHook(resourceAwsDynamoDBTableCreateV2),
+		UpdateContext: BeforeHook(resourceAwsDynamoDBTableUpdateV2),
+		DeleteContext: BeforeHook(resourceAwsDynamoDBTableDeleteV2),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},

--- a/duplosdk/utils.go
+++ b/duplosdk/utils.go
@@ -75,7 +75,8 @@ func (c *Client) GetDuploServicesPrefix(tenantID string) (string, ClientError) {
 
 // GetResourcePrefix builds a duplo resource prefix, given a tenant ID.
 func (c *Client) GetResourcePrefix(prefix, tenantID string) (string, ClientError) {
-	tenant, err := c.GetTenantForUser(tenantID)
+	// tenant, err := c.GetTenantForUser(tenantID)
+	tenant, err := c.TenantGetV3(tenantID)
 	if err != nil {
 		return "", err
 	}

--- a/duplosdk/utils.go
+++ b/duplosdk/utils.go
@@ -75,7 +75,6 @@ func (c *Client) GetDuploServicesPrefix(tenantID string) (string, ClientError) {
 
 // GetResourcePrefix builds a duplo resource prefix, given a tenant ID.
 func (c *Client) GetResourcePrefix(prefix, tenantID string) (string, ClientError) {
-	// tenant, err := c.GetTenantForUser(tenantID)
 	tenant, err := c.TenantGetV3(tenantID)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Overview

... (don't forget to put your clickup ticket ID in the title) ...

## Summary of changes

This PR does the following:

- Implements a before hook function for each CRUD operation on DynamoDB tables.
- Prefixes the table name with "duploservices" and the tenet name as expected by the API.


## Testing performed

- [ ] Using unit tests
- [X] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- 
