### PR TITLE
Revert "DUPLO-20879 Fallback implemented"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2024-08-26
+
+### Fixed
+- Removed fallback mechanism for error handling in DynamoDB table operations, simplifying code and improving maintainability.
+
 ## 2024-08-21
 
 ### Enhanced


### PR DESCRIPTION
### **User description**
Reverts duplocloud/terraform-provider-duplocloud#640


___

### **PR Type**
Bug fix


___

### **Description**
- Removed the fallback mechanism for handling errors during DynamoDB table retrieval and deletion, simplifying the code.
- Enhanced error handling by directly addressing errors without attempting a fallback.
- Cleaned up redundant code related to fallback attempts, improving code maintainability.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_dynamodb_table_v2.go</strong><dd><code>Remove fallback mechanism and simplify error handling</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_aws_dynamodb_table_v2.go

<li>Removed fallback mechanism for DynamoDB table retrieval and deletion.<br> <li> Simplified error handling by removing redundant code.<br> <li> Updated function to directly handle errors without fallback attempts.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/641/files#diff-589167a86b500ce20842028a24b38988f35a3d0719a3f4ddd018599bc8c2008a">+10/-29</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

