### PR TITLE
DUPLO-21253 

### DIFF
--- a/duplocloud/resource_duplo_azure_redis_cache.go
+++ b/duplocloud/resource_duplo_azure_redis_cache.go
@@ -249,6 +249,7 @@ func expandAzureRedisCache(d *schema.ResourceData) *duplosdk.DuploAzureRedisCach
 				Family:   d.Get("family").(string),
 				Capacity: d.Get("capacity").(int),
 			},
+			PublicNetworkAccess: "Disabled",
 		},
 	}
 }

--- a/duplosdk/azure_redis_cache.go
+++ b/duplosdk/azure_redis_cache.go
@@ -11,10 +11,11 @@ type DuploAzureRedisCacheSku struct {
 }
 
 type DuploAzureRedisCacheProperties struct {
-	ShardCount       int                     `json:"shardCount,omitempty"`
-	Sku              DuploAzureRedisCacheSku `json:"sku"`
-	EnableNonSslPort bool                    `json:"enableNonSslPort"`
-	SubnetID         string                  `json:"subnetId,omitempty"`
+	ShardCount          int                     `json:"shardCount,omitempty"`
+	Sku                 DuploAzureRedisCacheSku `json:"sku"`
+	EnableNonSslPort    bool                    `json:"enableNonSslPort"`
+	SubnetID            string                  `json:"subnetId,omitempty"`
+	PublicNetworkAccess string                  `json:"publicNetworkAccess"`
 }
 
 type DuploAzureRedisCacheRequest struct {


### PR DESCRIPTION
## Overview

Fix for redis cache creation in private network

## Summary of changes
Added attribute to disable public access
This PR does the following:

- Introduced missing attribute PublicNetworkAccess
- Hardcoded PublicNetworkAccess as Disabled based on UI design

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
