### PR TITLE
DUPLO 17447  Unable to create 'duplocloud_aws_dynamodb_table_v2' resource when ‘is_point_in_time_recovery’ is set to ‘true’.

### DIFF
--- a/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
+++ b/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
@@ -389,7 +389,7 @@ func resourceAwsDynamoDBTableCreateV2(ctx context.Context, d *schema.ResourceDat
 	if err != nil {
 		return diag.Errorf("Error creating tenant %s dynamodb table '%s': %s", tenantID, name, err)
 	}
-
+	d.Set("fullname", rp.TableName)
 	time.Sleep(time.Duration(10) * time.Second)
 
 	// Wait for Duplo to be able to return the table's details.
@@ -423,7 +423,8 @@ func resourceAwsDynamoDBTableCreateV2(ctx context.Context, d *schema.ResourceDat
 func updateDynamoDBTableV2PointInRecovery(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	if v, ok := d.GetOk("is_point_in_time_recovery"); ok && v.(bool) {
 		id := d.Id()
-		tenantID, name, err := parseAwsDynamoDBTableIdParts(id)
+		tenantID, _, err := parseAwsDynamoDBTableIdParts(id)
+		name := d.Get("fullname").(string)
 		c := m.(*duplosdk.Client)
 		_, errPir := c.DynamoDBTableV2PointInRecovery(tenantID, name, v.(bool))
 		if errPir != nil {


### PR DESCRIPTION
## Overview
Fixed : Unable to create `duplocloud_aws_dynamodb_table_v2` resource when `is_point_in_time_recovery` is set to ‘true’.

## Summary of changes

This PR does the following:

- Updating is_point_in_time_recovery status using dynamo full name
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
