### PR TITLE
DUPLO-21234: [Develop]:TF:Airflow: Getting error for resource 'duplocloud_aws_mwaa_environment' on destroy

### DIFF
--- a/duplosdk/aws_mwaa_environment.go
+++ b/duplosdk/aws_mwaa_environment.go
@@ -144,10 +144,11 @@ func (c *Client) MwaaAirflowList(tenantID string) (*[]DuploMwaaAirflowSummary, C
 }
 
 func (c *Client) MwaaAirflowDelete(tenantID string, id string) ClientError {
+	cloudResource := DuploAwsCloudResource{}
 	return c.deleteAPI(
 		fmt.Sprintf("MwaaAirflowDelete(%s, %s)", tenantID, id),
 		fmt.Sprintf("v3/subscriptions/%s/aws/mwaaairflow/%s", tenantID, id),
-		nil,
+		&cloudResource,
 	)
 }
 


### PR DESCRIPTION
## Overview

DUPLO-21234: fix tf regression, terraform assume delete message is null

## Summary of changes

This PR does the following:

- parse delete response
- ...

## Testing performed

- [ ] Using unit tests
- [X] Manually, on my local system
- [X] Manually, on a remote test system

## Describe any breaking changes

- None
