### PR TITLE
DUPLO-18177 feat: add support for enabling/disabling metrics in ASG resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-07-22
+
+### Enhanced
+- Added support for enabling/disabling metrics in ASG resources by introducing the `enabled_metrics` property in the ASG profile schema.
+
 ## 2024-04-29
 
 ### Fixed

--- a/duplosdk/asg.go
+++ b/duplosdk/asg.go
@@ -35,6 +35,7 @@ type DuploAsgProfile struct {
 	UseSpotInstances    bool                               `json:"UseSpotInstances,omitempty"`
 	Volumes             *[]DuploNativeHostVolume           `json:"Volumes,omitempty"`
 	Zone                int                                `json:"Zone"`
+	EnabledMetrics      *[]string                          `json:"EnabledMetrics,omitempty"`
 }
 
 type DuploAsgProfileDeleteReq struct {


### PR DESCRIPTION
### **User description**
## Overview

Adds support to enabling/disabling metrics for ASGs

## Summary of changes

This PR does the following:

- Introduces new schema property `enabled_metrics` on ASG profile resource

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

Must merge after merging https://github.com/duplocloud-internal/duplo/pull/2819


___

### **PR Type**
Enhancement


___

### **Description**
- Introduced a new schema property `enabled_metrics` on the ASG profile resource to support enabling/disabling metrics.
- Updated the `DuploAsgProfile` struct to include the `EnabledMetrics` field.
- Modified functions to handle the new `enabled_metrics` property, including `asgProfileToState`, `expandAsgProfile`, and `needsResourceAwsASGUpdate`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_asg_profile.go</strong><dd><code>Add support for enabling/disabling metrics in ASG schema</code>&nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_asg_profile.go

<li>Added <code>enabled_metrics</code> property to ASG schema.<br> <li> Updated <code>asgProfileToState</code> to set <code>enabled_metrics</code>.<br> <li> Modified <code>expandAsgProfile</code> to include <code>enabled_metrics</code>.<br> <li> Updated <code>needsResourceAwsASGUpdate</code> to check for changes in <br><code>enabled_metrics</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/596/files#diff-f58c7134634373bfbd4607fa72e0d5fb28a0da60d136394bacd5671ea75c8346">+23/-2</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>asg.go</strong><dd><code>Extend DuploAsgProfile with EnabledMetrics field</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplosdk/asg.go

- Added `EnabledMetrics` field to `DuploAsgProfile` struct.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/596/files#diff-b9e34e160487d98157b8b887377449bc8b90d93a1d7640c770a57ab0a7ca5507">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

