### PR TITLE
[DUPLO-17469, DUPLO-17888] fix: adjust duplo client timeout and include timeout error in retriable error check for TenantUpdateLbSettings

### DIFF
--- a/duplocloud/resource_duplo_service_params.go
+++ b/duplocloud/resource_duplo_service_params.go
@@ -215,7 +215,7 @@ func resourceDuploServiceParamsCreateOrUpdate(ctx context.Context, d *schema.Res
 			if clientError.Status() == 500 && duplo.Template.Cloud != 0 {
 				log.Printf("[TRACE] Ignoring error %s for non AWS cloud.", clientError)
 			} else {
-				return diag.FromErr(err)
+				return diag.FromErr(clientError)
 			}
 		}
 	}

--- a/duplosdk/agnostic_load_balancer.go
+++ b/duplosdk/agnostic_load_balancer.go
@@ -2,6 +2,7 @@ package duplosdk
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -51,7 +52,7 @@ func (c *Client) TenantUpdateLbSettings(tenantID, loadBalancerID string, rq *Agn
 			MaxJitter: 2000,
 			Timeout:   60 * time.Second,
 			IsRetryable: func(error ClientError) bool {
-				return error.Status() == 400
+				return error.Status() == 400 || strings.Contains(error.Error(), "context deadline exceeded")
 			},
 		})
 	return &rp, err
@@ -72,7 +73,7 @@ func (c *Client) TenantGetLbSettings(tenantID, loadBalancerID string) (*Agnostic
 			MaxJitter: 2000,
 			Timeout:   60 * time.Second,
 			IsRetryable: func(error ClientError) bool {
-				return error.Status() == 400
+				return error.Status() == 400 || strings.Contains(error.Error(), "context deadline exceeded")
 			},
 		})
 	return &rp, err

--- a/duplosdk/client.go
+++ b/duplosdk/client.go
@@ -124,7 +124,7 @@ func NewClient(host, token string) (*Client, error) {
 	if host != "" && token != "" {
 		tokenBearer := fmt.Sprintf("Bearer %s", token)
 		c := Client{
-			HTTPClient: &http.Client{Timeout: 20 * time.Second},
+			HTTPClient: &http.Client{Timeout: 30 * time.Second},
 			HostURL:    host,
 			Token:      tokenBearer,
 		}


### PR DESCRIPTION
### **User description**
## Overview

This PR adds timeout errors to the retryable error check for retries in service param calls. It also increases timeout tolerance to allow request to succeed more easily.

This PR adds retries with exponential backoff and jitter to GetWafInLb API call. It also fixes the error thrown when the call fails so we dont fail silently.

## Summary of changes

This PR does the following:

- Increases timeout limit for duplo client
- Adds timeout error check as retryable
- Fixes error thrown when GetWafInLb fails
- Adds retries with jitter and exponential backoff to GetWafInLb API call

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

QA testing recommended to sanity checking


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixed error handling in `resourceDuploServiceParamsCreateOrUpdate` to return `clientError` instead of `err`.
- Enhanced retry logic for `TenantUpdateLbSettings` and `TenantGetLbSettings` to include timeout errors as retryable.
- Increased HTTP client timeout from 20 to 30 seconds.
- Added retries with exponential backoff and jitter for `ReplicationControllerLbWafGet` to handle timeout and server errors.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_service_params.go</strong><dd><code>Fix error handling for service parameters update</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplocloud/resource_duplo_service_params.go

- Fixed error handling to return `clientError` instead of `err`.



</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/544/files#diff-37e8bdfe9349da9cca02de532725046d4c7d5cb1cdc6513e8a30f74cb28c9af0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>agnostic_load_balancer.go</strong><dd><code>Enhance retry logic for load balancer settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/agnostic_load_balancer.go

<li>Added timeout error check as retryable.<br> <li> Updated retry configuration for load balancer settings.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/544/files#diff-78d9fd610c8857617d21ac29a9d66d9d9aa0a73fcc708fda89fdaa2cdcaada1d">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>client.go</strong><dd><code>Increase HTTP client timeout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/client.go

- Increased HTTP client timeout from 20 to 30 seconds.



</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/544/files#diff-d41b0a967615fb42c878bac1a1fd70c9423c2e32d603b024fe3b1d5dac6fa613">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>replication_controller.go</strong><dd><code>Add retries with backoff for WAF ACL retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
duplosdk/replication_controller.go

<li>Added retries with exponential backoff and jitter for WAF ACL ID <br>retrieval.<br> <li> Enhanced retry logic to include timeout errors.<br>


</details>
    

  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/544/files#diff-06e27817a5fa8bc4ef2149b3caf90ba382fb422cdd7faf1ff225fe1c929a499e">+20/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

