### PR TITLE
DUPLO-21304 DUPLO-21209 Aurora/v2: replica tries to set value as nil for inplace update and inplace update fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 2024-09-16
+
+### Enhanced
+
+- Improved handling of Performance Insights configuration for RDS read replicas, particularly for Aurora clusters.
+- Enhanced RDS instance and read replica schemas by adding `DiffSuppressFunc` to suppress changes when Performance Insights is disabled.
+
+### Documentation
+
+- Updated documentation and examples to reflect changes in Performance Insights configuration, providing clearer guidance on referencing from primary resources.
+
 ## 2024-09-13
 
 ### Enhanced

--- a/docs/resources/rds_read_replica.md
+++ b/docs/resources/rds_read_replica.md
@@ -68,6 +68,7 @@ resource "duplocloud_rds_read_replica" "replica" {
 
 
 //Performance insight example for cluster db read replica
+//Performance insight for aurora cluster db is applied at cluster level
 resource "duplocloud_rds_instance" "rds" {
   tenant_id      = duplocloud_tenant.myapp.tenant_id
   name           = "clust"
@@ -80,21 +81,39 @@ resource "duplocloud_rds_instance" "rds" {
   encrypt_storage                 = true
   store_details_in_secret_manager = true
   enhanced_monitoring             = 0
-
+  performance_insights {
+    enabled          = false
+    retention_period = 31
+    kms_key_id       = "arn:aws:kms:us-west-2:182680712604:key/6b8dc967-92bf-43de-a850-ee7b945260f8"
+  }
 }
-
+//referencing performance insights block from writer or primary resource is must, 
+//to maintain tfstate to be in sync for performance insights block.
 resource "duplocloud_rds_read_replica" "replica" {
   tenant_id          = duplocloud_rds_instance.rds.tenant_id
   name               = "read-replica"
   size               = "db.r5.large"
   cluster_identifier = duplocloud_rds_instance.rds.cluster_identifier
-
-  // aurora db read replicas inherit performance insight configurations from its cluster's primary
-  // performance_insights {
-  //   enabled          = true
-  //   retention_period = 7
-  // }
+  performance_insights {
+    enabled          = duplocloud_rds_instance.rds.performance_insights.0.enabled
+    retention_period = duplocloud_rds_instance.rds.performance_insights.0.retention_period
+    kms_key_id       = duplocloud_rds_instance.rds.performance_insights.0.kms_key_id
+  }
 }
+
+resource "duplocloud_rds_read_replica" "replica2" {
+  tenant_id          = duplocloud_rds_instance.rds.tenant_id
+  name               = "read-replica2"
+  size               = "db.r5.large"
+  cluster_identifier = duplocloud_rds_instance.rds.cluster_identifier
+  performance_insights {
+    enabled          = duplocloud_rds_instance.rds.performance_insights.0.enabled
+    retention_period = duplocloud_rds_instance.rds.performance_insights.0.retention_period
+    kms_key_id       = duplocloud_rds_instance.rds.performance_insights.0.kms_key_id
+  }
+
+}
+
 
 //Performance insight example for instance db read replica
 resource "duplocloud_rds_instance" "mydb" {

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -1099,11 +1099,7 @@ func suppressIfPerformanceInsightsDisabled(k, old, new string, d *schema.Resourc
 			return false
 		}
 		return true
-	} //else if oldPI.(bool) && !newPI.(bool) {
-	//	if d.HasChange("performance_insights.0.kms_key_id") || d.HasChange("performance_insights.0.retention_period") {
-	//		return true
-	//	}
-	//}
+	}
 	return false
 }
 

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -304,10 +304,11 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 						Default:     false,
 					},
 					"kms_key_id": {
-						Description: "Specify ARN for the KMS key to encrypt Performance Insights data.",
-						Type:        schema.TypeString,
-						Optional:    true,
-						Computed:    true,
+						Description:      "Specify ARN for the KMS key to encrypt Performance Insights data.",
+						Type:             schema.TypeString,
+						Optional:         true,
+						Computed:         true,
+						DiffSuppressFunc: suppressKmsIfPerformanceInsightsDisabled,
 					},
 					"retention_period": {
 						Description: "Specify retention period in Days. Valid values are 7, 731 (2 years) or a multiple of 31. For Document DB retention period is 7",
@@ -318,6 +319,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 							validation.IntInSlice([]int{7, 731}),
 							validation.IntDivisibleBy(31),
 						),
