### PR TITLE
DUPLO-21209 DUPLO-21302

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2024-09-13
+
+### Enhanced
+
+- Added `DiffSuppressFunc` to suppress diffs for `performance_insights` when disabled in RDS instance and read replica schemas.
+- Modified logic to always set `performance_insights` state, regardless of enablement status.
+
+### Documentation
+
+- Updated documentation to specify that the retention period for DocumentDB is 7 days.
+
 ## 2024-09-12
 
 ### Enhanced

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -396,7 +396,7 @@ Optional:
 
 - `enabled` (Boolean) Turn on or off Performance Insights Defaults to `false`.
 - `kms_key_id` (String) Specify ARN for the KMS key to encrypt Performance Insights data.
-- `retention_period` (Number) Specify retention period in Days. Valid values are 7, 731 (2 years) or a multiple of 31 Defaults to `7`.
+- `retention_period` (Number) Specify retention period in Days. Valid values are 7, 731 (2 years) or a multiple of 31. For Document DB retention period is 7 Defaults to `7`.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/rds_read_replica.md
+++ b/docs/resources/rds_read_replica.md
@@ -167,7 +167,7 @@ Optional:
 
 - `enabled` (Boolean) Turn on or off Performance Insights Defaults to `false`.
 - `kms_key_id` (String) Specify ARN for the KMS key to encrypt Performance Insights data.
