### PR TITLE
Duplo 19094 Support to set VM `Disk Controller Type` to `NVMe` via TF

### DIFF
--- a/docs/resources/azure_virtual_machine.md
+++ b/docs/resources/azure_virtual_machine.md
@@ -67,6 +67,7 @@ resource "duplocloud_azure_virtual_machine" "az_vm" {
 - `agent_platform` (Number) The numeric ID of the container agent pool that this host is added to. Defaults to `0`.
 - `allocated_public_ip` (Boolean) Whether or not to allocate a public IP. Defaults to `false`.
 - `base64_user_data` (String) Base64 encoded user data to associated with the host.
+- `disk_control_type` (String) disk control types refer to the different levels of management and performance control provided for disks attached to virtual machines (VMs)
 - `disk_size_gb` (Number) Specifies the size of the OS Disk in gigabytes Defaults to `128`.
 - `enable_log_analytics` (Boolean) Enable log analytics on virtual machine. Defaults to `false`.
 - `encrypt_disk` (Boolean) Defaults to `false`.

--- a/duplocloud/diff_utils.go
+++ b/duplocloud/diff_utils.go
@@ -176,3 +176,20 @@ func diffStringMaps(oldMap, newMap map[string]interface{}) (map[string]*string, 
 
 	return create, remove
 }
+
+func suppressAzureManagedTags(k, old, new string, d *schema.ResourceData) bool {
+	_, tags := d.GetChange("tags")
+	suppressTagKeys := DuploManagedAzureTags()
+
+	for _, mp := range tags.([]interface{}) {
+		keyval := mp.(map[string]interface{})
+		for key, _ := range keyval {
+			if Contains(suppressTagKeys, key) {
+				return true
+			}
+
+		}
+	}
+
+	return false
+}

--- a/duplocloud/diff_utils.go
+++ b/duplocloud/diff_utils.go
@@ -183,7 +183,7 @@ func suppressAzureManagedTags(k, old, new string, d *schema.ResourceData) bool {
 
 	for _, mp := range tags.([]interface{}) {
 		keyval := mp.(map[string]interface{})
-		for key, _ := range keyval {
+		for key := range keyval {
 			if Contains(suppressTagKeys, key) {
 				return true
 			}

--- a/duplocloud/resource_duplo_azure_virtual_machine.go
+++ b/duplocloud/resource_duplo_azure_virtual_machine.go
@@ -206,6 +206,17 @@ func duploAzureVirtualMachineSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"disk_control_type": {
+			Description: "disk control types refer to the different levels of management and performance control provided for disks attached to virtual machines (VMs)",
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			ValidateFunc: validation.StringInSlice([]string{
+				"NVMe",
+				"SCSI",
+			}, true),
+			DiffSuppressFunc: diffSuppressWhenNotCreating,
+		},
 		"wait_until_ready": {
 			Description: "Whether or not to wait until azure virtual machine to be ready, after creation.",
 			Type:        schema.TypeBool,
@@ -486,6 +497,7 @@ func expandAzureVirtualMachine(d *schema.ResourceData) *duplosdk.DuploNativeHost
 				SubnetID: d.Get("subnet_id").(string),
 			},
 		},
+		DiskControlType: d.Get("disk_control_type").(string),
 	}
 }
 
@@ -542,6 +554,7 @@ func flattenAzureVirtualMachine(d *schema.ResourceData, duplo *duplosdk.DuploNat
 	d.Set("status", duplo.Status)
 	d.Set("user_account", duplo.UserAccount)
 	d.Set("tags", flattenTags(duplo.TagsEx))
+	d.Set("disk_control_type", duplo.DiskControlType)
 }
 
 func flattenTags(tags *[]duplosdk.DuploKeyStringValue) []interface{} {

--- a/duplocloud/resource_duplo_azure_virtual_machine.go
+++ b/duplocloud/resource_duplo_azure_virtual_machine.go
@@ -160,10 +160,11 @@ func duploAzureVirtualMachineSchema() map[string]*schema.Schema {
 			Computed:    true,
 		},
 		"tags": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			Elem:     KeyValueSchema(),
+			Type:             schema.TypeList,
+			Optional:         true,
+			Computed:         true,
+			Elem:             KeyValueSchema(),
+			DiffSuppressFunc: suppressAzureManagedTags,
 		},
 		"minion_tags": {
 			Description: "A map of tags to assign to the resource. Example - `AllocationTags` can be passed as tag key with any value.",

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -842,7 +842,7 @@ func base64IsEncoded(data string) bool {
 }
 
 func DuploManagedAzureTags() []string {
-	return []string{"TENANT_NAME", "TENANT_ID", "duplo-project", "duplo_creation_time", "duplo_sync_vm", "owner", "duplo_aaddomainjoin", "duplo_domainjoin"}
+	return []string{"TENANT_NAME", "TENANT_ID", "duplo-project", "duplo_creation_time", "duplo_sync_vm", "owner", "duplo_aaddomainjoin", "duplo_domainjoin", "duplo_associated_nic_name"}
 }
 
 func Contains(s []string, e string) bool {

--- a/duplosdk/native_hosts.go
+++ b/duplosdk/native_hosts.go
@@ -46,6 +46,7 @@ type DuploNativeHost struct {
 	Tags               *[]DuploKeyStringValue             `json:"Tags,omitempty"`
 	TagsEx             *[]DuploKeyStringValue             `json:"TagsEx,omitempty"`
 	MinionTags         *[]DuploKeyStringValue             `json:"MinionTags,omitempty"`
+	DiskControlType    string                             `json:"DiskControllerType,omitempty"`
 }
 
 // DuploNativeHostNetworkInterface is a Duplo SDK object that represents a network interface of a native host


### PR DESCRIPTION
## Overview

Added support for disk_control_type to duplocloud_azure_virtual_machine resource, added duplo_associated_nic_name to duplo manged tag list
## Summary of changes

This PR does the following:

- Updated resource schema and duplo manged tag list
- Updated docs

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
