### PR TITLE
DUPLO-20967 TF: duplocloud_k8_secret reports diffs even after apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2024-09-03
+
+### Fixed
+- Resolved an issue with `duplocloud_k8_secret` resource to correctly handle JSON value comparisons, preventing unnecessary diffs.
+- Added a nil check in the SSM resource logic to avoid potential nil pointer exceptions during read operations.
+
 
 ## 2024-08-26
 

--- a/duplocloud/resource_duplo_aws_ssm_parameter.go
+++ b/duplocloud/resource_duplo_aws_ssm_parameter.go
@@ -107,7 +107,6 @@ func resourceAwsSsmParameterRead(ctx context.Context, d *schema.ResourceData, m 
 	// Get the object from Duplo, detecting a missing object
 	c := m.(*duplosdk.Client)
 	body, clientErr := c.SsmParameterGet(tenantID, name)
-	logBody := *body
 	if clientErr != nil {
 		if clientErr.Status() == 404 {
 			d.SetId("") // object missing
@@ -116,11 +115,13 @@ func resourceAwsSsmParameterRead(ctx context.Context, d *schema.ResourceData, m 
 		return diag.Errorf("Unable to retrieve tenant %s SSM parameter '%s': %s", tenantID, name, clientErr)
 	}
 	ssmParam := body
-	if ssmParam.Type == "SecureString" {
-		logBody.Value = "**********"
+	if body != nil {
+		logBody := *body
+		if ssmParam.Type == "SecureString" {
+			logBody.Value = "**********"
+		}
+		log.Printf("[TRACE] SsmParameterGet: received response: %+v", logBody)
 	}
-	log.Printf("[TRACE] SsmParameterGet: received response: %+v", logBody)
-
 	d.Set("tenant_id", tenantID)
 	d.Set("name", name)
 	d.Set("type", ssmParam.Type)


### PR DESCRIPTION
## Overview

Difference on duplocloud_k8_secret resource if no change fix
## Summary of changes

Created a diffFunc that would convert all the json value to string specific and check the difference, since k8_secrets need a string type key value pair. Issue observed when ssm parameter value referred into k8_secrets

This PR does the following:

- Created diffSuppressFunc for secret_data to compare json object key value pair which first convert new data in string key value pair irrespective of data type of value 
- Added nil check condition an ssm resource logic at read context for avoiding potential nil pointer exception

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
