### PR TITLE
Duplo-21053 TF:Azure:AgentPool: Make 'Delete' as a default Scale Set Eviction Policy for "Scale Set Priority" = "Spot"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2024-09-04
+
+### Enhanced
+- Set default value for `eviction_policy` to "Delete" for Spot priority in `duplocloud_azure_k8_node_pool` resource.
+- Added custom diff validator to ensure proper handling of `scale_priority` attributes, preventing unsupported configurations.
+
 
 ## 2024-08-26
 

--- a/docs/resources/azure_k8_node_pool.md
+++ b/docs/resources/azure_k8_node_pool.md
@@ -64,7 +64,7 @@ resource "duplocloud_azure_k8_node_pool" "node_pool" {
 
 Optional:
 
-- `eviction_policy` (String) eviction policies Delete/Deallocate
+- `eviction_policy` (String) eviction policies Delete/Deallocate. Default value is Delete
 - `priority` (String) priority levels Regular/Spot
 - `spot_max_price` (String) for spot VMs sets the maximum price you're willing to pay, controlling costs, while priority.spot determines the scaling order of spot VM pools.
 

--- a/duplocloud/resource_duplo_azure_k8_node_pool.go
+++ b/duplocloud/resource_duplo_azure_k8_node_pool.go
@@ -88,7 +88,7 @@ func duploAgentK8NodePoolSchema() map[string]*schema.Schema {
 						}, false),
 					},
 					"eviction_policy": {
-						Description: "eviction policies Delete/Deallocate",
+						Description: "eviction policies Delete/Deallocate. Default value is Delete",
 						Optional:    true,
 						Computed:    true,
 						Type:        schema.TypeString,
@@ -350,6 +350,18 @@ func validateScalePriorityAttribute(ctx context.Context, diff *schema.ResourceDi
 	}
 	if mp["priority"].(string) == "Regular" && mp["eviction_policy"].(string) != "" {
 		return errors.New("Scale Priority of type Regular does not support Eviction Policy")
+	}
+	if mp["priority"].(string) == "Spot" && mp["eviction_policy"].(string) == "" {
+		smp := make(map[string]interface{})
+		smp["eviction_policy"] = "Delete"
+		smp["priority"] = "Spot"
+		smp["spot_max_price"] = mp["spot_max_price"]
+		p := make([]interface{}, 1, 1)
+		p = append(p, smp)
+		err := diff.SetNew("scale_priority", p)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/duplocloud/resource_duplo_azure_k8_node_pool.go
+++ b/duplocloud/resource_duplo_azure_k8_node_pool.go
@@ -356,7 +356,7 @@ func validateScalePriorityAttribute(ctx context.Context, diff *schema.ResourceDi
 		smp["eviction_policy"] = "Delete"
 		smp["priority"] = "Spot"
 		smp["spot_max_price"] = mp["spot_max_price"]
-		p := make([]interface{}, 1, 1)
+		p := make([]interface{}, 1)
 		p = append(p, smp)
 		err := diff.SetNew("scale_priority", p)
 		if err != nil {

--- a/duplocloud/resource_duplo_azure_k8_node_pool.go
+++ b/duplocloud/resource_duplo_azure_k8_node_pool.go
@@ -348,6 +348,9 @@ func validateScalePriorityAttribute(ctx context.Context, diff *schema.ResourceDi
 	if mp["priority"].(string) == "Regular" && mp["spot_max_price"].(string) != "" {
 		return errors.New("Scale Priority of type Regular does not support Spot max price")
 	}
+	if mp["priority"].(string) == "Regular" && mp["eviction_policy"].(string) != "" {
+		return errors.New("Scale Priority of type Regular does not support Eviction Policy")
+	}
 
 	return nil
 }


### PR DESCRIPTION
### **User description**
## Overview
Set default value as Delete for eviciton_policy in duplocloud_azure_k8_node_pool resource
## Summary of changes

Set default value as Delete for eviciton_policy in duplocloud_azure_k8_node_pool resource when priority is set as spot and no value for eviction_policy is set.
This PR does the following:

- Implement Custom diff to check if eviction_policy is empty to set Delete as default value for Spot priority type for scale_priority
- ...

## Testing performed

- [ ] Using unit tests
- [ ✓] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Added a custom diff validator to ensure proper handling of `scale_priority` attributes, preventing unsupported configurations.
- Set the default value for `eviction_policy` to "Delete" when `priority` is set to "Spot" in the `duplocloud_azure_k8_node_pool` resource.
- Updated documentation to reflect the default value for `eviction_policy`.
- Updated the CHANGELOG to document these enhancements.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_azure_k8_node_pool.go</strong><dd><code>Enhance `scale_priority` validation and default settings</code>&nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_azure_k8_node_pool.go

<li>Added custom diff validator for <code>scale_priority</code> attributes.<br> <li> Set default <code>eviction_policy</code> to "Delete" for Spot priority.<br> <li> Introduced error handling for unsupported configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/663/files#diff-4e7e041ce39a2ede6969b9cefb2aec1c29333af18b3d2b04d6b598d02b309d56">+29/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update CHANGELOG for recent enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented changes for setting default <code>eviction_policy</code>.<br> <li> Added notes on custom diff validator enhancements.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/663/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>azure_k8_node_pool.md</strong><dd><code>Document default value for `eviction_policy`</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/resources/azure_k8_node_pool.md

- Updated documentation for `eviction_policy` default value.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/663/files#diff-02064021c4288b01f7ce72c074cec52fbc2328ccc16117bb202b7ba9ac72f1bd">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

