### PR TITLE
DUPLO-21081 DUPLO-21083:  add docs to log delivery config, validate duplicate log types, validate lower verision allowed for log type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2024-09-05
+
+### Enhanced
+- Improved log delivery configuration with updated documentation and validation to prevent duplicate log types.
+- Implemented version checks for log types to ensure compatibility with specified engine versions.
+
 
 ## 2024-08-26
 

--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -99,14 +99,14 @@ See AWS documentation for the [available Redis instance types](https://docs.aws.
 
 Required:
 
-- `destination_type` (String) Select the snapshot/backup you want to use for creating redis.
-- `log_format` (String)
-- `log_type` (String)
+- `destination_type` (String) destination type : must be cloudwatch-logs.
+Refer: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CLI_Log.html
+- `log_format` (String) log_format: Value must be one of the ['json', 'text']
+- `log_type` (String) log_type: Value must be one of the ['slow-log', 'engine-log']
 
 Optional:
 
-- `delivery_stream` (String) provide delivery_stream for destination_type = kinesis-firehose
-- `log_group` (String) provide log_group for destination_type = cloudwatch-logs
+- `log_group` (String) cloudwatch log_group
 
 
 <a id="nestedblock--timeouts"></a>

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -213,7 +213,7 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 					},
 					"log_type": {
 						Type:        schema.TypeString,
-						Description: "log_format: Value must be one of the ['slow-log', 'engine-log']",
+						Description: "log_type: Value must be one of the ['slow-log', 'engine-log']",
 						Required:    true,
 						ValidateFunc: validation.StringInSlice([]string{
 							duplosdk.REDIS_LOG_DELIVERY_LOG_TYPE_SLOW_LOG,


### PR DESCRIPTION
### **User description**
## Overview

DUPLO-21081 DUPLO-21083:  add docs to log delivery config, validate duplicate log types, validate lower verision allowed for log type## Summary of changes

This PR does the following:

- add docs to log delivery config
- validate duplicate log types
- validate lower verision allowed for log type

## Testing performed

- [ ] Using unit tests
- [X] Manually, on my local system
- [X] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Enhanced log delivery configuration by adding validation to prevent duplicate log types.
- Implemented version checks for log types to ensure compatibility with specified engine versions.
- Updated documentation to reflect changes in log delivery configuration requirements and examples.
- Updated CHANGELOG to document the enhancements and validations added.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_ecache_instance.go</strong><dd><code>Enhance log delivery configuration with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_ecache_instance.go

<li>Updated descriptions for log delivery configuration fields.<br> <li> Added validation for duplicate log types.<br> <li> Implemented version checks for log types.<br> <li> Introduced helper functions for validation.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/667/files#diff-0d4e960f6d6fea601a3f043c811148ed9f58959f772948285f4a11cc38708a0c">+52/-16</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog for log delivery enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented improvements to log delivery configuration.<br> <li> Added version checks for log types.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/667/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ecache_instance.md</strong><dd><code>Update ecache_instance documentation for log delivery</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/resources/ecache_instance.md

<li>Updated documentation for log delivery configuration fields.<br> <li> Specified required and optional fields with examples.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/667/files#diff-043ac248497c05f1e877b1714946cf707b361bbd70c813e754295d7750a58398">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

