### PR TITLE
Duplo-21171 RDS TF: Performance insight enable is not working for Cluster DB writer instance. it works when enabled through the API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ### Enhanced
 
+- Improved RDS instance validation with a new `CustomizeDiff` function to ensure compatibility of engine and instance size combinations.
+- Streamlined performance insights handling for RDS instances, enhancing the enabling and disabling process.
+- Added validation for Aurora database storage types to ensure correct configuration.
+- Included a new example in the documentation for configuring performance insights on a cluster RDS instance.
+
+## 2024-09-06
+
+### Enhanced
+
 - Updated GitHub Actions workflows with new user and email configurations for improved consistency and management.
 - Added a new README file with instructions for development and debugging.
 - Updated Terraform provider version to 0.10.43 across various example configurations.

--- a/examples/resources/duplocloud_rds_instance/resource.tf
+++ b/examples/resources/duplocloud_rds_instance/resource.tf
@@ -62,3 +62,25 @@ resource "duplocloud_rds_instance" "mydb" {
     retention_period = 7
   }
 }
+
+#performance insigts example for cluster
+
+resource "duplocloud_rds_instance" "mydb" {
+  tenant_id      = duplocloud_tenant.myapp.tenant_id
+  name           = "clust"
+  engine         = 8
+  engine_version = "8.0.mysql_aurora.3.07.1"
+  size           = "db.r5.large"
+
+  master_username = "myuser"
+  master_password = "Qaazwedd#1"
+
+  encrypt_storage                 = true
+  store_details_in_secret_manager = true
+  enhanced_monitoring             = 0
+  storage_type                    = "aurora"
+  performance_insights {
+    enabled          = true
+    retention_period = 7
+  }
+}


### PR DESCRIPTION
### **User description**
## Overview

Implemented rds parameter validation and allowed cluster db creation and update for performance insights
## Summary of changes

Implemented validation on rds instance that support performance insight and checking storage_type for aurora dbs for duplocloud_rds_instance resource

This PR does the following:

- Added customdiff function for rds parameter validation
- Added example of cluster db for performance insights
- Updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Implemented a new `CustomizeDiff` function to validate RDS parameters, ensuring compatibility of engine and instance size combinations.
- Streamlined the process of enabling and disabling performance insights for RDS instances.
- Added validation for Aurora database storage types to ensure correct configuration.
- Updated documentation with a new example for configuring performance insights on a cluster RDS instance.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_instance.go</strong><dd><code>Enhance RDS instance validation and performance insights handling</code></dd></summary>
<hr>

duplocloud/resource_duplo_rds_instance.go

<li>Added <code>CustomizeDiff</code> function for RDS parameter validation.<br> <li> Streamlined performance insights handling for RDS instances.<br> <li> Removed Aurora DB check for performance insights.<br> <li> Added validation for Aurora database storage types.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/681/files#diff-a8bf9b56a3e9b39899a5d37d7608110678908754e0848fab2d0320653ea65f71">+95/-33</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update CHANGELOG with RDS validation enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented improvements in RDS instance validation.<br> <li> Added details on performance insights handling.<br> <li> Included example for cluster RDS instance configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/681/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource.tf</strong><dd><code>Add example for cluster RDS instance with performance insights</code></dd></summary>
<hr>

examples/resources/duplocloud_rds_instance/resource.tf

- Added example for performance insights on cluster RDS instance.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/681/files#diff-4461dc184c959908eb1db51855cf42bfafd849c340d3632e8da923f5a5a6240d">+22/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

