### PR TITLE
DUPLO-18177 fix: add missing adjustment to change in data contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-07-31
+
+### Fixed
+- Adjusted URL path construction for force delete ECR operations to reflect changes in the data contract.
+
 ## 2024-07-23
 
 ### Enhanced

--- a/duplosdk/aws_ecr_repository.go
+++ b/duplosdk/aws_ecr_repository.go
@@ -73,11 +73,11 @@ func (c *Client) AwsEcrRepositoryDelete(tenantID string, name string, forceDelet
 	forceDeletePostfix := ""
 
 	if forceDelete {
-		forceDeletePostfix = "/force"
+		forceDeletePostfix = "force/"
 	}
 	return c.deleteAPI(
 		fmt.Sprintf("AwsEcrRepositoryDelete(%s, %s)", tenantID, name),
-		fmt.Sprintf("v3/subscriptions/%s/aws/ecrRepository/%s%s", tenantID, name, forceDeletePostfix),
+		fmt.Sprintf("v3/subscriptions/%s/aws/ecrRepository/%s%s", tenantID, forceDeletePostfix, name),
 		nil,
 	)
 }


### PR DESCRIPTION
### **User description**
## Overview

We have changed the data contract for force_delete operations and this needs to reflect in the client code of Duplo's Terraform provider

## Summary of changes

This PR does the following:

- Adjust data contract for force_delete ecr operations

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

No


___

### **PR Type**
Bug fix


___

### **Description**
- Adjusted the URL path construction for force delete ECR operations in `AwsEcrRepositoryDelete` function.
- Changed the order of URL path segments to correctly reflect the new data contract.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws_ecr_repository.go</strong><dd><code>Fix URL path construction for force delete ECR operations</code></dd></summary>
<hr>

duplosdk/aws_ecr_repository.go

<li>Adjusted the URL path construction for force delete ECR operations.<br> <li> Changed the order of URL path segments.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/607/files#diff-0f3b9bb808459309525133fb08252307c54c0e81dad03e78169b4cf57db86849">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

