### PR TITLE
DUPLO-18013 TF: Support Opensearch instances with no EBS storage

### DIFF
--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -96,7 +96,6 @@ func awsElasticSearchSchema() map[string]*schema.Schema {
 			Type:        schema.TypeInt,
 			Optional:    true,
 			ForceNew:    true,
-			Default:     20,
 		},
 		"ebs_options": {
 			Type:     schema.TypeList,
@@ -392,12 +391,14 @@ func resourceDuploAwsElasticSearchCreate(ctx context.Context, d *schema.Resource
 		RequireSSL:                 d.Get("require_ssl").(bool),
 		UseLatestTLSCipher:         d.Get("use_latest_tls_cipher").(bool),
 		EnableNodeToNodeEncryption: d.Get("enable_node_to_node_encryption").(bool),
-		EBSOptions: duplosdk.DuploElasticSearchDomainEBSOptions{
-			VolumeSize: d.Get("storage_size").(int),
-		},
+
 		VPCOptions: duploVPCOptions,
 	}
-
+	if size, ok := d.GetOk("storage_size"); ok {
+		duploObject.EBSOptions = &duplosdk.DuploElasticSearchDomainEBSOptions{
+			VolumeSize: size.(int),
+		}
+	}
 	c := m.(*duplosdk.Client)
 	tenantID := d.Get("tenant_id").(string)
 	id := fmt.Sprintf("%s/%s", tenantID, duploObject.Name)
@@ -513,10 +514,7 @@ func resourceDuploAwsElasticSearchUpdate(ctx context.Context, d *schema.Resource
 		RequireSSL:                 d.Get("require_ssl").(bool),
 		UseLatestTLSCipher:         d.Get("use_latest_tls_cipher").(bool),
 		EnableNodeToNodeEncryption: d.Get("enable_node_to_node_encryption").(bool),
-		EBSOptions: duplosdk.DuploElasticSearchDomainEBSOptions{
-			VolumeSize: d.Get("storage_size").(int),
-		},
-		VPCOptions: duploVPCOptions,
+		VPCOptions:                 duploVPCOptions,
 	}
 
 	c := m.(*duplosdk.Client)

--- a/duplosdk/aws_elasticsearch.go
+++ b/duplosdk/aws_elasticsearch.go
@@ -92,7 +92,7 @@ type DuploElasticSearchDomainRequest struct {
 	Version                    string                                `json:"Version,omitempty"`
 	KmsKeyID                   string                                `json:"KmsKeyId,omitempty"`
 	ClusterConfig              DuploElasticSearchDomainClusterConfig `json:"ClusterConfig,omitempty"`
-	EBSOptions                 DuploElasticSearchDomainEBSOptions    `json:"EbsOptions,omitempty"`
+	EBSOptions                 *DuploElasticSearchDomainEBSOptions   `json:"EbsOptions,omitempty"`
 	VPCOptions                 DuploElasticSearchDomainVPCOptions    `json:"VPCOptions,omitempty"`
 	EnableNodeToNodeEncryption bool                                  `json:"EnableNodeToNodeEncryption,omitempty"`
 	RequireSSL                 bool                                  `json:"RequireSSL,omitempty"`


### PR DESCRIPTION
## Overview

Allowing creation of opensearch without storage_size for instance type i3. and im4gn. for duplocloud_aws_elasticsearch resource
## Summary of changes

This PR does the following:

- Removed default value of storage_size , passing null EBSOption object if storage_size not specified.
- Removed EBSOption assignment in update since storage_size is force new

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