+						DiffSuppressFunc: suppressRetentionPeriodIfPerformanceInsightsDisabled,
 					},
 				},
 			},
@@ -1090,13 +1092,39 @@ func performanceInsightsWaitUntilEnabled(ctx context.Context, c *duplosdk.Client
 func suppressIfPerformanceInsightsDisabled(k, old, new string, d *schema.ResourceData) bool {
 	// Check if the `enable` field is set to false
 	oldPI, newPI := d.GetChange("performance_insights.0.enabled")
-	if !oldPI.(bool) && !newPI.(bool) {
+	if !oldPI.(bool) && !newPI.(bool) { //both false return no change
 		return true
-	} else if oldPI.(bool) && newPI.(bool) {
+	} else if oldPI.(bool) && newPI.(bool) { //both true check if kms and retention period has change
 		if d.HasChange("performance_insights.0.kms_key_id") || d.HasChange("performance_insights.0.retention_period") {
 			return false
 		}
 		return true
+	} //else if oldPI.(bool) && !newPI.(bool) {
+	//	if d.HasChange("performance_insights.0.kms_key_id") || d.HasChange("performance_insights.0.retention_period") {
+	//		return true
+	//	}
+	//}
+	return false
+}
+
+func suppressKmsIfPerformanceInsightsDisabled(k, old, new string, d *schema.ResourceData) bool {
+	oldPI, newPI := d.GetChange("performance_insights.0.enabled")
+	if oldPI.(bool) && !newPI.(bool) {
+		if d.HasChange("performance_insights.0.kms_key_id") {
+			return true
+		}
 	}
 	return false
+
+}
+
+func suppressRetentionPeriodIfPerformanceInsightsDisabled(k, old, new string, d *schema.ResourceData) bool {
+	oldPI, newPI := d.GetChange("performance_insights.0.enabled")
+	if oldPI.(bool) && !newPI.(bool) {
+		if d.HasChange("performance_insights.0.retention_period") {
+			return true
+		}
+	}
+	return false
+
 }

--- a/duplocloud/resource_duplo_rds_read_replica.go
+++ b/duplocloud/resource_duplo_rds_read_replica.go
@@ -180,7 +180,7 @@ func resourceDuploRdsReadReplica() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 		Schema:        rdsReadReplicaSchema(),
-		CustomizeDiff: customdiff.All(validateRDSParameters), //, suppressClusterPerformanceInsightInReplica),
+		CustomizeDiff: customdiff.All(validateRDSParameters),
 	}
 }
 
@@ -540,20 +540,4 @@ func isEngineAuroraType(engineCode int) bool {
 func hasPerformanceInsightConfigurations(tfRdsReplicaSpecification *schema.ResourceData) bool {
 	configuration := tfRdsReplicaSpecification.Get("performance_insights").([]interface{})
 	return len(configuration) > 0
-}
-
-func suppressClusterPerformanceInsightInReplica(ctx context.Context, diff *schema.ResourceDiff, m interface{}) error {
-
-	eng := diff.Get("engine").(int)
-	if eng == 8 || eng == 9 || eng == 16 || eng == 11 || eng == 12 {
-		oldPI, _ := diff.GetChange("performance_insights")
-		list := oldPI.([]interface{})
-		if len(list) > 0 {
-			diff.SetNewComputed("performance_insights.0.enabled")
-			diff.SetNewComputed("performance_insights.0.retention_period")
-			diff.SetNewComputed("performance_insights.0.kms_key_id")
-
-		}
-	}
-	return nil
 }

--- a/duplocloud/resource_duplo_rds_read_replica.go
+++ b/duplocloud/resource_duplo_rds_read_replica.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -138,10 +139,11 @@ func rdsReadReplicaSchema() map[string]*schema.Schema {
 						Default:     false,
 					},
 					"kms_key_id": {
-						Description: "Specify ARN for the KMS key to encrypt Performance Insights data.",
-						Type:        schema.TypeString,
-						Optional:    true,
-						Computed:    true,
+						Description:      "Specify ARN for the KMS key to encrypt Performance Insights data.",
+						Type:             schema.TypeString,
+						Optional:         true,
+						Computed:         true,
+						DiffSuppressFunc: suppressKmsIfPerformanceInsightsDisabled,
 					},
 					"retention_period": {
 						Description: "Specify retention period in Days. Valid values are 7, 731 (2 years) or a multiple of 31. For Document DB retention period is 7",
@@ -152,6 +154,7 @@ func rdsReadReplicaSchema() map[string]*schema.Schema {
 							validation.IntInSlice([]int{7, 731}),
 							validation.IntDivisibleBy(31),
 						),
+						DiffSuppressFunc: suppressRetentionPeriodIfPerformanceInsightsDisabled,
 					},
 				},
 			},
