### PR TITLE
DUPLO-18931 Data source duplocloud_k8_secrets mask non read only user secrets

### DIFF
--- a/duplocloud/data_source_duplo_k8_secrets.go
+++ b/duplocloud/data_source_duplo_k8_secrets.go
@@ -52,7 +52,6 @@ func dataSourceK8SecretsRead(ctx context.Context, d *schema.ResourceData, m inte
 				break
 			}
 		}
-		usrResp.IsReadOnly = true
 	}
 	rp, err := c.K8SecretGetList(tenantID)
 	if err != nil {
@@ -65,10 +64,11 @@ func dataSourceK8SecretsRead(ctx context.Context, d *schema.ResourceData, m inte
 
 		// First, set the simple fields.
 		sc := map[string]interface{}{
-			"tenant_id":      duplo.TenantID,
-			"secret_name":    duplo.SecretName,
-			"secret_type":    duplo.SecretType,
-			"secret_version": duplo.SecretVersion,
+			"tenant_id":          duplo.TenantID,
+			"secret_name":        duplo.SecretName,
+			"secret_type":        duplo.SecretType,
+			"secret_version":     duplo.SecretVersion,
+			"secret_annotations": duplo.SecretAnnotations,
 		}
 		if usrResp.IsReadOnly {
 			for key := range duplo.SecretData {
@@ -77,7 +77,6 @@ func dataSourceK8SecretsRead(ctx context.Context, d *schema.ResourceData, m inte
 		}
 		// Next, set the JSON encoded strings.
 		toJsonStringField("secret_data", duplo.SecretData, sc)
-		toJsonStringField("secret_annotations", duplo.SecretAnnotations, sc)
 
 		list = append(list, sc)
 	}


### PR DESCRIPTION
## Overview

Fixed masking bug for secret readonly for non readonly user for  duplocloud_k8_secrets data source
## Summary of changes

This PR does the following:

- removed line that sets user_readonly flag which overrights actual state
- fixed secret_annotations set issue

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...
