### PR TITLE
DUPLO-15896 "No Kubernetes cluster for this plan" error should be displayed when the provided plan does not have AKS

### DIFF
--- a/duplocloud/data_source_duplo_eks_credentials.go
+++ b/duplocloud/data_source_duplo_eks_credentials.go
@@ -61,7 +61,7 @@ func dataSourceEksCredentialsRead(d *schema.ResourceData, m interface{}) error {
 	}
 	if infra != nil && !infra.EnableK8Cluster && infra.Cloud != 2 {
 		return fmt.Errorf("no kubernetes cluster for this plan %s", planID)
-	} else if infra.AksConfig != nil && !infra.AksConfig.CreateAndManage {
+	} else if infra.AksConfig == nil || (infra.AksConfig != nil && !infra.AksConfig.CreateAndManage) {
 		return fmt.Errorf("no kubernetes cluster for this plan %s", planID)
 	}
 	// First, try the newer method of obtaining a JIT access token.


### PR DESCRIPTION
## Overview

Fixed for azure platform to show "No Kubernetes cluster for this plan" error  for data "duplocloud_eks_credentials"
## Summary of changes

This PR does the following:

- Added check for AKSconfig exist
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
