### PR TITLE
DUPLO-21171 fix: consider performance insight configurations when creating aurora db writer instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 2024-09-06
 
+### Fixed
+- Enabled performance insights configuration for Aurora DB instances, ensuring consistent application across all RDS types.
+
+## 2024-09-06
+
 ### Enhanced
 
 - Updated GitHub Actions workflows with new user and email configurations for improved consistency and management.

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -789,17 +789,14 @@ func rdsInstanceFromState(d *schema.ResourceData) (*duplosdk.DuploRdsInstance, e
 		return nil, errors.New("multi_az and availability_zone can not be set together.")
 	}
 	duploObject.DatabaseName = d.Get("db_name").(string)
-	if !isAuroraDB(d) {
-		pI := expandPerformanceInsight(d)
-		if pI != nil {
+	pI := expandPerformanceInsight(d)
+	if pI != nil {
 
-			period := pI["retention_period"].(int)
-			kmsid := pI["kms_key_id"].(string)
-			duploObject.EnablePerformanceInsights = pI["enabled"].(bool)
-			duploObject.PerformanceInsightsRetentionPeriod = period
-			duploObject.PerformanceInsightsKMSKeyId = kmsid
-
-		}
+		period := pI["retention_period"].(int)
+		kmsid := pI["kms_key_id"].(string)
+		duploObject.EnablePerformanceInsights = pI["enabled"].(bool)
+		duploObject.PerformanceInsightsRetentionPeriod = period
+		duploObject.PerformanceInsightsKMSKeyId = kmsid
 
 	}
 	return duploObject, nil


### PR DESCRIPTION
### **User description**
## Overview

Include performance insight configuration for Aurora db type RDS instances

## Summary of changes

This PR does the following:

- Include performance insight configuration when RDS instance is an Aurora db type

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

No

## Sanity checking

Applying create for 
```
data "duplocloud_tenant" "nondefault" {
  name = "non-default"
}

resource "duplocloud_rds_instance" "app" {
  tenant_id      = data.duplocloud_tenant.nondefault.id
  name           = "tf-aurora-enable3"
  engine         = 8 
  engine_version = "8.0.mysql_aurora.3.07.1"
  size           = "db.r5.large"
  master_username              = "myuser"
  master_password              = "random_password.mypassword.result"
  encrypt_storage         = true
  backup_retention_period = 10
  db_name         =  "auroradb"
  skip_final_snapshot = true
  store_details_in_secret_manager = true
  performance_insights {
    enabled = true
    retention_period  = 7
  }
}
```
<img width="1167" alt="image" src="https://github.com/user-attachments/assets/644bb594-5655-4646-8703-d3935e3e921e">


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Removed the conditional check that prevented performance insights configuration for Aurora DB instances, ensuring consistent application across all RDS types.
- Updated the changelog to document the fix for enabling performance insights on Aurora DB instances.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_instance.go</strong><dd><code>Enable performance insights for Aurora DB instances</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_rds_instance.go

<li>Removed conditional check for Aurora DB when setting performance <br>insights.<br> <li> Unified performance insights configuration for all RDS instances.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/678/files#diff-a8bf9b56a3e9b39899a5d37d7608110678908754e0848fab2d0320653ea65f71">+8/-11</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with performance insights fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented the fix for enabling performance insights on Aurora DB <br>instances.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/678/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