@@ -176,8 +179,8 @@ func resourceDuploRdsReadReplica() *schema.Resource {
 			Update: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
-		Schema: rdsReadReplicaSchema(),
-		//CustomizeDiff: validateRDSParameters,
+		Schema:        rdsReadReplicaSchema(),
+		CustomizeDiff: customdiff.All(validateRDSParameters), //, suppressClusterPerformanceInsightInReplica),
 	}
 }
 
@@ -240,7 +243,7 @@ func resourceDuploRdsReadReplicaCreate(ctx context.Context, d *schema.ResourceDa
 
 	pI := expandPerformanceInsight(d)
 
-	if pI != nil && duplo.Engine != RDS_DOCUMENT_DB_ENGINE {
+	if pI != nil && duplo.Engine != RDS_DOCUMENT_DB_ENGINE && !validateReplicaPerformanceInsightsConfigurationAuroaDB(duplo.Engine, d) {
 
 		period := pI["retention_period"].(int)
 		kmsid := pI["kms_key_id"].(string)
@@ -254,11 +257,6 @@ func resourceDuploRdsReadReplicaCreate(ctx context.Context, d *schema.ResourceDa
 	errors := validateRdsInstance(duplo)
 	if len(errors) > 0 {
 		return errorsToDiagnostics(fmt.Sprintf("Cannot create RDS DB read replica: %s: ", id), errors)
-	}
-	// Validate read replica
-	replicaValidationErrors := validateReplicaPerformanceInsightsConfiguration(duplo.Engine, d)
-	if len(replicaValidationErrors) > 0 {
-		return errorsToDiagnostics(fmt.Sprintf("Cannot create RDS DB read replica: %s: ", id), replicaValidationErrors)
 	}
 
 	instResp, err := c.RdsInstanceCreate(tenantID, duplo)
@@ -329,26 +327,34 @@ func resourceDuploRdsReadReplicaUpdate(ctx context.Context, d *schema.ResourceDa
 	}
 	obj.DBInstanceIdentifier = identifier
 	// Validate read replica
-	replicaValidationErrors := validateReplicaPerformanceInsightsConfiguration(d.Get("engine").(int), d)
-	if len(replicaValidationErrors) > 0 {
-		return errorsToDiagnostics(fmt.Sprintf("Cannot update RDS DB read replica: %s: ", id), replicaValidationErrors)
-	}
-	if isAuroraDB(d) {
-		obj.DBInstanceIdentifier = identifier + "-cluster"
-
-		insightErr := c.UpdateDBClusterPerformanceInsight(tenantID, obj)
-		if insightErr != nil {
-			return diag.FromErr(insightErr)
-
-		}
-	} else {
+	////replicaValidationErrors := validateReplicaPerformanceInsightsConfiguration(d.Get("engine").(int), d)
+	////if len(replicaValidationErrors) > 0 {
+	////	return errorsToDiagnostics(fmt.Sprintf("Cannot update RDS DB read replica: %s: ", id), replicaValidationErrors)
+	////}
+	//if isAuroraDB(d) {
+	//		obj.DBInstanceIdentifier = identifier + "-cluster"
+	//
+	//		insightErr := c.UpdateDBClusterPerformanceInsight(tenantID, obj)
+	//		if insightErr != nil {
+	//			return diag.FromErr(insightErr)
+	//
+	//		}
+	//
+	//} else {
+	//	insightErr := c.UpdateDBInstancePerformanceInsight(tenantID, obj)
+	//	if insightErr != nil {
+	//		return diag.FromErr(insightErr)
+	//
+	//	}
+	//}
+	if !isAuroraDB(d) {
 		insightErr := c.UpdateDBInstancePerformanceInsight(tenantID, obj)
 		if insightErr != nil {
 			return diag.FromErr(insightErr)
 
 		}
-	}
 
+	}
 	// Wait for the instance to become unavailable - but continue on if we timeout, without any errors raised.
 	_ = readReplicaInstanceWaitUntilUnavailable(ctx, c, id, 150*time.Second)
 
@@ -510,13 +516,11 @@ func rdsReadReplicaToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Res
 	return jo
 }
 
-func validateReplicaPerformanceInsightsConfiguration(engineCode int, tfSpecification *schema.ResourceData) (errors []error) {
+func validateReplicaPerformanceInsightsConfigurationAuroaDB(engineCode int, tfSpecification *schema.ResourceData) bool {
 	if isEngineAuroraType(engineCode) && hasPerformanceInsightConfigurations(tfSpecification) {
-		errors = append(errors,
-			fmt.Errorf("Performance insight configurations are currently applied cluster wide for Aurora instances and should be declared in the primary database only"),
-		)
+		return true
 	}
-	return errors
+	return false
 }
 
 func isEngineAuroraType(engineCode int) bool {
@@ -536,4 +540,20 @@ func isEngineAuroraType(engineCode int) bool {
 func hasPerformanceInsightConfigurations(tfRdsReplicaSpecification *schema.ResourceData) bool {
 	configuration := tfRdsReplicaSpecification.Get("performance_insights").([]interface{})
 	return len(configuration) > 0
+}
+
+func suppressClusterPerformanceInsightInReplica(ctx context.Context, diff *schema.ResourceDiff, m interface{}) error {
+
+	eng := diff.Get("engine").(int)
+	if eng == 8 || eng == 9 || eng == 16 || eng == 11 || eng == 12 {
+		oldPI, _ := diff.GetChange("performance_insights")
+		list := oldPI.([]interface{})
+		if len(list) > 0 {
+			diff.SetNewComputed("performance_insights.0.enabled")
+			diff.SetNewComputed("performance_insights.0.retention_period")
+			diff.SetNewComputed("performance_insights.0.kms_key_id")
+
+		}
+	}
+	return nil
 }

--- a/duplocloud/resource_duplo_rds_read_replica.go
+++ b/duplocloud/resource_duplo_rds_read_replica.go
@@ -326,27 +326,6 @@ func resourceDuploRdsReadReplicaUpdate(ctx context.Context, d *schema.ResourceDa
 		obj.Disable = &disable
 	}
 	obj.DBInstanceIdentifier = identifier
-	// Validate read replica
-	////replicaValidationErrors := validateReplicaPerformanceInsightsConfiguration(d.Get("engine").(int), d)
-	////if len(replicaValidationErrors) > 0 {
-	////	return errorsToDiagnostics(fmt.Sprintf("Cannot update RDS DB read replica: %s: ", id), replicaValidationErrors)
-	////}
-	//if isAuroraDB(d) {
-	//		obj.DBInstanceIdentifier = identifier + "-cluster"
-	//
-	//		insightErr := c.UpdateDBClusterPerformanceInsight(tenantID, obj)
-	//		if insightErr != nil {
-	//			return diag.FromErr(insightErr)
-	//
-	//		}
-	//
-	//} else {
-	//	insightErr := c.UpdateDBInstancePerformanceInsight(tenantID, obj)
-	//	if insightErr != nil {
-	//		return diag.FromErr(insightErr)
-	//
-	//	}
-	//}
 	if !isAuroraDB(d) {
 		insightErr := c.UpdateDBInstancePerformanceInsight(tenantID, obj)
 		if insightErr != nil {

--- a/examples/resources/duplocloud_rds_read_replica/resource.tf
+++ b/examples/resources/duplocloud_rds_read_replica/resource.tf
@@ -53,6 +53,7 @@ resource "duplocloud_rds_read_replica" "replica" {
 
 
 //Performance insight example for cluster db read replica
+//Performance insight for aurora cluster db is applied at cluster level
 resource "duplocloud_rds_instance" "rds" {
   tenant_id      = duplocloud_tenant.myapp.tenant_id
   name           = "clust"
@@ -65,21 +66,39 @@ resource "duplocloud_rds_instance" "rds" {
   encrypt_storage                 = true
   store_details_in_secret_manager = true
   enhanced_monitoring             = 0
-
+  performance_insights {
+    enabled          = false
+    retention_period = 31
+    kms_key_id       = "arn:aws:kms:us-west-2:182680712604:key/6b8dc967-92bf-43de-a850-ee7b945260f8"
+  }
 }
-
+//referencing performance insights block from writer or primary resource is must, 
+//to maintain tfstate to be in sync for performance insights block.
 resource "duplocloud_rds_read_replica" "replica" {
   tenant_id          = duplocloud_rds_instance.rds.tenant_id
   name               = "read-replica"
   size               = "db.r5.large"
   cluster_identifier = duplocloud_rds_instance.rds.cluster_identifier
-
-  // aurora db read replicas inherit performance insight configurations from its cluster's primary
-  // performance_insights {
-  //   enabled          = true
-  //   retention_period = 7
-  // }
+  performance_insights {
+    enabled          = duplocloud_rds_instance.rds.performance_insights.0.enabled
+    retention_period = duplocloud_rds_instance.rds.performance_insights.0.retention_period
+    kms_key_id       = duplocloud_rds_instance.rds.performance_insights.0.kms_key_id
+  }
 }
+
+resource "duplocloud_rds_read_replica" "replica2" {
+  tenant_id          = duplocloud_rds_instance.rds.tenant_id
+  name               = "read-replica2"
+  size               = "db.r5.large"
+  cluster_identifier = duplocloud_rds_instance.rds.cluster_identifier
+  performance_insights {
+    enabled          = duplocloud_rds_instance.rds.performance_insights.0.enabled
+    retention_period = duplocloud_rds_instance.rds.performance_insights.0.retention_period
+    kms_key_id       = duplocloud_rds_instance.rds.performance_insights.0.kms_key_id
+  }
+
+}
+
 
 //Performance insight example for instance db read replica
 resource "duplocloud_rds_instance" "mydb" {


### PR DESCRIPTION
### **User description**
## Overview

Fixed aurora db updation for performance insights state and plan issues
## Summary of changes
Fixed plan issues, 
Fixed replica performance insights issue, 
Updated doc example

This PR does the following:

- Fixed logic at read replica's create and update context for aurora cluster performance insights
- Fixed plan issues
- updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Enhanced the RDS instance and read replica schemas by adding `DiffSuppressFunc` to suppress changes when Performance Insights is disabled.
- Improved validation logic for Aurora DB configurations to ensure correct application of Performance Insights settings.
- Updated documentation and examples to reflect changes in Performance Insights configuration, providing clearer guidance on referencing from primary resources.
- Updated the changelog to document the recent enhancements and documentation updates.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_instance.go</strong><dd><code>Enhance RDS instance schema with diff suppression</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_rds_instance.go

<li>Added <code>DiffSuppressFunc</code> for <code>kms_key_id</code> and <code>retention_period</code> fields.<br> <li> Improved handling of Performance Insights configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/707/files#diff-a8bf9b56a3e9b39899a5d37d7608110678908754e0848fab2d0320653ea65f71">+34/-6</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_read_replica.go</strong><dd><code>Improve RDS read replica schema and validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplocloud/resource_duplo_rds_read_replica.go

<li>Added <code>DiffSuppressFunc</code> for <code>kms_key_id</code> and <code>retention_period</code>.<br> <li> Improved validation logic for Aurora DB.<br> <li> Updated <code>CustomizeDiff</code> with <code>validateRDSParameters</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/707/files#diff-1ffdcfb6fc7a0fed517c0f77bbfb406b208cb1084f420e755eb9d029683dfdfe">+35/-31</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog with recent enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented enhancements for Performance Insights configuration.<br> <li> Updated documentation for RDS read replicas.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/707/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+11/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rds_read_replica.md</strong><dd><code>Update RDS read replica documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/resources/rds_read_replica.md

<li>Updated documentation for Performance Insights configuration.<br> <li> Added examples for Aurora cluster level settings.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/707/files#diff-e223dad9b259eae20181173087aafb1d47d2eb221d1a7d6ba1493bd78aafc5af">+26/-7</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>resource.tf</strong><dd><code>Add examples for RDS read replica configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/resources/duplocloud_rds_read_replica/resource.tf

<li>Added examples for Performance Insights configuration.<br> <li> Demonstrated Aurora cluster level settings.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/707/files#diff-3e5f9986f926543549bd2d58be9bb79a2277e56293965198b698e94a55e4d9ff">+26/-7</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

