### PR TITLE
Duplo-20967 TF: duplocloud_k8_secret reports diffs even after apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2024-09-03
+
+### Fixed
+- Resolved an issue with `duplocloud_k8_secret` resource to correctly handle JSON value comparisons, preventing unnecessary diffs.
+- Added a nil check in the SSM resource logic to avoid potential nil pointer exceptions during read operations.
+
 
 ## 2024-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+The changes introduced in this PR have already been documented in the current CHANGELOG.md under the date 2024-09-03. No further updates are necessary.
+
 ## 2024-09-03
 
 ### Fixed

--- a/duplocloud/resource_duplo_aws_ssm_parameter.go
+++ b/duplocloud/resource_duplo_aws_ssm_parameter.go
@@ -107,7 +107,6 @@ func resourceAwsSsmParameterRead(ctx context.Context, d *schema.ResourceData, m 
 	// Get the object from Duplo, detecting a missing object
 	c := m.(*duplosdk.Client)
 	body, clientErr := c.SsmParameterGet(tenantID, name)
-	logBody := *body
 	if clientErr != nil {
 		if clientErr.Status() == 404 {
 			d.SetId("") // object missing
@@ -116,11 +115,13 @@ func resourceAwsSsmParameterRead(ctx context.Context, d *schema.ResourceData, m 
 		return diag.Errorf("Unable to retrieve tenant %s SSM parameter '%s': %s", tenantID, name, clientErr)
 	}
 	ssmParam := body
-	if ssmParam.Type == "SecureString" {
-		logBody.Value = "**********"
+	if body != nil {
+		logBody := *body
+		if ssmParam.Type == "SecureString" {
+			logBody.Value = "**********"
+		}
+		log.Printf("[TRACE] SsmParameterGet: received response: %+v", logBody)
 	}
-	log.Printf("[TRACE] SsmParameterGet: received response: %+v", logBody)
-
 	d.Set("tenant_id", tenantID)
 	d.Set("name", name)
 	d.Set("type", ssmParam.Type)


### PR DESCRIPTION
### **User description**
## Overview

Difference on duplocloud_k8_secret resource if no change fix
## Summary of changes

Created a diffFunc that would convert all the json value to string specific and check the difference, since k8_secrets need a string type key value pair. Issue observed when ssm parameter value referred into k8_secrets

This PR does the following:

- Created diffSuppressFunc for secret_data to compare json object key value pair which first convert new data in string key value pair irrespective of data type of value 
- Added nil check condition an ssm resource logic at read context for avoiding potential nil pointer exception

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
bug_fix, enhancement


___

### **Description**
- Implemented a `DiffSuppressFunc` for `duplocloud_k8_secret` to handle JSON value comparisons, preventing unnecessary diffs.
- Added a nil check in the SSM parameter read logic to avoid potential nil pointer exceptions.
- Updated the changelog to reflect the recent fixes and enhancements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_ssm_parameter.go</strong><dd><code>Add nil check and adjust logging in SSM parameter read</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_aws_ssm_parameter.go

<li>Added a nil check for <code>body</code> to prevent nil pointer exceptions.<br> <li> Adjusted logging to handle potential nil values.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/658/files#diff-c2481cca893f2c5fa066e9821a004883b945851509f65b0163098f293f118fd9">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_k8_secret.go</strong><dd><code>Implement JSON diff suppression for k8s secret data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_k8_secret.go

<li>Introduced <code>secretDataDiff</code> function for JSON comparison.<br> <li> Implemented <code>secretDataCompare</code> to handle JSON unmarshalling and <br>comparison.<br> <li> Enabled <code>DiffSuppressFunc</code> for <code>secret_data</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/658/files#diff-6af5c793e9044da0cac8960f8bb312c99f1f3e7a92989ef2b17bccd2f4b9417a">+41/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with recent fixes and enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented fixes for <code>duplocloud_k8_secret</code> JSON handling.<br> <li> Mentioned nil check addition in SSM resource logic.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/658/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

