### PR TITLE
Duplo 19031 Azure> TF> Feature to add customized name for AKS and resource group via TF

### DIFF
--- a/docs/resources/azure_k8s_cluster.md
+++ b/docs/resources/azure_k8s_cluster.md
@@ -37,15 +37,15 @@ resource "duplocloud_azure_k8s_cluster" "cluster" {
 ### Required
 
 - `infra_name` (String) The name of the infrastructure.
-- `name` (String) The name of the aks.
-- `resource_group_name` (String) The name of the aks resource group.
 
 ### Optional
 
 - `kubernetes_version` (String) Version of Kubernetes specified when creating the AKS managed cluster.
+- `name` (String) The name of the aks.
 - `network_plugin` (String) Network plugin to use for networking. Valid values are: `azure` and `kubenet`.
 - `outbound_type` (String) The outbound (egress) routing method which should be used for this Kubernetes Cluster. Valid values are: `loadBalancer` and `userDefinedRouting`.
 - `private_cluster_enabled` (Boolean) Should this Kubernetes Cluster have its API server only exposed on internal IP addresses? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to `false`.
+- `resource_group_name` (String) The name of the aks resource group.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `vm_size` (String) The size of the Virtual Machine.
 

--- a/docs/resources/azure_k8s_cluster.md
+++ b/docs/resources/azure_k8s_cluster.md
@@ -41,7 +41,7 @@ resource "duplocloud_azure_k8s_cluster" "cluster" {
 ### Optional
 
 - `kubernetes_version` (String) Version of Kubernetes specified when creating the AKS managed cluster.
-- `name` (String) The name of the aks.
+- `name` (String) The name of the aks. If not specified default name would be infra name
 - `network_plugin` (String) Network plugin to use for networking. Valid values are: `azure` and `kubenet`.
 - `outbound_type` (String) The outbound (egress) routing method which should be used for this Kubernetes Cluster. Valid values are: `loadBalancer` and `userDefinedRouting`.
 - `private_cluster_enabled` (Boolean) Should this Kubernetes Cluster have its API server only exposed on internal IP addresses? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to `false`.

--- a/duplocloud/resource_duplo_azure_k8s_cluster.go
+++ b/duplocloud/resource_duplo_azure_k8s_cluster.go
@@ -22,7 +22,7 @@ func duploAzureK8sClusterSchema() map[string]*schema.Schema {
 			ForceNew:    true,
 		},
 		"name": {
-			Description: "The name of the aks.",
+			Description: "The name of the aks. If not specified default name would be infra name",
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
@@ -177,9 +177,6 @@ func expandAzureK8sCluster(d *schema.ResourceData) *duplosdk.AksConfig {
 		body.Name = d.Get("infra_name").(string)
 	}
 
-	if body.NodeResourceGroup == "" {
-		body.Name = d.Get("infra_name").(string)
-	}
 	return body
 }
 

--- a/duplocloud/resource_duplo_azure_k8s_cluster.go
+++ b/duplocloud/resource_duplo_azure_k8s_cluster.go
@@ -24,14 +24,14 @@ func duploAzureK8sClusterSchema() map[string]*schema.Schema {
 		"name": {
 			Description: "The name of the aks.",
 			Type:        schema.TypeString,
-			Required:    true,
-			ForceNew:    true,
+			Optional:    true,
+			Computed:    true,
 		},
 		"resource_group_name": {
 			Description: "The name of the aks resource group.",
 			Type:        schema.TypeString,
-			Required:    true,
-			ForceNew:    true,
+			Optional:    true,
+			Computed:    true,
 		},
 
 		"vm_size": {
@@ -163,7 +163,7 @@ func resourceAzureK8sClusterDelete(ctx context.Context, d *schema.ResourceData, 
 }
 
 func expandAzureK8sCluster(d *schema.ResourceData) *duplosdk.AksConfig {
-	return &duplosdk.AksConfig{
+	body := &duplosdk.AksConfig{
 		Name:              d.Get("name").(string),
 		PrivateCluster:    d.Get("private_cluster_enabled").(bool),
 		K8sVersion:        d.Get("kubernetes_version").(string),
@@ -173,6 +173,14 @@ func expandAzureK8sCluster(d *schema.ResourceData) *duplosdk.AksConfig {
 		NodeResourceGroup: d.Get("resource_group_name").(string),
 		CreateAndManage:   true,
 	}
+	if body.Name == "" {
+		body.Name = d.Get("infra_name").(string)
+	}
+
+	if body.NodeResourceGroup == "" {
+		body.Name = d.Get("infra_name").(string)
+	}
+	return body
 }
 
 func flattenAzureK8sCluster(d *schema.ResourceData, duplo *duplosdk.AksConfig) {


### PR DESCRIPTION
## Overview

Made name and resource_group_name optional for backward compatibility, if name not passed infra name will be assigned
## Summary of changes

This PR does the following:

- schema behaviour change
- updated doc

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
