### PR TITLE
Duplo 19647 , Duplo 19648 jul tag and name issue dynamodb

### DIFF
--- a/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
+++ b/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"reflect"
 	"strings"
 	"terraform-provider-duplocloud/duplosdk"
 	"time"
@@ -506,7 +505,7 @@ func updateDynamoDBTableV2PointInRecovery(_ context.Context, d *schema.ResourceD
 	return nil
 }
 
-func tagDynamoDBtTableV2(
+/*func tagDynamoDBtTableV2(
 	tenantId, name string,
 	rq *duplosdk.DuploDynamoDBTagResource,
 	m interface{},
@@ -518,7 +517,7 @@ func tagDynamoDBtTableV2(
 	}
 	return resp, nil
 }
-
+*/
 /*
 Not supported for july 2024 release
 
@@ -1409,6 +1408,7 @@ func resourceAwsDynamoDBTableUpdateV2(ctx context.Context, d *schema.ResourceDat
 	return diags
 }
 
+/*
 func setDeleteProtection(d *schema.ResourceData) bool {
 	return d.HasChange("deletion_protection_enabled")
 }
@@ -1445,3 +1445,4 @@ func shouldUpdateThroughput(
 ) bool {
 	return !reflect.DeepEqual(table.ProvisionedThroughput, request.ProvisionedThroughput)
 }
+*/

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -1000,39 +1000,3 @@ func addIfDefined(target interface{}, resourceName string, targetValue interface
 		}
 	}
 }
-
-// to be removed after july 2024 release
-func waitForResourceToBePresentAfterUpdate(
-	ctx context.Context,
-	d *schema.ResourceData,
-	resourceType string,
-	resourceId string,
-	getResource func() (interface{}, duplosdk.ClientError)) diag.Diagnostics {
-	err := retry.RetryContext(ctx, d.Timeout("update"), func() *retry.RetryError {
-		resource, errGet := getResource()
-
-		if errGet != nil {
-			if errGet.Status() == 404 {
-				s := "expected %s '%s' to be present after update, but got a 404"
-				e := fmt.Errorf(s, resourceType, resourceId)
-				return retry.RetryableError(e)
-			}
-
-			s := "error retrieving %s '%s': %s"
-			e := fmt.Errorf(s, resourceType, resourceId, errGet)
-			return retry.NonRetryableError(e)
-		}
-
-		if isInterfaceNil(resource) {
-			s := "expected %s '%s' to be present after update, but got: nil"
-			e := fmt.Errorf(s, resourceType, resourceId)
-			return retry.RetryableError(e)
-		}
-
-		return nil
-	})
-	if err != nil {
-		return diag.Errorf("error updating %s '%s': %s", resourceType, resourceId, err)
-	}
-	return nil
-}

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -1000,3 +1000,39 @@ func addIfDefined(target interface{}, resourceName string, targetValue interface
 		}
 	}
 }
