### PR TITLE
DUPLO-20874 TF Import: Dynamo DB missing name in Get API

### DIFF
--- a/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
+++ b/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
@@ -323,13 +323,11 @@ func resourceAwsDynamoDBTableReadV2(ctx context.Context, d *schema.ResourceData,
 		return diag.FromErr(err)
 	}
 	log.Printf("[TRACE] resourceAwsDynamoDBTableReadV2(%s, %s): start", tenantID, name)
-	reservedFullname := d.Get("fullname").(string)
+	fullName := d.Get("fullname").(string)
 	c := m.(*duplosdk.Client)
 
-	var fullName string
-
-	if fullName != reservedFullname && reservedFullname != "" {
-		fullName = reservedFullname
+	if fullName == "" {
+		fullName = name
 	}
 	duplo, clientErr := c.DynamoDBTableGetV2(tenantID, fullName)
 	if clientErr != nil {

--- a/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
+++ b/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
@@ -322,12 +322,18 @@ func resourceAwsDynamoDBTableReadV2(ctx context.Context, d *schema.ResourceData,
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	var fullName string
 	log.Printf("[TRACE] resourceAwsDynamoDBTableReadV2(%s, %s): start", tenantID, name)
-	fullName := d.Get("fullname").(string)
 	c := m.(*duplosdk.Client)
+	prefix, err := c.GetDuploServicesPrefix(tenantID)
 
-	if fullName == "" {
+	if err != nil {
+		return diag.Errorf("Unable to retrieve duplo service name (name: %s, error: %s)", name, err.Error())
+	}
+	if strings.Contains(name, prefix) {
 		fullName = name
+	} else {
+		fullName = prefix + "-" + name
 	}
 	duplo, clientErr := c.DynamoDBTableGetV2(tenantID, fullName)
 	if clientErr != nil {

--- a/examples/resources/duplocloud_aws_dynamodb_table_v2/import.sh
+++ b/examples/resources/duplocloud_aws_dynamodb_table_v2/import.sh
@@ -3,3 +3,4 @@
 #  - *NAME* is the name of dynamodb table
 #
 terraform import duplocloud_aws_dynamodb_table_v2.myDynamodbTable *TENANT_ID*/*NAME*
+


### PR DESCRIPTION
## Overview

Fixed Get API fail on import of duplocloud_aws_dynamodb_table_v2 resource

## Summary of changes

This PR does the following:

- Initializing name to fullname if fullname is empty
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...
