### PR TITLE
gcp cloud sql resource update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2024-09-17
+
+### Enhanced
+
+- Updated `duplocloud_gcp_sql_database_instance` to handle `ip_address` as a list of strings.
+- Improved formatting and corrected typos in the `database_version` field description.
+
 ## 2024-09-13
 
 ### Enhanced

--- a/docs/resources/gcp_sql_database_instance.md
+++ b/docs/resources/gcp_sql_database_instance.md
@@ -36,7 +36,7 @@ resource "duplocloud_gcp_sql_database_instance" "sql_instance" {
 
 ### Required
 
-- `database_version` (String) The MySQL, PostgreSQL orSQL Server version to use.Supported values include `MYSQL_5_6`,`MYSQL_5_7`, `MYSQL_8_0`, `POSTGRES_9_6`,`POSTGRES_10`,`POSTGRES_11`,`POSTGRES_12`, `POSTGRES_13`, `POSTGRES_14`, `POSTGRES_15`, `SQLSERVER_2017_STANDARD`,`SQLSERVER_2017_ENTERPRISE`,`SQLSERVER_2017_EXPRESS`, `SQLSERVER_2017_WEB`.`SQLSERVER_2019_STANDARD`, `SQLSERVER_2019_ENTERPRISE`, `SQLSERVER_2019_EXPRESS`,`SQLSERVER_2019_WEB`.[Database Version Policies](https://cloud.google.com/sql/docs/db-versions)includes an up-to-date reference of supported versions.
+- `database_version` (String) The MySQL, PostgreSQL or SQL Server version to use.Supported values include `MYSQL_5_6`,`MYSQL_5_7`, `MYSQL_8_0`, `POSTGRES_9_6`,`POSTGRES_10`,`POSTGRES_11`,`POSTGRES_12`, `POSTGRES_13`, `POSTGRES_14`, `POSTGRES_15`, `SQLSERVER_2017_STANDARD`,`SQLSERVER_2017_ENTERPRISE`,`SQLSERVER_2017_EXPRESS`, `SQLSERVER_2017_WEB`,`SQLSERVER_2019_STANDARD`, `SQLSERVER_2019_ENTERPRISE`, `SQLSERVER_2019_EXPRESS`,`SQLSERVER_2019_WEB`.[Database Version Policies](https://cloud.google.com/sql/docs/db-versions) includes an up-to-date reference of supported versions.
 - `name` (String) The short name of the sql database.  Duplo will add a prefix to the name.  You can retrieve the full name from the `fullname` attribute.
 - `tenant_id` (String) The GUID of the tenant that the sql database will be created in.
 - `tier` (String) The machine type to use. See tiers for more details and supported versions. Postgres supports only shared-core machine types, and custom machine types such as `db-custom-2-13312`.See the [Custom Machine Type Documentation](https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type#create) to learn about specifying custom machine types.
@@ -51,10 +51,10 @@ resource "duplocloud_gcp_sql_database_instance" "sql_instance" {
 
 ### Read-Only
 
-- `connection_name` (String) Connection name  of the database.
+- `connection_name` (String) Connection name of the database.
 - `fullname` (String) The full name of the sql database.
 - `id` (String) The ID of this resource.
-- `ip_address` (String) IP address of the database.
+- `ip_address` (List of String) List of IP addresses of the database.
 - `self_link` (String) The SelfLink of the sql database.
 
 <a id="nestedblock--timeouts"></a>

--- a/duplocloud/resource_duplo_gcp_sql_database.go
+++ b/duplocloud/resource_duplo_gcp_sql_database.go
@@ -41,11 +41,11 @@ func gcpSqlDBInstanceSchema() map[string]*schema.Schema {
 			Computed:    true,
 		},
 		"database_version": {
-			Description: "The MySQL, PostgreSQL orSQL Server version to use." +
+			Description: "The MySQL, PostgreSQL or SQL Server version to use." +
 				"Supported values include `MYSQL_5_6`,`MYSQL_5_7`, `MYSQL_8_0`, `POSTGRES_9_6`,`POSTGRES_10`," +
 				"`POSTGRES_11`,`POSTGRES_12`, `POSTGRES_13`, `POSTGRES_14`, `POSTGRES_15`, `SQLSERVER_2017_STANDARD`,`SQLSERVER_2017_ENTERPRISE`," +
-				"`SQLSERVER_2017_EXPRESS`, `SQLSERVER_2017_WEB`.`SQLSERVER_2019_STANDARD`, `SQLSERVER_2019_ENTERPRISE`, `SQLSERVER_2019_EXPRESS`," +
-				"`SQLSERVER_2019_WEB`.[Database Version Policies](https://cloud.google.com/sql/docs/db-versions)includes an up-to-date reference of supported versions.",
+				"`SQLSERVER_2017_EXPRESS`, `SQLSERVER_2017_WEB`,`SQLSERVER_2019_STANDARD`, `SQLSERVER_2019_ENTERPRISE`, `SQLSERVER_2019_EXPRESS`," +
+				"`SQLSERVER_2019_WEB`.[Database Version Policies](https://cloud.google.com/sql/docs/db-versions) includes an up-to-date reference of supported versions.",
 			Type:         schema.TypeString,
 			Required:     true,
 			ValidateFunc: validation.StringInSlice(supportedGcpSQLDBVersions(), false),
@@ -84,12 +84,13 @@ func gcpSqlDBInstanceSchema() map[string]*schema.Schema {
 			Computed:    true,
 		},
 		"ip_address": {
-			Description: "IP address of the database.",
-			Type:        schema.TypeString,
+			Description: "List of IP addresses of the database.",
+			Type:        schema.TypeList,
 			Computed:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 		"connection_name": {
-			Description: "Connection name  of the database.",
+			Description: "Connection name of the database.",
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
@@ -99,7 +100,6 @@ func gcpSqlDBInstanceSchema() map[string]*schema.Schema {
 func checkPasswordNeeded(d *schema.ResourceData) bool {
 
 	// Check the value of dependent_field
-
 	dependentFieldValue := d.Get("database_version").(string)
 	mp := map[string]bool{
 		"SQLSERVER_2017_STANDARD":   true,
@@ -113,6 +113,7 @@ func checkPasswordNeeded(d *schema.ResourceData) bool {
 	}
 	return mp[dependentFieldValue]
 }
+
 func resourceGcpSqlDBInstance() *schema.Resource {
 	return &schema.Resource{
 		Description: "`duplocloud_gcp_sql_database_instance` manages a GCP SQL Database Instance in Duplo.",
@@ -322,7 +323,7 @@ func flattenGcpSqlDBInstance(d *schema.ResourceData, tenantID string, name strin
 	d.Set("tier", duplo.Tier)
 	d.Set("database_version", reverseGcpSQLDBVersionsMap()[duplo.DatabaseVersion])
 	d.Set("disk_size", duplo.DataDiskSizeGb)
-	d.Set("ip_address", duplo.IPAddress)
+	d.Set("ip_address", flattenStringList(duplo.IPAddress))
 	d.Set("connection_name", duplo.ConnectionName)
 	flattenGcpLabels(d, duplo.Labels)
 }

--- a/duplosdk/gcp_sql_database.go
+++ b/duplosdk/gcp_sql_database.go
@@ -76,7 +76,7 @@ type DuploGCPSqlDBInstance struct {
 	Labels          map[string]string `json:"labels,omitempty"`
 	SelfLink        string            `json:"SelfLink,omitempty"`
 	RootPassword    string            `json:"RootPassword,omitempty"`
-	IPAddress       string            `json:"IpAddress,omitempty"`
+	IPAddress       []string          `json:"IpAddress,omitempty"`
 	ConnectionName  string            `json:"ConnectionName,omitempty"`
 }
 


### PR DESCRIPTION
### **User description**
## Overview

For `duplocloud_gcp_sql_database_instance` resource, the Duplo backed is updated to generate an array of ip_address, but this resource expects it to be a string. I have made the required changes for that.

## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Updated the `duplocloud_gcp_sql_database_instance` resource to handle `ip_address` as a list of strings, allowing for multiple IP addresses.
- Improved formatting and corrected typos in the `database_version` field description.
- Updated documentation to reflect changes in the `ip_address` field and corrected typos.
- Documented changes in the CHANGELOG.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>resource_duplo_gcp_sql_database.go</strong><dd><code>Update GCP SQL Database resource to handle multiple IP addresses</code></dd></summary>
<hr>

duplocloud/resource_duplo_gcp_sql_database.go

<li>Changed <code>ip_address</code> from a string to a list of strings.<br> <li> Improved formatting and corrected typos in <code>database_version</code> <br>description.<br> <li> Minor formatting improvements in code.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/709/files#diff-5e2b59a959de92a468b84aa15f4066eb662d23e4c9a0e8ef04fca002d5235831">+9/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gcp_sql_database.go</strong><dd><code>Modify IPAddress field to support multiple addresses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

duplosdk/gcp_sql_database.go

- Changed `IPAddress` field from a string to a list of strings.



</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/709/files#diff-ef4280fb2cddb49187c078fc9a79d10c1b8a94e27286a2e4c718da2d320ac2d8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update CHANGELOG for GCP SQL Database enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<li>Documented changes to handle <code>ip_address</code> as a list.<br> <li> Noted improvements in formatting and typo corrections.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/709/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>gcp_sql_database_instance.md</strong><dd><code>Update GCP SQL Database instance documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/resources/gcp_sql_database_instance.md

<li>Updated documentation to reflect <code>ip_address</code> as a list.<br> <li> Corrected typos in <code>database_version</code> description.<br>


</details>


  </td>
  <td><a href="https://github.com/duplocloud/terraform-provider-duplocloud/pull/709/files#diff-5695da959b1954953ab1c73c64b4a4fc96c884d73e08e5119eb6b6b67d008b6f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

