### PR TITLE
DUPLO-21304 fix: force rds replicas not to have perf insight configuration when they belong in an aurora cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Enhanced
 
+- Implemented validation to prevent Aurora read replicas from having performance insights configurations, as these are managed at the cluster level.
+
+## 2024-09-13
+
+### Enhanced
+
 - Added `DiffSuppressFunc` to suppress diffs for `performance_insights` when disabled in RDS instance and read replica schemas.
 - Modified logic to always set `performance_insights` state, regardless of enablement status.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,9 @@
 
 ### Enhanced
 
-- Implemented validation to prevent Aurora read replicas from having performance insights configurations, as these are managed at the cluster level.
-
-## 2024-09-13
-
-### Enhanced
-
 - Added `DiffSuppressFunc` to suppress diffs for `performance_insights` when disabled in RDS instance and read replica schemas.
 - Modified logic to always set `performance_insights` state, regardless of enablement status.
+- Implemented validation to prevent Aurora read replicas from having performance insights configurations, as these are managed at the cluster level.
 
 ### Documentation
 

--- a/docs/resources/rds_read_replica.md
+++ b/docs/resources/rds_read_replica.md
@@ -88,10 +88,12 @@ resource "duplocloud_rds_read_replica" "replica" {
   name               = "read-replica"
   size               = "db.r5.large"
   cluster_identifier = duplocloud_rds_instance.rds.cluster_identifier
-  performance_insights {
-    enabled          = true
-    retention_period = 7
-  }
+
+  // aurora db read replicas inherit performance insight configurations from its cluster's primary
+  // performance_insights {
+  //   enabled          = true
+  //   retention_period = 7
+  // }
 }
 
 //Performance insight example for instance db read replica

--- a/examples/resources/duplocloud_rds_read_replica/resource.tf
+++ b/examples/resources/duplocloud_rds_read_replica/resource.tf
@@ -73,10 +73,12 @@ resource "duplocloud_rds_read_replica" "replica" {
   name               = "read-replica"
   size               = "db.r5.large"
   cluster_identifier = duplocloud_rds_instance.rds.cluster_identifier
-  performance_insights {
-    enabled          = true
-    retention_period = 7
-  }
+
+  // aurora db read replicas inherit performance insight configurations from its cluster's primary
+  // performance_insights {
+  //   enabled          = true
+  //   retention_period = 7
+  // }
 }
 
 //Performance insight example for instance db read replica


### PR DESCRIPTION
### **User description**
## Overview

Because aurora db performance insights is currently managed at cluster scope, there is no point having performance insights configurations be allowed for such engine types. This may change in the future if we decide to support instance level management for performance insights in aurora engine type instances.

## Summary of changes

This PR does the following:

- Prevents creating new aurora read replicas with performance insight configuration set 
- Prevents adding performance insight configuration as an update to an existing aurora read replica

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

No

## Sanity Checking

plan
<img width="925" alt="image" src="https://github.com/user-attachments/assets/0db87155-a735-43d2-9883-6799c488a72e">

result
<img width="1069" alt="image" src="https://github.com/user-attachments/assets/60b7a129-16c6-4e5a-a95a-1cefd1bfc743">


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Added validation to prevent Aurora read replicas from having performance insights configurations, as these are managed at the cluster level.
- Updated documentation and examples to reflect changes in performance insights configuration for Aurora read replicas.
- Moved RDS instance validation logic to ensure correct order of operations.
- Updated the changelog to include recent enhancements and documentation updates.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_read_replica.go</strong><dd><code>Add validation for Aurora read replicas performance insights</code></dd></summary>
<hr>

duplocloud/resource_duplo_rds_read_replica.go

<li>Moved RDS instance validation after performance insights <br>configuration.<br> <li> Added validation to prevent Aurora read replicas from having <br>performance insights configurations.<br> <li> Introduced helper functions for engine type checks and performance <br>insights configuration checks.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/706/files#diff-1ffdcfb6fc7a0fed517c0f77bbfb406b208cb1084f420e755eb9d029683dfdfe">+44/-5</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with recent changes and enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented validation for Aurora read replicas performance insights.<br> <li> Updated changelog with recent enhancements and documentation changes.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/706/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+27/-26</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rds_read_replica.md</strong><dd><code>Update documentation for Aurora read replicas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/resources/rds_read_replica.md

<li>Commented out performance insights configuration for Aurora read <br>replicas.<br> <li> Added notes about Aurora read replicas inheriting configurations from <br>the cluster.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/706/files#diff-e223dad9b259eae20181173087aafb1d47d2eb221d1a7d6ba1493bd78aafc5af">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource.tf</strong><dd><code>Update example for Aurora read replicas configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/resources/duplocloud_rds_read_replica/resource.tf

<li>Commented out performance insights configuration for Aurora read <br>replicas.<br> <li> Added comments about configuration inheritance from the cluster.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/706/files#diff-3e5f9986f926543549bd2d58be9bb79a2277e56293965198b698e94a55e4d9ff">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

