### PR TITLE
DUPLO-21141 TF:duplocloud_azure_k8_node_pool: Provider plugin crashed when the scale set priority is not specified in Terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 2024-09-05
 
+### Fixed
+- Resolved a regression issue in `duplocloud_azure_k8_node_pool` by adding a length check for the `scale_priority` slice to prevent crashes when the scale set priority is not specified.
+
+## 2024-09-05
+
 ### Enhanced
 - Improved log delivery configuration with updated documentation and validation to prevent duplicate log types.
 - Implemented version checks for log types to ensure compatibility with specified engine versions.

--- a/duplocloud/resource_duplo_azure_k8_node_pool.go
+++ b/duplocloud/resource_duplo_azure_k8_node_pool.go
@@ -360,6 +360,9 @@ func azureK8NodePoolWaitUntilReady(ctx context.Context, c *duplosdk.Client, tena
 
 func validateScalePriorityAttribute(ctx context.Context, diff *schema.ResourceDiff, m interface{}) error {
 	scalePriority := diff.Get("scale_priority").([]interface{})
+	if len(scalePriority) == 0 {
+		return nil
+	}
 	mp := scalePriority[0].(map[string]interface{})
 	if mp["priority"].(string) == "Regular" && mp["spot_max_price"].(float64) != 0 {
 		return errors.New("Scale Priority of type Regular does not support Spot max price")


### PR DESCRIPTION
### **User description**
## Overview

Regression Fix 
## Summary of changes
Added missing length check on a slice in customdiff func
This PR does the following:

- added.length check for a slice of scalePriority object in customdiff func of duplocloud_azure_k8_node_pool resource
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed a regression issue in `duplocloud_azure_k8_node_pool` by adding a length check for the `scale_priority` slice to prevent crashes when the scale set priority is not specified.
- Updated the changelog to document the regression fix.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_azure_k8_node_pool.go</strong><dd><code>Add length check for scale_priority to prevent crashes</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_azure_k8_node_pool.go

<li>Added a length check for the <code>scale_priority</code> slice.<br> <li> Prevented crashes when the scale set priority is not specified.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/669/files#diff-4e7e041ce39a2ede6969b9cefb2aec1c29333af18b3d2b04d6b598d02b309d56">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with regression fix details</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented the regression fix for <code>duplocloud_azure_k8_node_pool</code>.<br> <li> Updated the changelog to reflect the bug fix.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/669/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

