### PR TITLE
DUPLO 18002 Hosts don't output public ip

### DIFF
--- a/docs/data-sources/asg_profiles.md
+++ b/docs/data-sources/asg_profiles.md
@@ -52,6 +52,7 @@ Read-Only:
 - `minion_tags` (List of Object) (see [below for nested schema](#nestedobjatt--asg_profiles--minion_tags))
 - `network_interface` (List of Object) (see [below for nested schema](#nestedobjatt--asg_profiles--network_interface))
 - `prepend_user_data` (Boolean)
+- `puplic_ip_address` (String)
 - `tags` (List of Object) (see [below for nested schema](#nestedobjatt--asg_profiles--tags))
 - `tenant_id` (String)
 - `use_spot_instances` (Boolean)

--- a/docs/data-sources/native_hosts.md
+++ b/docs/data-sources/native_hosts.md
@@ -48,6 +48,7 @@ Read-Only:
 - `network_interface` (List of Object) (see [below for nested schema](#nestedobjatt--hosts--network_interface))
 - `prepend_user_data` (Boolean)
 - `private_ip_address` (String)
+- `puplic_ip_address` (String)
 - `status` (String)
 - `tags` (List of Object) (see [below for nested schema](#nestedobjatt--hosts--tags))
 - `tenant_id` (String)

--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -86,6 +86,7 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 - `fullname` (String) The full name of the ASG profile.
 - `id` (String) The ID of this resource.
 - `initial_base64_user_data` (String)
+- `puplic_ip_address` (String) The primary public IP address assigned to the host.
 
 <a id="nestedblock--metadata"></a>
 ### Nested Schema for `metadata`

--- a/docs/resources/aws_host.md
+++ b/docs/resources/aws_host.md
@@ -127,6 +127,7 @@ resource "duplocloud_aws_host" "host" {
 - `initial_base64_user_data` (String)
 - `instance_id` (String) The AWS EC2 instance ID of the host.
 - `private_ip_address` (String) The primary private IP address assigned to the host.
+- `puplic_ip_address` (String) The primary public IP address assigned to the host.
 - `status` (String) The current status of the host.
 
 <a id="nestedblock--metadata"></a>

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -145,6 +145,11 @@ func nativeHostSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
+		"puplic_ip_address": {
+			Description: "The primary public IP address assigned to the host.",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
 		"metadata": {
 			Description: "Configuration metadata used when creating the host.",
 			Type:        schema.TypeList,
@@ -627,6 +632,8 @@ func nativeHostToState(d *schema.ResourceData, duplo *duplosdk.DuploNativeHost) 
 	d.Set("status", duplo.Status)
 	d.Set("identity_role", duplo.IdentityRole)
 	d.Set("private_ip_address", duplo.PrivateIPAddress)
+	d.Set("private_ip_address", duplo.PublicIpAddress)
+
 	d.Set("tags", keyValueToState("tags", duplo.Tags))
 	d.Set("minion_tags", keyValueToState("minion_tags", duplo.MinionTags))
 	// Ignore the value in the response for duplo.PrependUserData

--- a/duplosdk/native_hosts.go
+++ b/duplosdk/native_hosts.go
@@ -45,6 +45,7 @@ type DuploNativeHost struct {
 	Tags               *[]DuploKeyStringValue             `json:"Tags,omitempty"`
 	TagsEx             *[]DuploKeyStringValue             `json:"TagsEx,omitempty"`
 	MinionTags         *[]DuploKeyStringValue             `json:"MinionTags,omitempty"`
+	PublicIpAddress    string                             `json:"PublicIpAddress,omitempty"`
 }
 
 // DuploNativeHostNetworkInterface is a Duplo SDK object that represents a network interface of a native host


### PR DESCRIPTION
## Overview

 Added public_ip_address for `duplocloud_aws_host` resource and updated docs
## Summary of changes

This PR does the following:

- Updated read context to read public ip 
- Updated schema added puplic_ip_address
## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
