### PR TITLE
DUPLO-19011 feat: allow option to force delete ECR repositories from duplo provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-07-23
+
+### Enhanced
+- Added `force_delete` option to ECR resource, allowing forced deletion of ECR repositories in DuploCloud provider.
+
 ## 2024-07-17
 
 ### Enhanced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2024-07-17
+
+### Enhanced
+- Added `force_delete` option to ECR resource, allowing forced deletion of ECR repositories in DuploCloud provider.
+
+## 2024-04-29
+
+### Fixed
+- Fixed an issue with handling slashes in `keyType` for `duplocloud_admin_system_setting` resource ID creation and parsing.
+
+### Enhanced
+- Added utility functions to encode and decode slashes in identifiers, improving handling of special characters in resource IDs.
+- Updated build script to include documentation generation and modified import script to guide users on handling slashes in identifiers.
+
+
 ## 2024-07-12
 
 ### Enhanced
@@ -12,7 +27,6 @@
 ### Enhanced
 - Added utility functions to encode and decode slashes in identifiers, improving handling of special characters in resource IDs.
 - Updated build script to include documentation generation and modified import script to guide users on handling slashes in identifiers.
-
 
 ## 2024-04-15
 

--- a/docs/resources/aws_ecr_repository.md
+++ b/docs/resources/aws_ecr_repository.md
@@ -23,6 +23,7 @@ resource "duplocloud_aws_ecr_repository" "test-ecr" {
   name                      = "test-ecr"
   enable_scan_image_on_push = true
   enable_tag_immutability   = true
+  force_delete              = false
 }
 ```
 
@@ -38,6 +39,7 @@ resource "duplocloud_aws_ecr_repository" "test-ecr" {
 
 - `enable_scan_image_on_push` (Boolean) Indicates whether images are scanned after being pushed to the repository (true) or not scanned (false).
 - `enable_tag_immutability` (Boolean) The tag mutability setting for the repository.
+- `force_delete` (Boolean) Whether to force delete the repository on destroy operations Defaults to `false`.
 - `kms_encryption_key` (String) The ARN of the KMS key to use.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/duplocloud/resource_duplo_aws_ecr_repository.go
+++ b/duplocloud/resource_duplo_aws_ecr_repository.go
@@ -61,6 +61,12 @@ func duploAwsEcrRepositorySchema() map[string]*schema.Schema {
 			Computed:    true,
 			Optional:    true,
 		},
+		"force_delete": {
+			Description: "Whether to force delete the repository on destroy operations",
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+		},
 	}
 }
 
@@ -142,13 +148,14 @@ func resourceAwsEcrRepositoryUpdate(ctx context.Context, d *schema.ResourceData,
 func resourceAwsEcrRepositoryDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	id := d.Id()
 	tenantID, name, err := parseAwsEcrRepositoryIdParts(id)
+	forceDelete := d.Get("force_delete").(bool)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	log.Printf("[TRACE] resourceAwsEcrRepositoryDelete(%s, %s): start", tenantID, name)
 
 	c := m.(*duplosdk.Client)
-	clientErr := c.AwsEcrRepositoryDelete(tenantID, name)
+	clientErr := c.AwsEcrRepositoryDelete(tenantID, name, forceDelete)
 	if clientErr != nil {
 		if clientErr.Status() == 404 {
 			return nil

--- a/duplosdk/aws_ecr_repository.go
+++ b/duplosdk/aws_ecr_repository.go
@@ -69,10 +69,15 @@ func (c *Client) AwsEcrRepositoryExists(tenantID, name string) (bool, ClientErro
 	return false, nil
 }
 
-func (c *Client) AwsEcrRepositoryDelete(tenantID string, name string) ClientError {
+func (c *Client) AwsEcrRepositoryDelete(tenantID string, name string, forceDelete bool) ClientError {
+	forceDeletePostfix := ""
+
+	if forceDelete {
+		forceDeletePostfix = "/force"
+	}
 	return c.deleteAPI(
 		fmt.Sprintf("AwsEcrRepositoryDelete(%s, %s)", tenantID, name),
-		fmt.Sprintf("v3/subscriptions/%s/aws/ecrRepository/%s", tenantID, name),
+		fmt.Sprintf("v3/subscriptions/%s/aws/ecrRepository/%s%s", tenantID, name, forceDeletePostfix),
 		nil,
 	)
 }

--- a/examples/resources/duplocloud_aws_ecr_repository/resource.tf
+++ b/examples/resources/duplocloud_aws_ecr_repository/resource.tf
@@ -8,4 +8,5 @@ resource "duplocloud_aws_ecr_repository" "test-ecr" {
   name                      = "test-ecr"
   enable_scan_image_on_push = true
   enable_tag_immutability   = true
+  force_delete              = false
 }


### PR DESCRIPTION
### **User description**
## Overview

Re-applies PR https://github.com/duplocloud/terraform-provider-duplocloud/pull/591 reverted due to unmerged backend changes

## Summary of changes

This PR does the following:

- re-applies force delete support for ECR repositories

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

Merge after merging https://github.com/duplocloud-internal/duplo/pull/2910


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added `force_delete` attribute to the ECR repository schema to allow forced deletion.
- Updated `AwsEcrRepositoryDelete` function to handle `forceDelete` parameter and modify API endpoint accordingly.
- Documented the new `force_delete` option in the CHANGELOG and resource documentation.
- Updated example resource configuration to include `force_delete` attribute.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_ecr_repository.go</strong><dd><code>Add force delete option to ECR repository schema</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_aws_ecr_repository.go

<li>Added <code>force_delete</code> attribute to the ECR repository schema.<br> <li> Updated delete function to handle <code>force_delete</code> attribute.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/600/files#diff-6705aca1b63752ca77b49a6b3fc82ab8db519741894b91aee0bbdd8763b9051c">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aws_ecr_repository.go</strong><dd><code>Update ECR repository delete function for force delete</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplosdk/aws_ecr_repository.go

<li>Modified <code>AwsEcrRepositoryDelete</code> function to accept <code>forceDelete</code> <br>parameter.<br> <li> Appended <code>force</code> postfix to API endpoint if <code>forceDelete</code> is true.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/600/files#diff-0f3b9bb808459309525133fb08252307c54c0e81dad03e78169b4cf57db86849">+7/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document force delete option for ECR resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

- Documented the addition of `force_delete` option for ECR resource.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/600/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+15/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aws_ecr_repository.md</strong><dd><code>Add documentation for force delete in ECR resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/resources/aws_ecr_repository.md

<li>Added documentation for <code>force_delete</code> attribute in ECR repository <br>resource.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/600/files#diff-f8b130c559b6eb716246413866292bae78f1d69f6857fd65db6ac4a8d85df578">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource.tf</strong><dd><code>Update ECR repository example with force delete</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/resources/duplocloud_aws_ecr_repository/resource.tf

- Included `force_delete` attribute in the ECR repository example.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/600/files#diff-a1d67193bafa90585e2e7ef0810e0aa81c0013153fce0c934322f4080d2bca63">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

