### PR TITLE
DUPLO-17362 DUPLO-DUPLO-17361  BUG FIX

### DIFF
--- a/duplocloud/resource_duplo_gcp_firestore.go
+++ b/duplocloud/resource_duplo_gcp_firestore.go
@@ -51,10 +51,11 @@ func gcpFirestoreSchema() map[string]*schema.Schema {
 			Required:    true,
 		},
 		"type": {
-			Description:  "Firestore supports type `FIRESTORE_NATIVE` and `DATASTORE_MODE`",
-			Type:         schema.TypeString,
-			Required:     true,
-			ValidateFunc: validateFirestoreOrDatastoreMode,
+			Description:      "Firestore supports type `FIRESTORE_NATIVE` and `DATASTORE_MODE`",
+			Type:             schema.TypeString,
+			Required:         true,
+			ValidateFunc:     validateFirestoreOrDatastoreMode,
+			DiffSuppressFunc: nativeToModeNotAllowed,
 		},
 		"etag": {
 			Type:     schema.TypeString,
@@ -262,7 +263,7 @@ func expandGcpFirestore(d *schema.ResourceData) *duplosdk.DuploFirestoreBody {
 
 	if val, ok := d.GetOk("enable_point_in_time_recovery"); ok {
 		if val.(bool) {
-			duplo.PointInTimeRecoveryEnablement = "POINT_IN_TIME_RECOVERY_DISABLED_ENABLED"
+			duplo.PointInTimeRecoveryEnablement = "POINT_IN_TIME_RECOVERY_ENABLED"
 		}
 	}
 
@@ -278,4 +279,11 @@ func validateFirestoreOrDatastoreMode(value interface{}, key string) (warns []st
 		errs = append(errs, fmt.Errorf("%q must be either 'FIRESTORE_NATIVE' or 'DATASTORE_MODE'", key))
 	}
 	return
+}
+
+func nativeToModeNotAllowed(k, old, new string, d *schema.ResourceData) bool {
+	if old == "FIRESTORE_NATIVE" && new == "DATASTORE_MODE" {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
This PR contains fix for DUPLO-DUPLO-17361 `enable_point_in_time_recovery` not getting set for `duplocloud_gcp_firestore` resource
and 
fix for DUPLO-17362  `duplocloud_gcp_firestore` resources update if `type` is changed from "FIRESTORE_NATIVE" to "DATASTORE_MODE" which should not be allowed "DATASTORE_MODE" to "FIRESTORE_NATIVE" is allowed
## Summary of changes

This PR does the following:

- enable_point_in_time_recovery status typo fix
- Added diffsuppress function to suppress change if old=FIRESTORE_NATIVE and new =DATASTORE_MODE

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
