### PR TITLE
DUPLO-19094 Support for below specification during VM creation via TF

### DIFF
--- a/docs/resources/azure_virtual_machine.md
+++ b/docs/resources/azure_virtual_machine.md
@@ -68,12 +68,18 @@ resource "duplocloud_azure_virtual_machine" "az_vm" {
 - `allocated_public_ip` (Boolean) Whether or not to allocate a public IP. Defaults to `false`.
 - `base64_user_data` (String) Base64 encoded user data to associated with the host.
 - `disk_size_gb` (Number) Specifies the size of the OS Disk in gigabytes Defaults to `128`.
+- `enable_encrypt_at_host` (Boolean) Defaults to `false`.
 - `enable_log_analytics` (Boolean) Enable log analytics on virtual machine. Defaults to `false`.
+- `enable_security_boot` (Boolean) Select to enable Secure Boot for your VM. Used with security_type=TrustedLaunch, default to true Defaults to `true`.
+- `enable_vtpm` (Boolean) Select to enable virtual Trusted Platform Module (vTPM) for Azure VM.. Used with security_type=TrustedLaunch, default to true Defaults to `true`.
 - `encrypt_disk` (Boolean) Defaults to `false`.
 - `is_minion` (Boolean) Defaults to `true`.
 - `join_domain` (Boolean) Join a Windows Server virtual machine to an Azure Active Directory Domain Services. Defaults to `false`.
 - `minion_tags` (Block List) A map of tags to assign to the resource. Example - `AllocationTags` can be passed as tag key with any value. (see [below for nested schema](#nestedblock--minion_tags))
 - `os_disk_type` (String) Specifies the type of managed disk to create. Possible values are either `Standard_LRS`, `StandardSSD_LRS`, `Premium_LRS`, `PremiumV2_LRS`, `Premium_ZRS`, `StandardSSD_ZRS` or `UltraSSD_LRS`.
+- `security_type` (String) Select "Standard" or "Trusted Launch" security type. Defaults to "Standard".
+			Use Trusted Launch for the security of "Generation 2" virtual machines (VMs). [Supported Sizes](https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch#virtual-machines-sizes)
+			 Defaults to `Standard`.
 - `tags` (Block List) (see [below for nested schema](#nestedblock--tags))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `timezone` (String) Specifies the time zone of the virtual machine, [the possible values are defined here](https://jackstromberg.com/2017/01/list-of-time-zones-consumed-by-azure/).

--- a/duplosdk/native_hosts.go
+++ b/duplosdk/native_hosts.go
@@ -46,6 +46,10 @@ type DuploNativeHost struct {
 	Tags               *[]DuploKeyStringValue             `json:"Tags,omitempty"`
 	TagsEx             *[]DuploKeyStringValue             `json:"TagsEx,omitempty"`
 	MinionTags         *[]DuploKeyStringValue             `json:"MinionTags,omitempty"`
+	SecurityType       string                             `json:"SecurityType"`
+	IsEncryptAtHost    bool                               `json:"IsEncryptAtHost"`
+	IsSecureBoot       bool                               `json:"IsSecureBoot"`
+	IsvTPM             bool                               `json:"IsvTPM"`
 }
 
 // DuploNativeHostNetworkInterface is a Duplo SDK object that represents a network interface of a native host


### PR DESCRIPTION
## Overview

Support added  for encryption at host and security type and other related schema attribute for duplocloud_azure_virtual_machine resource
## Summary of changes

This PR does the following:

- Added support for encryption_at_host, security_type, enable_vtpm, enable_security_boot 
- Updated doc

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
