### PR TITLE
DUPLO 17945 Support Duplo provider env variable with uppercase

### DIFF
--- a/duplocloud/provider.go
+++ b/duplocloud/provider.go
@@ -222,9 +222,16 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 	var diags diag.Diagnostics
 	if token == "" {
 		token = os.Getenv("duplo_token")
+		if token == "" {
+			token = os.Getenv("DUPLO_TOKEN")
+
+		}
 	}
 	if host == "" {
 		host = os.Getenv("duplo_host")
+		if host == "" {
+			host = os.Getenv("DUPLO_HOST")
+		}
 	}
 
 	c, err := duplosdk.NewClient(host, token)


### PR DESCRIPTION
## Overview

Added support to fetch provider env variable detail in upper case
## Summary of changes

This PR does the following:

- added check for duplo_token and duplo_host in uppercase to fetch the value
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
