### PR TITLE
DUPLO-25476 fix: throw error if access grant create times out

### DIFF
--- a/duplocloud/resource_duplo_tenant_access_grant.go
+++ b/duplocloud/resource_duplo_tenant_access_grant.go
@@ -116,7 +116,7 @@ func resourceTenantAccessGrantCreate(ctx context.Context, d *schema.ResourceData
 		return diag.FromErr(clientError)
 	}
 	id := fmt.Sprintf("%s/%s/%s", granteeTenantId, grantorTenantId, grantedArea)
-	waitForResourceToBePresentAfterCreate(ctx, d, "tenant access grant", id, func() (interface{}, duplosdk.ClientError) {
+	diag := waitForResourceToBePresentAfterCreate(ctx, d, "tenant access grant", id, func() (interface{}, duplosdk.ClientError) {
 		resp, err := c.GetTenantAccessGrantStatus(granteeTenantId, grantorTenantId, grantedArea)
 		if err != nil {
 			return nil, err
@@ -128,6 +128,9 @@ func resourceTenantAccessGrantCreate(ctx context.Context, d *schema.ResourceData
 		}
 		return resp, nil
 	})
+	if diag != nil {
+		return diag
+	}
 
 	d.SetId(id)
 


### PR DESCRIPTION
## Overview

We are currently ignoring timeouts on access grant create and succeeding resource creation regardless of it being deployed in AWS or not. This PR makes it so we throw an exception if access grant deployment status does not complete before timeout.

## Summary of changes

This PR does the following:

- returns diagnostic data from deployment status monitoring if timeout occurs

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

Yes, this will break KMS access grants unless we merge after this Backend PR https://github.com/duplocloud-internal/duplo/pull/3278
