### PR TITLE
DUPLO-21079 Mask SSM parameter of type secret string in terraform logs.

### DIFF
--- a/duplocloud/data_source_duplo_aws_ssm_parameter.go
+++ b/duplocloud/data_source_duplo_aws_ssm_parameter.go
@@ -64,15 +64,20 @@ func dataSourceSsmParameterRead(d *schema.ResourceData, m interface{}) error {
 	// Get the object from Duplo.
 	id := fmt.Sprintf("%s/%s", tenantID, name)
 	c := m.(*duplosdk.Client)
-	ssmParam, err := c.SsmParameterGet(tenantID, name)
+	body, err := c.SsmParameterGet(tenantID, name)
 	if err != nil {
 		return fmt.Errorf("failed to get SSM parameter: %s: %s", id, err)
 	}
 
 	// Check for missing result
-	if ssmParam == nil {
+	if body == nil {
 		return fmt.Errorf("SSM parameter '%s' not found", id)
 	}
+	ssmParam := body
+	if ssmParam.Type == "SecureString" {
+		body.Value = "**********"
+	}
+	log.Printf("[TRACE] SsmParameterGet: received response: %+v", body)
 
 	d.SetId(id)
 	d.Set("type", ssmParam.Type)

--- a/duplocloud/data_source_duplo_aws_ssm_parameters.go
+++ b/duplocloud/data_source_duplo_aws_ssm_parameters.go
@@ -75,10 +75,17 @@ func dataSourceSsmParametersRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("failed to list SSM parameters: %s", err)
 	}
 	d.SetId(tenantID)
-
+	resp := *rp
 	// Set the Terraform resource data
 	list := make([]map[string]interface{}, 0, len(*rp))
-	for _, ssmParam := range *rp {
+	for i, body := range resp {
+		ssmParam := body
+		if ssmParam.Type == "SecureString" {
+			resp[i].Value = "**********"
+		}
+		if i == len(resp)-1 {
+			log.Printf("[TRACE] SsmParameterGet: received response: %+v", resp)
+		}
 		list = append(list, map[string]interface{}{
 			"tenant_id":          tenantID,
 			"name":               ssmParam.Name,

--- a/duplocloud/resource_duplo_aws_ssm_parameter.go
+++ b/duplocloud/resource_duplo_aws_ssm_parameter.go
@@ -106,7 +106,7 @@ func resourceAwsSsmParameterRead(ctx context.Context, d *schema.ResourceData, m 
 
 	// Get the object from Duplo, detecting a missing object
 	c := m.(*duplosdk.Client)
-	ssmParam, clientErr := c.SsmParameterGet(tenantID, name)
+	body, clientErr := c.SsmParameterGet(tenantID, name)
 	if clientErr != nil {
 		if clientErr.Status() == 404 {
 			d.SetId("") // object missing
@@ -114,6 +114,11 @@ func resourceAwsSsmParameterRead(ctx context.Context, d *schema.ResourceData, m 
 		}
 		return diag.Errorf("Unable to retrieve tenant %s SSM parameter '%s': %s", tenantID, name, clientErr)
 	}
+	ssmParam := body
+	if ssmParam.Type == "SecureString" {
+		body.Value = "**********"
+	}
+	log.Printf("[TRACE] SsmParameterGet: received response: %+v", body)
 
 	d.Set("tenant_id", tenantID)
 	d.Set("name", name)

--- a/duplosdk/client.go
+++ b/duplosdk/client.go
@@ -194,7 +194,7 @@ func (c *Client) doAPI(verb string, apiName string, apiPath string, rp interface
 		return httpErr
 	}
 	bodyString := string(body)
-	if !strings.Contains(apiName, "K8SecretGetList") {
+	if !strings.Contains(apiName, "K8SecretGetList") && !strings.Contains(apiName, "SsmParameterGet") && !strings.Contains(apiName, "SsmParameterList") {
 		log.Printf("[TRACE] %s: received response: %s", apiName, bodyString)
 	}
 	// Check for an expected "null" response.


### PR DESCRIPTION
## Overview

Masking ssm parameter secure string value in log
## Summary of changes

This PR does the following:

- skipping log at doApi function for get and list api for ssm param
- masking value of list and get api if type is SecureString

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
