### PR TITLE
DUPLO-21150: TF Doc: Update doc to include samples for Redis logging configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2024-09-07
+
+### Documentation
+
+- Added examples for configuring Redis logging and automatic failover in Amazon ElastiCache documentation.
+- Updated schema description for `destination_type` in Redis configuration, removing outdated reference links.
+
 ## 2024-09-06
 
 ### Enhanced

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -194,10 +194,9 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"destination_type": {
-						Description: "destination type : must be cloudwatch-logs.\n" +
-							"Refer: https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/CLI_Log.html",
-						Type:     schema.TypeString,
-						Required: true,
+						Description: "destination type : must be cloudwatch-logs.",
+						Type:        schema.TypeString,
+						Required:    true,
 						ValidateFunc: validation.StringInSlice([]string{
 							duplosdk.REDIS_LOG_DELIVERYDIST_DEST_TYPE_CLOUDWATCH_LOGS,
 						}, false),

--- a/templates/resources/ecache_instance.md.tmpl
+++ b/templates/resources/ecache_instance.md.tmpl
@@ -59,6 +59,41 @@ resource "duplocloud_ecache_instance" "redis_cache" {
 }
 ```
 
+### Create an Amazon ElastiCache of type Redis with log delivery configuration and automatic failover enabled in dev tenant.
+
+
+```terraform
+# Assuming the 'dev' tenant is already created, use a data source to fetch the tenant ID.
+data "duplocloud_tenant" "tenant" {
+  name = "dev"
+}
+
+# Use the tenant_id from the duplocloud_tenant, which will be populated after the tenant resource is created, when setting up the Redis ElastiCache.
+resource "duplocloud_ecache_instance" "redis_cache" {
+  tenant_id           = data.duplocloud_tenant.tenant.id
+  name                = "mycache"
+  cache_type          = 0 # 0: Redis, 1: Memcache
+  replicas            = 2
+  size                = "cache.t2.small"
+  automatic_failover_enabled = true # minimum 2 replicas or enable_cluster_mode is true
+
+  log_delivery_configuration {
+    log_group        = "/elasticache/redis" # cloudwatch log group
+    destination_type = "cloudwatch-logs"
+    log_format       = "text" # log_format in text format.
+    log_type         = "slow-log"  # log_type of type low-log
+  }
+
+  log_delivery_configuration {
+    log_group        = "/elasticache/redis" # cloudwatch log group
+    destination_type = "cloudwatch-logs"
+    log_format       = "json" # log_format in json format.
+    log_type         = "engine-log" # log_type of type low-log
+  }
+}
+
+```
+
 ### Set up an ElastiCache Redis cluster with 2 shards and 2 cache.t2.small replicas in the dev tenant.
 
 ```terraform


### PR DESCRIPTION
### **User description**
## Overview

DUPLO-21150: TF Doc: Update doc to include samples for Redis logging configuration

## Summary of changes

This PR does the following:

- add sample to templates
- ...

## Testing performed

- [ ] Using unit tests
- [X] Manually, on my local system
- [X] Manually, on a remote test system

## Describe any breaking changes

- None


___

### **PR Type**
Documentation, Enhancement


___

### **Description**
- Added new documentation examples for creating an Amazon ElastiCache of type Redis with log delivery configuration and automatic failover enabled.
- Updated the Go schema description for `destination_type` by removing the reference link.
- Enhanced the documentation by providing detailed examples for log delivery configuration in both Markdown and template files.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_ecache_instance.go</strong><dd><code>Update schema description for destination type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_ecache_instance.go

<li>Updated the description for <code>destination_type</code> in the schema.<br> <li> Removed the reference link from the description.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/682/files#diff-0d4e960f6d6fea601a3f043c811148ed9f58959f772948285f4a11cc38708a0c">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ecache_instance.md</strong><dd><code>Add Redis log delivery configuration example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/resources/ecache_instance.md

<li>Added a new example for Redis with log delivery configuration.<br> <li> Removed reference link from the required section.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/682/files#diff-043ac248497c05f1e877b1714946cf707b361bbd70c813e754295d7750a58398">+35/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>ecache_instance.md.tmpl</strong><dd><code>Add Redis log delivery configuration example template</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

templates/resources/ecache_instance.md.tmpl

- Added a new example for Redis with log delivery configuration.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/682/files#diff-592f88c194371d524f191ae54225812b0e26e0659475704b0132909cecfee8e9">+35/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

