### PR TITLE
DUPLO-21304 fix: ignore backend values for replica perf configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2024-09-16
+
+### Fixed
+
+- Ignored backend values for Aurora replica performance insights configuration, ensuring they follow the primary's configuration.
+- Removed primary-specific code from the read replica resource to simplify Terraform operations.
+
 ## 2024-09-13
 
 ### Enhanced


### PR DESCRIPTION
### **User description**
## Overview

Performance insights configuration for RDS Aurora is applied at the cluster level and is controlled entirely by the perf insights block of the primary rds resource. Replicas merely copy whatever configuration is set on the primary. Because of their passive role for aurora use cases, we are keeping them permanently as null to simplify terraform operations (not allowing them to be set if replica is type Aurora and also by ignoring these configurations coming from the backend)

## Summary of changes

This PR does the following:

- Actively ignore Aurora replica performance insight configuration data when applying BE model to state
- Removes primary specific code from read replica resource

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

No

# Sanity Checking

```
data "duplocloud_tenant" "nondefault" {
  name = "non-default"
}

resource "duplocloud_rds_instance" "app" {
  tenant_id      = data.duplocloud_tenant.nondefault.id
  name           = "writer1-sql161-3"
  engine         = 8 
  engine_version = "8.0.mysql_aurora.3.07.1"
  size           = "db.r5.large"
  master_username              = "myuser"
  master_password              = "random_password.mypassword.result"
  encrypt_storage         = true
  backup_retention_period = 10
  db_name         =  "auroradb"
  store_details_in_secret_manager = false
  availability_zone = "us-west-2b"
  storage_type                    = "aurora"
  performance_insights {
    enabled = false
  }
}


resource "duplocloud_rds_read_replica" "replica1" {
  tenant_id          = duplocloud_rds_instance.app.tenant_id
  name               = "aurora-replica-161-3"
  size               = "db.r5.large"
  cluster_identifier = duplocloud_rds_instance.app.cluster_identifier
  availability_zone = "us-west-2a"

}

resource "duplocloud_rds_read_replica" "replica2" {
  tenant_id          = duplocloud_rds_instance.app.tenant_id
  name               = "aurora-replica-16-12-3"
  size               = "db.r5.large"
  cluster_identifier = duplocloud_rds_instance.app.cluster_identifier
  availability_zone = "us-west-2b"
}
```
<img width="1148" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/17da9d2c-53d0-4623-9e81-67e48eba7686">

<img width="1154" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/b72350ce-8825-4c26-a942-0a79541008a9">

<img width="1147" alt="Pasted Graphic 2" src="https://github.com/user-attachments/assets/a74dd276-7da4-4262-9f17-ae75f41552f4">

<img width="1071" alt="Pasted Graphic 3" src="https://github.com/user-attachments/assets/78753c95-9b2a-4e67-98e6-f1358d04fb15">

No-op Update:
<img width="1065" alt="Pasted Graphic 4" src="https://github.com/user-attachments/assets/e2033020-e226-46ef-a23c-b40b7f844549">

Attempt to change replica perf insight configuration on instance level:
<img width="1001" alt="Pasted Graphic 6" src="https://github.com/user-attachments/assets/a1b018be-896b-494c-be95-7facba10d2e9">

<img width="1072" alt="Pasted Graphic 5" src="https://github.com/user-attachments/assets/aedceafe-5aaf-417a-878c-99247fc14639">

Enabling writer perf insights:
<img width="997" alt="Pasted Graphic 7" src="https://github.com/user-attachments/assets/07b3c8d7-b73b-405f-808c-ef92303cf7e5">

<img width="1136" alt="Pasted Graphic 8" src="https://github.com/user-attachments/assets/4c056c76-fa05-40d0-a353-954b0e12f90b">

<img width="1150" alt="Pasted Graphic 9" src="https://github.com/user-attachments/assets/ec740cf3-1b91-4d9f-8884-38aae2401e6c">

<img width="1139" alt="Storage" src="https://github.com/user-attachments/assets/cac5ff8b-0e22-4588-bf34-5563028f07f5">

<img width="1054" alt="Pasted Graphic 11" src="https://github.com/user-attachments/assets/d8a4bb11-91c9-4bf9-9fbd-300ef642f4dc">

Non aurora create
All perf insight configurations working as expected after create
<img width="1151" alt="image" src="https://github.com/user-attachments/assets/64e397b4-86ba-47e2-a3e9-9afa94e0613d">

No-op update non aurora dbs
<img width="984" alt="image" src="https://github.com/user-attachments/assets/3b6b2fcb-7322-4b89-9abc-b7fe676c0f00">

Perf insight configuration update non aurora dbs
<img width="986" alt="image" src="https://github.com/user-attachments/assets/b2d11fea-59d2-484c-8d36-9cc3d05fbeb8">


___

### **PR Type**
enhancement, bug fix


___

### **Description**
- Enhanced the handling of Aurora RDS read replicas by ignoring performance insights configurations, as they are inherited from the primary instance.
- Removed unnecessary update logic for performance insights on Aurora replicas, ensuring changes are managed through the primary instance.
- Improved code clarity and maintainability by focusing on primary instance configurations for Aurora.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_rds_read_replica.go</strong><dd><code>Enhance Aurora replica handling by ignoring performance insights</code></dd></summary>
<hr>

duplocloud/resource_duplo_rds_read_replica.go

<li>Added logic to ignore performance insights configuration for Aurora <br>replicas.<br> <li> Removed update logic for performance insights on Aurora replicas.<br> <li> Improved handling of Aurora replica configurations by deferring to <br>primary settings.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/708/files#diff-1ffdcfb6fc7a0fed517c0f77bbfb406b208cb1084f420e755eb9d029683dfdfe">+8/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

