### PR TITLE
DUPLO-17188 TF:GCP: allowed to create tenant with google in it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2024-09-13
+
+### Enhanced
+
+- Implemented validation to restrict tenant creation in GCP cloud if the tenant name contains the keyword 'google'.
+
 ## 2024-09-12
 
 ### Enhanced

--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -180,7 +180,7 @@ func resourceTenantCreate(ctx context.Context, d *schema.ResourceData, m interfa
 		return diag.Errorf("Unable to retrieve duplo infrastructure '%s': %s", rq.PlanID, err)
 	}
 	if infra.Cloud == GCP_CLOUD && strings.Contains(rq.AccountName, "google") {
-		return diag.Errorf("Restricted use of keyword google in account_name for gcp cloud")
+		return diag.Errorf("Use of reserved keyword 'google', not allowed to create tenant in gcp cloud")
 	}
 	if infra.Cloud == 2 {
 		_, err = c.TenantCreateAzure(rq)

--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -179,7 +179,7 @@ func resourceTenantCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	if err != nil {
 		return diag.Errorf("Unable to retrieve duplo infrastructure '%s': %s", rq.PlanID, err)
 	}
-	if infra.Cloud == GCP_CLOUD && strings.Contains(rq.AccountName, "google") {
+	if infra.Cloud == GCP_CLOUD && strings.Contains(strings.ToLower(rq.AccountName), "google") {
 		return diag.Errorf("Use of reserved keyword 'google', not allowed to create tenant in gcp cloud")
 	}
 	if infra.Cloud == 2 {

--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -179,7 +179,9 @@ func resourceTenantCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	if err != nil {
 		return diag.Errorf("Unable to retrieve duplo infrastructure '%s': %s", rq.PlanID, err)
 	}
-
+	if infra.Cloud == GCP_CLOUD && strings.Contains(rq.AccountName, "google") {
+		return diag.Errorf("Restricted use of keyword google in account_name for gcp cloud")
+	}
 	if infra.Cloud == 2 {
 		_, err = c.TenantCreateAzure(rq)
 	} else {

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -27,6 +27,7 @@ const (
 	MAX_DUPLOSERVICES_LENGTH            = len("duploservices-1234567890ab-")
 	MAX_DUPLOSERVICES_AND_SUFFIX_LENGTH = len("duploservices-1234567890ab--1234567890ab")
 	RDS_DOCUMENT_DB_ENGINE              = 13
+	GCP_CLOUD                           = 3
 )
 
 // Utility function to make a single schema element computed.


### PR DESCRIPTION
### **User description**
## Overview

Added validation for tenant name for gcp cloud

## Summary of changes
Restricting tenant creation for gcp cloud if tenant name contains google key word in `duplocloud_tenant` resource

This PR does the following:

- Implemented validation on tenant name for cloud=3 (gcp) to restrict use of google keyword
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Implemented validation to restrict tenant creation in GCP cloud if the tenant name contains the keyword 'google'.
- Defined a constant `GCP_CLOUD` to represent the GCP cloud identifier.
- Updated `CHANGELOG.md` to document the new validation feature.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_tenant.go</strong><dd><code>Add validation for tenant name in GCP cloud</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_tenant.go

<li>Added validation to restrict tenant creation in GCP cloud.<br> <li> Checks if the tenant name contains the keyword 'google'.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/704/files#diff-fd738e9bb1cb4f0e03eed01292440c2c79dc914139da1f32e1ebacf2ede9b861">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>utils.go</strong><dd><code>Define constant for GCP cloud identifier</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/utils.go

- Defined a constant for GCP cloud identifier.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/704/files#diff-a8b0d524e2d08c8969f058ead081e31847409515b2417bfcbfcdf83cf79a1b9e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with GCP tenant validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented the enhancement for tenant name validation in GCP cloud.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/704/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

