### PR TITLE
made duplocloud_gcp_storage_bucket depreciated, added missing attribu…

### DIFF
--- a/docs/resources/gcp_s3_bucket.md
+++ b/docs/resources/gcp_s3_bucket.md
@@ -87,6 +87,7 @@ resource "duplocloud_gcp_s3_bucket" "mydata" {
 - `allow_public_access` (Boolean) Whether or not to remove the public access block from the bucket.
 - `default_encryption` (Block List, Max: 1) Default encryption settings for objects uploaded to the bucket. (see [below for nested schema](#nestedblock--default_encryption))
 - `enable_versioning` (Boolean) Whether or not to enable versioning.
+- `labels` (Map of String) The labels assigned to this storage bucket.
 - `location` (String) The location is to set region/multi region, applicable for gcp cloud.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/duplocloud/resource_duplo_gcp_storage_bucket.go
+++ b/duplocloud/resource_duplo_gcp_storage_bucket.go
@@ -63,7 +63,8 @@ func gcpStorageBucketSchema() map[string]*schema.Schema {
 // Resource for managing a GCP storage bucket
 func resourceGcpStorageBucket() *schema.Resource {
 	return &schema.Resource{
-		Description: "`duplocloud_gcp_storage_bucket` manages a GCP storage bucket in Duplo.",
+		Description:        "`duplocloud_gcp_storage_bucket` manages a GCP storage bucket in Duplo.",
+		DeprecationMessage: "duplocloud_gcp_storage_bucket is deprecated. Use duplocloud_gcp_s3_bucket instead.",
 
 		ReadContext:   resourceGcpStorageBucketRead,
 		CreateContext: resourceGcpStorageBucketCreate,

--- a/duplocloud/resource_duplo_s3_bucket.go
+++ b/duplocloud/resource_duplo_s3_bucket.go
@@ -470,33 +470,3 @@ func fillS3BucketRequest(duploObject *duplosdk.DuploS3BucketSettingsRequest, d *
 	log.Printf("[TRACE] fillS3BucketRequest ******** end")
 	return nil
 }
-
-func fillGCPBucketRequest(duploObject *duplosdk.DuploGCPBucket, d *schema.ResourceData) error {
-	log.Printf("[TRACE] fillS3BucketRequest ******** start")
-
-	// Set the object versioning
-	if v, ok := d.GetOk("enable_versioning"); ok && v != nil {
-		duploObject.EnableVersioning = v.(bool)
-	}
-
-	// Set the public access block.
-	if v, ok := d.GetOk("allow_public_access"); ok && v != nil {
-		duploObject.AllowPublicAccess = v.(bool)
-	}
-
-	// Set the default encryption.
-	defaultEncryption, err := getOptionalBlockAsMap(d, "default_encryption")
-	if err != nil {
-		return err
-	}
-	if v, ok := defaultEncryption["method"]; ok && v != nil {
-		duploObject.DefaultEncryptionType = decodeEncryption(v.(string))
-	}
-
-	if v, ok := d.GetOk("location"); ok && v != nil {
-		duploObject.Location = v.(string)
-	}
-
-	log.Printf("[TRACE] fillS3BucketRequest ******** end")
-	return nil
-}

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -727,6 +727,15 @@ func flattenStringMap(duplo map[string]string) map[string]interface{} {
 }
 
 func flattenGcpLabels(d *schema.ResourceData, duplo map[string]string) {
+	duploManagedLabels := []string{"duplo-allow-public-access", "duplo-encryption"}
+	mp := flattenStringMap(duplo)
+	for _, v := range duploManagedLabels {
+		delete(mp, v)
+	}
+	duplo = map[string]string{}
+	for k, v := range mp {
+		duplo[k] = v.(string)
+	}
 	d.Set("labels", flattenStringMap(duplo))
 }
 
@@ -741,6 +750,8 @@ func expandAsStringMap(fieldName string, d *schema.ResourceData) map[string]stri
 				m[k] = v.(string)
 			}
 		}
+	} else {
+		return nil
 	}
 
 	return m

--- a/duplosdk/tenant_aws_cloud_resources.go
+++ b/duplosdk/tenant_aws_cloud_resources.go
@@ -97,12 +97,13 @@ type DuploGCPBucket struct {
 	// NOTE: The TenantID field does not come from the backend - we synthesize it
 	TenantID string `json:"-"`
 
-	Name                  string `json:"Name,omitempty"`
-	DomainName            string `json:"SelfLink,omitempty"`
-	Location              string `json:"Location,omitempty"`
-	EnableVersioning      bool   `json:"EnableVersioning,omitempty"`
-	AllowPublicAccess     bool   `json:"AllowPublicAccess,omitempty"`
-	DefaultEncryptionType int    `json:"DefaultEncryptionType,omitempty"`
+	Name                  string            `json:"Name,omitempty"`
+	DomainName            string            `json:"SelfLink,omitempty"`
+	Location              string            `json:"Location,omitempty"`
+	EnableVersioning      bool              `json:"EnableVersioning,omitempty"`
+	AllowPublicAccess     bool              `json:"AllowPublicAccess,omitempty"`
+	DefaultEncryptionType int               `json:"DefaultEncryptionType,omitempty"`
+	Labels                map[string]string `json:"Labels,omitempty"`
 }
 
 // DuploApplicationLB represents an AWS application load balancer resource for a Duplo tenant
@@ -544,7 +545,7 @@ func (c *Client) TenantCreateV3S3Bucket(tenantID string, duplo DuploS3BucketSett
 	return &resp, nil
 }
 
-func (c *Client) GCPTenantCreateV3S3Bucket(tenantID string, duplo DuploS3BucketSettingsRequest) (*DuploS3Bucket, ClientError) {
+func (c *Client) GCPTenantCreateV3S3Bucket(tenantID string, duplo DuploGCPBucket) (*DuploS3Bucket, ClientError) {
 
 	resp := DuploS3Bucket{}
 


### PR DESCRIPTION

## Overview

Made duplocloud_gcp_storage_bucket resource deprecated, added missing attribute lables to duplocloud_gcp_s3_bucket resource

## Summary of changes

This PR does the following:

- Added labels to duplocloud_gcp_s3_bucket
- Resource duplocloud_gcp_storage_bucket deprecated
- Updated doc

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
