### PR TITLE
Duplo 21203 Performance Insight Regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 2024-09-09
 
+### Enhanced
+
+- Improved RDS instance update logic to handle Aurora DB clusters separately, including performance insights updates.
+- Modified storage type validation to allow empty values for Aurora DBs.
+
+## 2024-09-09
+
 ### Configuration
 
 - Updated GitHub bot user email and credentials in multiple workflow files.

--- a/duplocloud/resource_duplo_azure_k8_node_pool.go
+++ b/duplocloud/resource_duplo_azure_k8_node_pool.go
@@ -120,7 +120,6 @@ func duploAgentK8NodePoolSchema() map[string]*schema.Schema {
 			Type:        schema.TypeSet,
 			Optional:    true,
 			Computed:    true,
-			ForceNew:    true,
 			Elem: &schema.Schema{Type: schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"1", "2", "3"}, true),
 			},

--- a/duplocloud/resource_duplo_azure_k8_node_pool.go
+++ b/duplocloud/resource_duplo_azure_k8_node_pool.go
@@ -120,6 +120,7 @@ func duploAgentK8NodePoolSchema() map[string]*schema.Schema {
 			Type:        schema.TypeSet,
 			Optional:    true,
 			Computed:    true,
+			ForceNew:    true,
 			Elem: &schema.Schema{Type: schema.TypeString,
 				ValidateFunc: validation.StringInSlice([]string{"1", "2", "3"}, true),
 			},

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -305,6 +305,25 @@ func (c *Client) UpdateDBInstancePerformanceInsight(tenantID string, duploObject
 	return err
 }
 
+func (c *Client) UpdateDBClusterPerformanceInsight(tenantID string, duploObject DuploRdsUpdatePerformanceInsights) ClientError {
+	if duploObject.Enable != nil {
+		err := c.putAPI(
+			fmt.Sprintf("UpdateDBClusterPerformanceInsight(%s, %s)", tenantID, duploObject.DBInstanceIdentifier),
+			fmt.Sprintf("v3/subscriptions/%s/aws/rds/cluster/%s", tenantID, duploObject.DBInstanceIdentifier),
+			duploObject.Enable,
+			nil,
+		)
+		return err
+	}
+	err := c.putAPI(
+		fmt.Sprintf("UpdateDBClusterPerformanceInsight(%s, %s)", tenantID, duploObject.DBInstanceIdentifier),
+		fmt.Sprintf("v3/subscriptions/%s/aws/rds/cluster/%s", tenantID, duploObject.DBInstanceIdentifier),
+		duploObject.Disable,
+		nil,
+	)
+	return err
+}
+
 func (c *Client) UpdateRdsCluster(tenantID string, duploObject DuploRdsUpdateCluster) ClientError {
 	return c.putAPI(
 		fmt.Sprintf("UpdateRdsCluster(%s, %s)", tenantID, duploObject.DBClusterIdentifier),


### PR DESCRIPTION
### **User description**
## Overview

Allowing storage_type if empty for aurora dbs. Added un staged changes related to cluster
## Summary of changes

This PR does the following:

- Added un staged  code related to cluster update
- Updated storage_type allow logic in customdiff function

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Enhanced the RDS instance update logic to handle Aurora DB clusters separately by appending "-cluster" to the `DBInstanceIdentifier`.
- Added a new function `UpdateDBClusterPerformanceInsight` to support performance insights updates for DB clusters.
- Modified storage type validation to allow empty values, specifically for Aurora DBs.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_instance.go</strong><dd><code>Enhance RDS instance update logic for Aurora DBs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_rds_instance.go

<li>Added logic to handle Aurora DB clusters separately.<br> <li> Modified <code>DBInstanceIdentifier</code> to append "-cluster" for Aurora DBs.<br> <li> Updated storage type validation to allow empty values.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/685/files#diff-a8bf9b56a3e9b39899a5d37d7608110678908754e0848fab2d0320653ea65f71">+14/-5</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rds_instance.go</strong><dd><code>Add support for updating DB cluster performance insights</code>&nbsp; </dd></summary>
<hr>

duplosdk/rds_instance.go

<li>Added a new function <code>UpdateDBClusterPerformanceInsight</code>.<br> <li> Implemented API calls for updating performance insights for DB <br>clusters.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/685/files#diff-3aeb597ae11ae40342366a786a3b78f55a1265ea03d8d2729401d9a7f3b7291a">+19/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