-- `retention_period` (Number) Specify retention period in Days. Valid values are 7, 731 (2 years) or a multiple of 31 Defaults to `7`.
+- `retention_period` (Number) Specify retention period in Days. Valid values are 7, 731 (2 years) or a multiple of 31. For Document DB retention period is 7 Defaults to `7`.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -1090,9 +1090,9 @@ func performanceInsightsWaitUntilEnabled(ctx context.Context, c *duplosdk.Client
 func suppressIfPerformanceInsightsDisabled(k, old, new string, d *schema.ResourceData) bool {
 	// Check if the `enable` field is set to false
 	oldPI, newPI := d.GetChange("performance_insights.0.enabled")
-	if oldPI.(bool) == false && newPI.(bool) == false {
+	if !oldPI.(bool) && !newPI.(bool) {
 		return true
-	} else if oldPI.(bool) == true && newPI.(bool) == true {
+	} else if oldPI.(bool) && newPI.(bool) {
 		if d.HasChange("performance_insights.0.kms_key_id") || d.HasChange("performance_insights.0.retention_period") {
 			return false
 		}

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -290,10 +290,11 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.IntInSlice([]int{0, 1, 5, 10, 15, 30, 60}),
 		},
 		"performance_insights": {
-			Description: "Amazon RDS Performance Insights is a database performance tuning and monitoring feature that helps you quickly assess the load on your database, and determine when and where to take action. Perfomance Insights get apply when enable is set to true.",
-			Type:        schema.TypeList,
-			MaxItems:    1,
-			Optional:    true,
+			Description:      "Amazon RDS Performance Insights is a database performance tuning and monitoring feature that helps you quickly assess the load on your database, and determine when and where to take action. Perfomance Insights get apply when enable is set to true.",
+			Type:             schema.TypeList,
+			MaxItems:         1,
+			Optional:         true,
+			DiffSuppressFunc: suppressIfPerformanceInsightsDisabled,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"enabled": {
@@ -309,7 +310,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 						Computed:    true,
 					},
 					"retention_period": {
-						Description: "Specify retention period in Days. Valid values are 7, 731 (2 years) or a multiple of 31",
+						Description: "Specify retention period in Days. Valid values are 7, 731 (2 years) or a multiple of 31. For Document DB retention period is 7",
 						Type:        schema.TypeInt,
 						Optional:    true,
 						Default:     7,
@@ -898,15 +899,13 @@ func rdsInstanceToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Resour
 	jo["enhanced_monitoring"] = duploObject.MonitoringInterval
 	jo["db_name"] = duploObject.DatabaseName
 
-	if duploObject.EnablePerformanceInsights {
-		pis := []interface{}{}
-		pi := make(map[string]interface{})
-		pi["enabled"] = duploObject.EnablePerformanceInsights
-		pi["retention_period"] = duploObject.PerformanceInsightsRetentionPeriod
-		pi["kms_key_id"] = duploObject.PerformanceInsightsKMSKeyId
-		pis = append(pis, pi)
-		jo["performance_insights"] = pis
-	}
+	pis := []interface{}{}
+	pi := make(map[string]interface{})
+	pi["enabled"] = duploObject.EnablePerformanceInsights
+	pi["retention_period"] = duploObject.PerformanceInsightsRetentionPeriod
+	pi["kms_key_id"] = duploObject.PerformanceInsightsKMSKeyId
+	pis = append(pis, pi)
+	jo["performance_insights"] = pis
 	jsonData2, _ := json.Marshal(jo)
 	log.Printf("[TRACE] duplo-RdsInstanceToState ******** 2: OUTPUT => %s ", string(jsonData2))
 
@@ -1086,4 +1085,18 @@ func performanceInsightsWaitUntilEnabled(ctx context.Context, c *duplosdk.Client
 	log.Printf("[DEBUG] performanceInsightsWaitUntilAvailable (%s)", id)
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
+}
+
+func suppressIfPerformanceInsightsDisabled(k, old, new string, d *schema.ResourceData) bool {
+	// Check if the `enable` field is set to false
+	oldPI, newPI := d.GetChange("performance_insights.0.enabled")
+	if oldPI.(bool) == false && newPI.(bool) == false {
+		return true
+	} else if oldPI.(bool) == true && newPI.(bool) == true {
+		if d.HasChange("performance_insights.0.kms_key_id") || d.HasChange("performance_insights.0.retention_period") {
+			return false
+		}
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
### **User description**
## Overview

Validating Diff for performance insights. Updated documentation
## Summary of changes
Added diffsupressfunction on performance insights
This PR does the following:

- Validating diff based on enabled key on performance insights 
- Updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Added `DiffSuppressFunc` to suppress diffs for `performance_insights` when disabled in RDS instance and read replica schemas.
- Modified logic to always set `performance_insights` state, regardless of enablement status.
- Updated documentation to specify that the retention period for DocumentDB is 7 days.
- Enhanced descriptions and added a new function `suppressIfPerformanceInsightsDisabled` to handle suppression logic.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_instance.go</strong><dd><code>Enhance RDS instance schema with diff suppression</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_rds_instance.go

<li>Added <code>DiffSuppressFunc</code> for <code>performance_insights</code>.<br> <li> Updated logic to always set <code>performance_insights</code> state.<br> <li> Modified description for <code>retention_period</code>.<br> <li> Introduced <code>suppressIfPerformanceInsightsDisabled</code> function.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/705/files#diff-a8bf9b56a3e9b39899a5d37d7608110678908754e0848fab2d0320653ea65f71">+27/-14</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_read_replica.go</strong><dd><code>Enhance RDS read replica schema with diff suppression</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_rds_read_replica.go

<li>Added <code>DiffSuppressFunc</code> for <code>performance_insights</code>.<br> <li> Updated logic to always set <code>performance_insights</code> state.<br> <li> Modified description for <code>retention_period</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/705/files#diff-1ffdcfb6fc7a0fed517c0f77bbfb406b208cb1084f420e755eb9d029683dfdfe">+14/-15</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with recent enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented addition of <code>DiffSuppressFunc</code>.<br> <li> Updated retention period information for DocumentDB.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/705/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rds_instance.md</strong><dd><code>Update RDS instance documentation for retention period</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/resources/rds_instance.md

- Updated retention period description for DocumentDB.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/705/files#diff-2be785952795586c48f30db78e5f3684f72a430f66155dd8ea0d85f0607eedb7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rds_read_replica.md</strong><dd><code>Update RDS read replica documentation for retention period</code></dd></summary>
<hr>

docs/resources/rds_read_replica.md

- Updated retention period description for DocumentDB.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/705/files#diff-e223dad9b259eae20181173087aafb1d47d2eb221d1a7d6ba1493bd78aafc5af">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

