### PR TITLE
DUPLO-21174 TF: RDS: Update of 'Availability Zone' shows 'update in-place' for resource 'duplocloud_rds_instance'

### DIFF
--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -328,6 +328,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Computed: true,
 			Optional: true,
+			ForceNew: true,
 		},
 	}
 }
@@ -897,15 +898,15 @@ func rdsInstanceToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Resour
 	jo["enhanced_monitoring"] = duploObject.MonitoringInterval
 	jo["db_name"] = duploObject.DatabaseName
 
-	pis := []interface{}{}
-	pi := make(map[string]interface{})
-	pi["enabled"] = duploObject.EnablePerformanceInsights
 	if duploObject.EnablePerformanceInsights {
+		pis := []interface{}{}
+		pi := make(map[string]interface{})
+		pi["enabled"] = duploObject.EnablePerformanceInsights
 		pi["retention_period"] = duploObject.PerformanceInsightsRetentionPeriod
 		pi["kms_key_id"] = duploObject.PerformanceInsightsKMSKeyId
+		pis = append(pis, pi)
+		jo["performance_insights"] = pis
 	}
-	pis = append(pis, pi)
-	jo["performance_insights"] = pis
 	jsonData2, _ := json.Marshal(jo)
 	log.Printf("[TRACE] duplo-RdsInstanceToState ******** 2: OUTPUT => %s ", string(jsonData2))
 

--- a/duplocloud/resource_duplo_rds_read_replica.go
+++ b/duplocloud/resource_duplo_rds_read_replica.go
@@ -484,16 +484,16 @@ func rdsReadReplicaToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Res
 		clusterIdentifier = duploObject.ReplicationSourceIdentifier
 	}
 	jo["cluster_identifier"] = clusterIdentifier
-	pis := []interface{}{}
-	pi := make(map[string]interface{})
-	pi["enabled"] = duploObject.EnablePerformanceInsights
 	if duploObject.EnablePerformanceInsights {
+
+		pis := []interface{}{}
+		pi := make(map[string]interface{})
+		pi["enabled"] = duploObject.EnablePerformanceInsights
 		pi["retention_period"] = duploObject.PerformanceInsightsRetentionPeriod
 		pi["kms_key_id"] = duploObject.PerformanceInsightsKMSKeyId
+		pis = append(pis, pi)
+		jo["performance_insights"] = pis
 	}
-	pis = append(pis, pi)
-	jo["performance_insights"] = pis
-
 	jsonData2, _ := json.Marshal(jo)
 	log.Printf("[TRACE] duplo-RdsInstanceToState ******** 2: OUTPUT => %s ", jsonData2)
 


### PR DESCRIPTION

## Overview

Force New availability_zone. Ignore performance insight set if not enable in duplocloud_rds_instance' resource
## Summary of changes
Made availablity zone force replacement on change. 
Handled condition at performance insights state value set if not enable to avoid unwanted diff 

This PR does the following:

- Added force new property to availablity_zone attribute.
- Updated condition to ignore performance insights value to be set if not enable to avoid diff

## Testing performed

- [ ] Using unit tests
- [ ✓] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
