### PR TITLE
DUPLO-21153 TF:RDS: performance insight: change flag from enable to enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2024-09-06
+
+### Enhanced
+- Renamed the `enable` attribute to `enabled` for performance insights in RDS instances, improving clarity and consistency.
+- Updated documentation to reflect changes in performance insights configuration for RDS instances.
+
 ## 2024-09-05
 
 ### Fixed

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -324,7 +324,7 @@ If you don't know the available engine versions for your RDS instance, you can u
 
 Optional:
 
-- `enable` (Boolean) Enable or Disable Performance Insights Defaults to `false`.
+- `enabled` (Boolean) Turn on or off Performance Insights Defaults to `false`.
 - `kms_key_id` (String) Specify ARN for the KMS key to encrypt Performance Insights data.
 - `retention_period` (Number) Specify retention period in Days. Valid values are 7, 731 (2 years) or a multiple of 31
 

--- a/examples/resources/duplocloud_rds_instance/resource.tf
+++ b/examples/resources/duplocloud_rds_instance/resource.tf
@@ -44,7 +44,7 @@ resource "duplocloud_rds_instance" "aurora-mydb" {
 
 //performance insights example
 resource "duplocloud_rds_instance" "mydb" {
-  tenant_id      = "5d3171c2-0fbc-4195-bb5e-05cd757ef786"
+  tenant_id      = duplocloud_tenant.myapp.tenant_id
   name           = "mydb1psql"
   engine         = 1 // PostgreSQL
   engine_version = "14.11"
@@ -57,9 +57,8 @@ resource "duplocloud_rds_instance" "mydb" {
   store_details_in_secret_manager = true
   enhanced_monitoring             = 0
   storage_type                    = "gp2"
-  # parameter_group_name = "psql-group"
   performance_insights {
-    enable           = false
+    enabled          = true
     retention_period = 7
   }
 }


### PR DESCRIPTION
### **User description**
## Overview

Rename attribute and delay fix
## Summary of changes
Renamed attribute enable to enabled.
Fixed Delay issue for performance insights
This PR does the following:

- Renamed attribute enable to enabled
- Moved performance insights body as part of post request in create context
- Updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Renamed the `enable` attribute to `enabled` for performance insights in the RDS instance schema.
- Updated the logic to handle the performance insights configuration, including the removal of redundant update code.
- Updated the documentation to reflect the renaming of the attribute.
- Modified example resource configuration to use the new `enabled` attribute.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_instance.go</strong><dd><code>Refactor performance insights attribute and logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_rds_instance.go

<li>Renamed <code>enable</code> attribute to <code>enabled</code> for performance insights.<br> <li> Updated logic to handle performance insights configuration.<br> <li> Removed redundant performance insights update code.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/674/files#diff-a8bf9b56a3e9b39899a5d37d7608110678908754e0848fab2d0320653ea65f71">+18/-27</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>rds_instance.md</strong><dd><code>Update documentation for performance insights attribute</code>&nbsp; &nbsp; </dd></summary>
<hr>

docs/resources/rds_instance.md

<li>Updated documentation to reflect the renaming of <code>enable</code> to <code>enabled</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/674/files#diff-2be785952795586c48f30db78e5f3684f72a430f66155dd8ea0d85f0607eedb7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource.tf</strong><dd><code>Update example for performance insights attribute</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/resources/duplocloud_rds_instance/resource.tf

<li>Changed example to use <code>enabled</code> instead of <code>enable</code> for performance <br>insights.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/674/files#diff-4461dc184c959908eb1db51855cf42bfafd849c340d3632e8da923f5a5a6240d">+2/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

