### PR TITLE
DUPLO-25462  Bug Fix

### DIFF
--- a/duplocloud/resource_duplo_azure_redis_cache.go
+++ b/duplocloud/resource_duplo_azure_redis_cache.go
@@ -133,7 +133,7 @@ func resourceAzureRedisCache() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(60 * time.Minute),
-			Delete: schema.DefaultTimeout(15 * time.Minute),
+			Delete: schema.DefaultTimeout(60 * time.Minute),
 		},
 		Schema: duploAzureRedisCacheSchema(),
 	}
@@ -281,7 +281,9 @@ func redisCacheWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID 
 		Target:  []string{"ready"},
 		Refresh: func() (interface{}, string, error) {
 			rp, err := c.RedisCacheGet(tenantID, name)
-			log.Printf("[TRACE] Redis cache provisioning state is (%s).", rp.PropertiesProvisioningState)
+			if rp != nil {
+				log.Printf("[TRACE] Redis cache provisioning state is (%s).", rp.PropertiesProvisioningState)
+			}
 			status := "pending"
 			if err == nil {
 				if rp.PropertiesProvisioningState == "Succeeded" {


### PR DESCRIPTION
## Overview

Fix for Delete context time out even after resource deleted
## Summary of changes

This PR does the following:

- Added customised polling function for delete context
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
