### PR TITLE
DUPLO-16746 plugin crash issue fix

### DIFF
--- a/duplocloud/data_source_duplo_k8_secret.go
+++ b/duplocloud/data_source_duplo_k8_secret.go
@@ -68,11 +68,11 @@ func dataSourceK8SecretRead(ctx context.Context, d *schema.ResourceData, m inter
 			}
 		}
 	}
-	access, err := c.SystemSettingGet("AllowReadonlySecrets")
+	access, err := c.SystemSettingGet("AllowReadonlyK8sSecrets")
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if strings.ToLower(access.Value) == "true" {
+	if access != nil && strings.ToLower(access.Value) == "true" {
 		usrResp.IsReadOnly = false
 	}
 	rp, err := c.K8SecretGet(tenantID, name)

--- a/duplocloud/data_source_duplo_k8_secrets.go
+++ b/duplocloud/data_source_duplo_k8_secrets.go
@@ -58,7 +58,7 @@ func dataSourceK8SecretsRead(ctx context.Context, d *schema.ResourceData, m inte
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	if strings.ToLower(access.Value) == "true" {
+	if access != nil && strings.ToLower(access.Value) == "true" {
 		usrResp.IsReadOnly = false
 	}
 	rp, err := c.K8SecretGetList(tenantID)


### PR DESCRIPTION
### **User description**
## Overview

... (don't forget to put your clickup ticket ID in the title) ...

## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
Bug fix


___

### **Description**
- Corrected the system setting key from `AllowReadonlySecrets` to `AllowReadonlyK8sSecrets` in `data_source_duplo_k8_secret.go`.
- Added a nil check for `access` before comparing its value in both `data_source_duplo_k8_secret.go` and `data_source_duplo_k8_secrets.go`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_source_duplo_k8_secret.go</strong><dd><code>Fix system setting key and add nil check in K8 secret read</code></dd></summary>
<hr>

duplocloud/data_source_duplo_k8_secret.go

<li>Corrected system setting key from <code>AllowReadonlySecrets</code> to <br><code>AllowReadonlyK8sSecrets</code>.<br> <li> Added nil check for <code>access</code> before comparing its value.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/587/files#diff-036aa77bf4f3b50d58199957c5145e01e0a51b6f2d907eda0abed5217db37b8e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>data_source_duplo_k8_secrets.go</strong><dd><code>Add nil check for access in K8 secrets read</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/data_source_duplo_k8_secrets.go

- Added nil check for `access` before comparing its value.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/587/files#diff-887f717ea698c29850e1098b90f70b63eea80e5996c833c2463d722a71063b84">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

