### PR TITLE
DUPLO-21171 hotfix: apply aurora perf insights validation only if performance insights is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 2024-09-09
 
+### Fixed
+
+- Applied Aurora performance insights validation only when performance insights are enabled, preventing unnecessary validation errors.
+
+## 2024-09-09
+
 ### Enhanced
 
 - Added `ForceNew` property to `availability_zones` in `duplocloud_azure_k8_node_pool` to ensure resource replacement on updates.

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -1014,7 +1014,13 @@ func validateRDSParameters(ctx context.Context, diff *schema.ResourceDiff, m int
 		16: "Aurora",
 	}
 	eng := diff.Get("engine").(int)
-	if v, ok := nonsup[eng]; ok {
+	perf_insights_enabled := false
+	perf_insights_configuration_list := diff.Get("performance_insights").([]interface{})
+	if len(perf_insights_configuration_list) > 0 {
+		perf_insights_configuration := perf_insights_configuration_list[0].(map[string]interface{})
+		perf_insights_enabled = perf_insights_configuration["enabled"].(bool)
+	}
+	if v, ok := nonsup[eng]; perf_insights_enabled && ok {
 		s := diff.Get("size").(string)
 		if _, ok := v[s]; ok {
 			if engines[eng] == "DocumentDB" {


### PR DESCRIPTION
### **User description**
## Overview

Ignore aurora type compatibility with performance insights if performance insights is not enabled

## Summary of changes

This PR does the following:

- Ignore aurora type compatibility with performance insights if performance insights is not enabled

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

No

## Sanity check

Incompatible perf insights aurora db size and perf insights enabled
<img width="952" alt="image" src="https://github.com/user-attachments/assets/5e3a2f48-a9bf-4845-b9c1-0bc470cb61ba">

Incompatible perf insights aurora db size and perf insights disabled
<img width="943" alt="image" src="https://github.com/user-attachments/assets/14507bb3-662a-40b0-8457-ac60b91d193b">

Compatible aurora db size with perf insights enabled
<img width="947" alt="image" src="https://github.com/user-attachments/assets/a5a3862f-e2cf-4160-9e49-9f1d77e418e2">

Compatible aurora db size with perf insights disabled
<img width="946" alt="image" src="https://github.com/user-attachments/assets/262ffc39-a89e-48dc-b36c-2fe51e8bbd8f">


___

### **PR Type**
Bug fix


___

### **Description**
- Added logic to check if performance insights are enabled before applying Aurora type compatibility validation.
- Modified the validation function to prevent errors when performance insights are not enabled.
- This change ensures that the system only validates performance insights compatibility for Aurora when it is actually enabled, preventing unnecessary validation errors.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_instance.go</strong><dd><code>Conditional Aurora Performance Insights Validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_rds_instance.go

<li>Added a check for performance insights configuration.<br> <li> Ensured validation of Aurora performance insights only if enabled.<br> <li> Modified logic to handle performance insights compatibility.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/690/files#diff-a8bf9b56a3e9b39899a5d37d7608110678908754e0848fab2d0320653ea65f71">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

