### PR TITLE
DUPLO-21079 Mask SSM parameter of type secret string in terraform logs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Enhanced
 
+- Masked sensitive information in Terraform logs by marking SSM parameter values as sensitive.
+- Updated documentation to reflect changes in sensitivity for SSM parameter values.
+
+## 2024-09-06
+
+### Enhanced
+
 - Updated GitHub Actions workflows with new user and email configurations for improved consistency and management.
 - Added a new README file with instructions for development and debugging.
 - Updated Terraform provider version to 0.10.43 across various example configurations.

--- a/docs/data-sources/aws_ssm_parameter.md
+++ b/docs/data-sources/aws_ssm_parameter.md
@@ -29,4 +29,4 @@ description: |-
 - `last_modified_date` (String)
 - `last_modified_user` (String)
 - `type` (String)
-- `value` (String)
+- `value` (String, Sensitive)

--- a/docs/resources/aws_ssm_parameter.md
+++ b/docs/resources/aws_ssm_parameter.md
@@ -34,7 +34,7 @@ resource "duplocloud_aws_ssm_parameter" "ssm_param" {
 - `name` (String) The name of the SSM parameter.
 - `tenant_id` (String) The GUID of the tenant that the SSM parameter will be created in.
 - `type` (String) The type of the SSM parameter. Valid values are `String`, `StringList`, and `SecureString`.
-- `value` (String) The value of the SSM parameter.
+- `value` (String, Sensitive) The value of the SSM parameter.
 
 ### Optional
 

--- a/duplocloud/data_source_duplo_aws_ssm_parameter.go
+++ b/duplocloud/data_source_duplo_aws_ssm_parameter.go
@@ -27,8 +27,9 @@ func dataSourceAwsSsmParameter() *schema.Resource {
 				Computed: true,
 			},
 			"value": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
 			},
 			"key_id": {
 				Type:     schema.TypeString,

--- a/duplocloud/resource_duplo_aws_ssm_parameter.go
+++ b/duplocloud/resource_duplo_aws_ssm_parameter.go
@@ -44,6 +44,7 @@ func awsSsmParameterSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Required:    true,
 			ForceNew:    false,
+			Sensitive:   true,
 		},
 		"description": {
 			Description: "The description of the SSM parameter.",


### PR DESCRIPTION
### **User description**
## Overview

Mask ssm parameter value 
## Summary of changes

This PR does the following:

- Added sensitive property to value attribute for duplocloud_aws_ssm_parameter for datasource and resource
- Updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Added `Sensitive: true` to the `value` attribute for both the SSM parameter data source and resource to ensure sensitive information is masked in logs.
- Updated the documentation to reflect the change in sensitivity for the `value` attribute in both data source and resource.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>data_source_duplo_aws_ssm_parameter.go</strong><dd><code>Mark SSM parameter value as sensitive in data source</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/data_source_duplo_aws_ssm_parameter.go

<li>Added <code>Sensitive: true</code> to the <code>value</code> attribute in the SSM parameter data <br>source.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/677/files#diff-9840d2a08f3ff1c3f287ef4156c90bca212fabe223744239ad2a1bd614855038">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_aws_ssm_parameter.go</strong><dd><code>Mark SSM parameter value as sensitive in resource</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_aws_ssm_parameter.go

<li>Added <code>Sensitive: true</code> to the <code>value</code> attribute in the SSM parameter <br>resource.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/677/files#diff-c2481cca893f2c5fa066e9821a004883b945851509f65b0163098f293f118fd9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>aws_ssm_parameter.md</strong><dd><code>Update data source documentation for sensitive value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/data-sources/aws_ssm_parameter.md

- Updated documentation to mark `value` as sensitive in data source.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/677/files#diff-352c3653cbd3500c4a051aa92f713fc9310dc6eaba417292253d5bf0c0bf765f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>aws_ssm_parameter.md</strong><dd><code>Update resource documentation for sensitive value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/resources/aws_ssm_parameter.md

- Updated documentation to mark `value` as sensitive in resource.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/677/files#diff-8c36c5999adb4ff41ad2a2462ee90b2dd40a5cb684a0312b48914eb72008a857">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

