### PR TITLE
DUPLO-20452 Infra Setting document fix

### DIFF
--- a/docs/resources/infrastructure_setting.md
+++ b/docs/resources/infrastructure_setting.md
@@ -56,6 +56,7 @@ resource "duplocloud_infrastructure_setting" "settings" {
 - `custom_data` (Block List, Deprecated) A complete list of configuration settings for this infrastructure, even ones not being managed by this resource. The custom_data argument is only applied on creation, and is deprecated in favor of the settings argument. (see [below for nested schema](#nestedblock--custom_data))
 - `delete_unspecified_settings` (Boolean) Whether or not this resource should delete any settings not specified by this resource. **WARNING:**  It is not recommended to change the default value of `false`. Defaults to `false`.
 - `setting` (Block List) A list of configuration settings to manage, expressed as key / value pairs.
+				
 | Cloud     | Key (string)                 | Value (string)                                          |
 |-----------|------------------------------|---------------------------------------------------------| 
 | All Cloud | MaximumK8sSessionDuration    | int                                                     | 
@@ -73,7 +74,8 @@ resource "duplocloud_infrastructure_setting" "settings" {
 | Azure     | Shared Image Gallery         | string                                                  |
 | Azure     | EnableAzureAppGatewayIngress | bool                                                    |
 | GCP       | GkeMinPortsPerVm             | int                                                     |
-*Note: EksControlplaneLogs value can be set with combination of settings separated by ; with no spaces* (see [below for nested schema](#nestedblock--setting))
+
+Note: EksControlplaneLogs value can be set with combination of settings separated by ; with no spaces (see [below for nested schema](#nestedblock--setting))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/duplocloud/resource_duplo_infrastructure_setting.go
+++ b/duplocloud/resource_duplo_infrastructure_setting.go
@@ -39,6 +39,7 @@ func resourceInfrastructureSetting() *schema.Resource {
 			},
 			"setting": {
 				Description: `A list of configuration settings to manage, expressed as key / value pairs.
+				
 | Cloud     | Key (string)                 | Value (string)                                          |
 |-----------|------------------------------|---------------------------------------------------------| 
 | All Cloud | MaximumK8sSessionDuration    | int                                                     | 
@@ -56,7 +57,8 @@ func resourceInfrastructureSetting() *schema.Resource {
 | Azure     | Shared Image Gallery         | string                                                  |
 | Azure     | EnableAzureAppGatewayIngress | bool                                                    |
 | GCP       | GkeMinPortsPerVm             | int                                                     |
-*Note: EksControlplaneLogs value can be set with combination of settings separated by ; with no spaces*`,
+
+Note: EksControlplaneLogs value can be set with combination of settings separated by ; with no spaces`,
 				Type:          schema.TypeList,
 				Optional:      true,
 				Elem:          KeyValueSchema(),


### PR DESCRIPTION
### **User description**
## Overview

potential fix
## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Enhanced the `setting` field documentation in both the Go source file and the Markdown documentation by adding a detailed table of key/value pairs.
- Clarified the note regarding the format of the `EksControlplaneLogs` value.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_infrastructure_setting.go</strong><dd><code>Enhance `setting` field documentation with detailed table</code></dd></summary>
<hr>

duplocloud/resource_duplo_infrastructure_setting.go

<li>Added detailed description for <code>setting</code> field with a table of key/value <br>pairs.<br> <li> Clarified note about <code>EksControlplaneLogs</code> value format.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/621/files#diff-49ed8db59924b0abf8371ceed9b3d608b2b20a549c4450d17da07a33eb72825a">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>infrastructure_setting.md</strong><dd><code>Update documentation for `setting` field with detailed table</code></dd></summary>
<hr>

docs/resources/infrastructure_setting.md

<li>Added detailed description for <code>setting</code> field with a table of key/value <br>pairs.<br> <li> Clarified note about <code>EksControlplaneLogs</code> value format.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/621/files#diff-88b7fcb153130ab0b3626b72ea4b3f2b24e34f60f975a0307b4c0e83717d732c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

