### PR TITLE
DUPLO-25915 TF provider: SSM data source cannot be used to retrieve secure ssm value 

### DIFF
--- a/duplocloud/data_source_duplo_aws_ssm_parameter.go
+++ b/duplocloud/data_source_duplo_aws_ssm_parameter.go
@@ -75,10 +75,6 @@ func dataSourceSsmParameterRead(d *schema.ResourceData, m interface{}) error {
 		return fmt.Errorf("SSM parameter '%s' not found", id)
 	}
 	ssmParam := body
-	if ssmParam.Type == "SecureString" {
-		body.Value = "**********"
-	}
-	log.Printf("[TRACE] SsmParameterGet: received response: %+v", body)
 
 	d.SetId(id)
 	d.Set("type", ssmParam.Type)
@@ -88,6 +84,10 @@ func dataSourceSsmParameterRead(d *schema.ResourceData, m interface{}) error {
 	d.Set("allowed_pattern", ssmParam.AllowedPattern)
 	d.Set("last_modified_user", ssmParam.LastModifiedUser)
 	d.Set("last_modified_date", ssmParam.LastModifiedDate)
+	if ssmParam.Type == "SecureString" {
+		body.Value = "**********"
+	}
+	log.Printf("[TRACE] SsmParameterGet: received response: %+v", body)
 
 	log.Printf("[TRACE] dataSourceSsmParameterRead(%s, %s): end", tenantID, name)
 	return nil

--- a/duplocloud/data_source_duplo_aws_ssm_parameters.go
+++ b/duplocloud/data_source_duplo_aws_ssm_parameters.go
@@ -80,9 +80,7 @@ func dataSourceSsmParametersRead(d *schema.ResourceData, m interface{}) error {
 	list := make([]map[string]interface{}, 0, len(*rp))
 	for i, body := range resp {
 		ssmParam := body
-		if ssmParam.Type == "SecureString" {
-			resp[i].Value = "**********"
-		}
+
 		if i == len(resp)-1 {
 			log.Printf("[TRACE] SsmParameterGet: received response: %+v", resp)
 		}
@@ -96,6 +94,9 @@ func dataSourceSsmParametersRead(d *schema.ResourceData, m interface{}) error {
 			"last_modified_user": ssmParam.LastModifiedUser,
 			"last_modified_date": ssmParam.LastModifiedDate,
 		})
+		if ssmParam.Type == "SecureString" {
+			resp[i].Value = "**********"
+		}
 	}
 
 	d.Set("parameters", list)


### PR DESCRIPTION

Fix for assigning masked secure string from ssm parameter to other env map resources

## Overview

Fixed datasource duplocloud_aws_ssm_parameter secure value assignment to state file

## Summary of changes

This PR does the following:

- First assigned value to state file and then explicitly masked for log output
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
