### PR TITLE
DUPLO-19736 Data resource duplocloud_eks_credentials handle case where infra does not exists

### DIFF
--- a/duplocloud/data_source_duplo_eks_credentials.go
+++ b/duplocloud/data_source_duplo_eks_credentials.go
@@ -64,12 +64,10 @@ func dataSourceEksCredentialsRead(d *schema.ResourceData, m interface{}) error {
 	if infra != nil && planID != "default" {
 		if !infra.EnableK8Cluster && infra.Cloud != 2 {
 			return fmt.Errorf("no kubernetes cluster for this plan %s", planID)
-		} else if infra.Cloud == 2 {
-			// Check for AksConfig only if Cloud is 2 (relevant scenario)
-			if infra.AksConfig == nil || !infra.AksConfig.CreateAndManage {
-				return fmt.Errorf("no kubernetes cluster for plan %s", planID)
-			}
+		} else if infra.Cloud == 2 && (infra.AksConfig == nil || !infra.AksConfig.CreateAndManage) {
+			return fmt.Errorf("no kubernetes cluster for plan %s", planID)
 		}
+
 		k8sConfig, err = c.GetPlanK8sJitAccess(planID)
 		if err != nil && !err.PossibleMissingAPI() {
 			return fmt.Errorf("failed to get plan %s kubernetes JIT access: %s", planID, err)

--- a/duplocloud/data_source_duplo_eks_credentials.go
+++ b/duplocloud/data_source_duplo_eks_credentials.go
@@ -59,31 +59,43 @@ func dataSourceEksCredentialsRead(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return fmt.Errorf("failed to get plan %s kubernetes JIT access: %s", planID, err)
 	}
-
-	if infra == nil {
-		return fmt.Errorf("no infra configuration for plan %s found", planID)
-	}
-
+	k8sConfig := &duplosdk.DuploEksCredentials{}
 	// Now we know infra is not nil, proceed with checks
-	if !infra.EnableK8Cluster && infra.Cloud != 2 {
-		return fmt.Errorf("no kubernetes cluster for this plan %s", planID)
-	} else if infra.Cloud == 2 {
-		// Check for AksConfig only if Cloud is 2 (relevant scenario)
-		if infra.AksConfig == nil || !infra.AksConfig.CreateAndManage {
-			return fmt.Errorf("no kubernetes cluster for plan %s", planID)
+	if infra != nil && planID != "default" {
+		if !infra.EnableK8Cluster && infra.Cloud != 2 {
+			return fmt.Errorf("no kubernetes cluster for this plan %s", planID)
+		} else if infra.Cloud == 2 {
+			// Check for AksConfig only if Cloud is 2 (relevant scenario)
+			if infra.AksConfig == nil || !infra.AksConfig.CreateAndManage {
+				return fmt.Errorf("no kubernetes cluster for plan %s", planID)
+			}
 		}
-	}
-	// First, try the newer method of obtaining a JIT access token.
-	k8sConfig, err := c.GetPlanK8sJitAccess(planID)
-	if err != nil && !err.PossibleMissingAPI() {
-		return fmt.Errorf("failed to get plan %s kubernetes JIT access: %s", planID, err)
-	}
+		k8sConfig, err = c.GetPlanK8sJitAccess(planID)
+		if err != nil && !err.PossibleMissingAPI() {
+			return fmt.Errorf("failed to get plan %s kubernetes JIT access: %s", planID, err)
+		}
 
-	// If it failed, try the fallback method.
-	if k8sConfig == nil {
-		k8sConfig, err = c.GetK8sCredentials(planID)
-		if err != nil {
-			return fmt.Errorf("failed to read EKS credentials: %s", err)
+		// If it failed, try the fallback method.
+		if k8sConfig == nil {
+			k8sConfig, err = c.GetK8sCredentials(planID)
+			if err != nil {
+				return fmt.Errorf("failed to read EKS credentials: %s", err)
+			}
+		}
+	} else {
+		// First, try the newer method of obtaining a JIT access token.
+
+		k8sConfig, err = c.GetPlanK8sJitAccess(planID)
+		if err != nil && !err.PossibleMissingAPI() {
+			return fmt.Errorf("failed to get plan %s kubernetes JIT access: %s", planID, err)
+		}
+
+		// If it failed, try the fallback method.
+		if k8sConfig == nil {
+			k8sConfig, err = c.GetK8sCredentials(planID)
+			if err != nil {
+				return fmt.Errorf("failed to read EKS credentials: %s", err)
+			}
 		}
 	}
 	d.SetId(planID)


### PR DESCRIPTION
## Overview

Checking if plan has k8s enabled if plan is non default and has infra response. Otherwise fetching k8s config
## Summary of changes

This PR does the following:

- updated code for duplocloud_eks_credentials data-source
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ☑️] Manually, on a remote test system

## Describe any breaking changes

- ...
