### PR TITLE
DUPLO 17920 TF:ElastiCache:redis gets created with custom KMS Key without adding to plan. Expected- kms lookup should fail

### DIFF
--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -156,6 +156,12 @@ func duploLbConfigSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 		},
+		"web_acl_id": {
+			Description: "The ARN of a WAF to attach to the load balancer.",
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+		},
 	}
 }
 


### PR DESCRIPTION
## Overview

Checking kms_id association with tenant plan on ecache creation if kms_id added to `duplocloud_ecache_instance` resource

## Summary of changes

This PR does the following:

- Get plan details
- Get kms keys associated with plan and compare with passed kms_id

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...
