### PR TITLE
DUPLO-25437: DOC: TF: S3 Replication: Make rule block as a required field for resource 'duplocloud_s3_bucket_replication'

### DIFF
--- a/docs/resources/s3_bucket_replication.md
+++ b/docs/resources/s3_bucket_replication.md
@@ -40,12 +40,12 @@ resource "duplocloud_s3_bucket_replication" "rep" {
 
 ### Required
 
+- `rules` (Block List, Min: 1, Max: 1) replication rules for source bucket (see [below for nested schema](#nestedblock--rules))
 - `source_bucket` (String) name of source bucket.
 - `tenant_id` (String) The GUID of the tenant that the S3 bucket replication rule will be created in.
 
 ### Optional
 
-- `rules` (Block List, Max: 1) replication rules for source bucket (see [below for nested schema](#nestedblock--rules))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/duplocloud/resource_duplo_s3_replication.go
+++ b/duplocloud/resource_duplo_s3_replication.go
@@ -83,7 +83,7 @@ func s3BucketReplicationSchema() map[string]*schema.Schema {
 		"rules": {
 			Description: "replication rules for source bucket",
 			Type:        schema.TypeList,
-			Optional:    true,
+			Required:    true,
 			MaxItems:    1,
 			Elem:        ruleSchema(),
 		},


### PR DESCRIPTION
## Overview

rule block is an optional field for resource 'duplocloud_s3_bucket_replication'

## Summary of changes

This PR does the following:

- rule block as a required field for resource 'duplocloud_s3_bucket_replication'