+
+// to be removed after july 2024 release
+func waitForResourceToBePresentAfterUpdate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	resourceType string,
+	resourceId string,
+	getResource func() (interface{}, duplosdk.ClientError)) diag.Diagnostics {
+	err := retry.RetryContext(ctx, d.Timeout("update"), func() *retry.RetryError {
+		resource, errGet := getResource()
+
+		if errGet != nil {
+			if errGet.Status() == 404 {
+				s := "expected %s '%s' to be present after update, but got a 404"
+				e := fmt.Errorf(s, resourceType, resourceId)
+				return retry.RetryableError(e)
+			}
+
+			s := "error retrieving %s '%s': %s"
+			e := fmt.Errorf(s, resourceType, resourceId, errGet)
+			return retry.NonRetryableError(e)
+		}
+
+		if isInterfaceNil(resource) {
+			s := "expected %s '%s' to be present after update, but got: nil"
+			e := fmt.Errorf(s, resourceType, resourceId)
+			return retry.RetryableError(e)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return diag.Errorf("error updating %s '%s': %s", resourceType, resourceId, err)
+	}
+	return nil
+}

--- a/duplosdk/aws_dynamo_db.go
+++ b/duplosdk/aws_dynamo_db.go
@@ -48,6 +48,29 @@ type DuploDynamoDBTableV2 struct {
 	TtlStatus                 string                                      `json:"TtlStatus,omitempty"`
 }
 
+type DuploDynamoDBTableV2Old struct {
+	// NOTE: The TenantID field does not come from the backend - we synthesize it
+	TenantID string `json:"-"`
+
+	TableName                 string                                      `json:"TableName"`
+	TableId                   string                                      `json:"TableId"`
+	TableArn                  string                                      `json:"TableArn,omitempty"`
+	DeletionProtectionEnabled bool                                        `json:"DeletionProtectionEnabled,omitempty"`
+	PointInTimeRecoveryStatus string                                      `json:"PointInTimeRecoveryStatus,omitempty"`
+	KeySchema                 *[]DuploDynamoDBKeySchema                   `json:"KeySchema,omitempty"`
+	AttributeDefinitions      *[]DuploDynamoDBAttributeDefinion           `json:"AttributeDefinitions,omitempty"`
+	TableStatus               *DuploStringValue                           `json:"TableStatus,omitempty"`
+	TableSizeBytes            int                                         `json:"TableSizeBytes,omitempty"`
+	LocalSecondaryIndexes     *[]DuploDynamoDBTableV2LocalSecondaryIndex  `json:"LocalSecondaryIndexes,omitempty"`
+	GlobalSecondaryIndexes    *[]DuploDynamoDBTableV2GlobalSecondaryIndex `json:"GlobalSecondaryIndexes,omitempty"`
+	LatestStreamArn           string                                      `json:"LatestStreamArn,omitempty"`
+	LatestStreamLabel         string                                      `json:"LatestStreamLabel,omitempty"`
+	ProvisionedThroughput     *DuploDynamoDBProvisionedThroughput         `json:"ProvisionedThroughput,omitempty"`
+	SSEDescription            *DuploDynamoDBTableV2SSESpecification       `json:"SSEDescription,omitempty"`
+	StreamSpecification       *DuploDynamoDBTableV2StreamSpecification    `json:"StreamSpecification,omitempty"`
+	BillingModeSummary        *DuploDynamoDBTableV2BillingModeSummary     `json:"BillingModeSummary,omitempty"`
+}
+
 type DuploDynamoDBTableV2Response struct {
 	// NOTE: The TenantID field does not come from the backend - we synthesize it
 	TenantID string `json:"-"`
@@ -456,4 +479,15 @@ type Delete struct {
 type Update struct {
 	IndexName             string                             `json:"IndexName"`
 	ProvisionedThroughput DuploDynamoDBProvisionedThroughput `json:"ProvisionedThroughput"`
+}
+
+// remove after july 2024 release updation
+func (c *Client) DynamoDBTableGetV2Old(tenantID string, name string) (*DuploDynamoDBTableV2Old, ClientError) {
+	rp := DuploDynamoDBTableV2Old{}
+	err := c.getAPI(
+		fmt.Sprintf("DynamoDBTableGet(%s, %s)", tenantID, name),
+		fmt.Sprintf("v3/subscriptions/%s/aws/dynamodbTableV2/%s", tenantID, name),
+		&rp)
+	rp.TenantID = tenantID
+	return &rp, err
 }


### PR DESCRIPTION
## Overview

Kept support for below available service.
Fixed name issue, currently table will be created with prefix since some update api expects duplo prefix

Available api for july 2024 release
```
        [HttpGet] "dynamodbTableV2/{id}"
        
        [HttpPost]"dynamodbTableV2"
        
        [HttpDelete]"dynamodbTableV2/{id}"

        [HttpPut] dynamodbTableV2/{id}/ttl"
       
        [HttpPut] "dynamodbTableV2/{id}/point-in-time-recovery"

```   
## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [_/ ] Manually, on a remote test system

## Describe any breaking changes

- ...
