### PR TITLE
Duplo 17581 Support for cluster ip cidr for gcp

### DIFF
--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -534,6 +534,10 @@ func duploInfrastructureConfigFromState(d *schema.ResourceData) duplosdk.DuploIn
 		}
 	}
 
+	if config.Cloud == 3 && !config.IsServerlessKubernetes {
+		config.ClusterIpv4Cidr = d.Get("cluster_ip_cidr").(string)
+	}
+
 	if d.HasChange("setting") {
 		config.CustomData = keyValueFromState("setting", d)
 	} else if d.HasChange("custom_data") {

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -305,6 +305,13 @@ func resourceInfrastructure() *schema.Resource {
 				Default:          false,
 				DiffSuppressFunc: diffSuppressFuncIgnore,
 			},
+			"cluster_ip_cidr": {
+				Description: "cluster IP CIDR defines a private IP address range used for internal Kubernetes services.",
+				Type:        schema.TypeString,
+				ForceNew:    true,
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 }

--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -117,7 +117,7 @@ type DuploInfrastructureConfig struct {
 	ProvisioningStatus      string                   `json:"ProvisioningStatus"`
 	CustomData              *[]DuploKeyStringValue   `json:"CustomData,omitempty"`
 	AksConfig               *AksConfig               `json:"AksConfig,omitempty"`
-	ClusterIPCIDR           string                   `json:"ClusterIPCIDR,omitempty"`
+	ClusterIpv4Cidr         string                   `json:"ClusterIpv4Cidr,omitempty"`
 }
 
 type AksConfig struct {

--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -117,6 +117,7 @@ type DuploInfrastructureConfig struct {
 	ProvisioningStatus      string                   `json:"ProvisioningStatus"`
 	CustomData              *[]DuploKeyStringValue   `json:"CustomData,omitempty"`
 	AksConfig               *AksConfig               `json:"AksConfig,omitempty"`
+	ClusterIPCIDR           string                   `json:"ClusterIPCIDR,omitempty"`
 }
 
 type AksConfig struct {


### PR DESCRIPTION
## Overview

Updated `duplocloud_infrastructure` resource added `cluster_ip_cidr` schema attribute
## Summary of changes

This PR does the following:

- Added schema attribute `cluster_ip_cidr`
- Made applicable for gcp and standard gke

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
