### PR TITLE
Duplo 25436 TF: S3: Replication: Update of 'Delete marker replication' shows no changes and DUPLO-25447

### DIFF
--- a/duplocloud/resource_duplo_s3_replication.go
+++ b/duplocloud/resource_duplo_s3_replication.go
@@ -28,12 +28,8 @@ func ruleSchema() *schema.Resource {
 				Description:  "replication rule name for s3 source bucket",
 				Type:         schema.TypeString,
 				Required:     true,
-<<<<<<< HEAD
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]+$`), "Invalid rule name: only alphabetic characters (A-Z, a-z) are allowed"),
 				ForceNew:     false,
-=======
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[a-zA-Z0-9_-]}`), "Invalid rule name: only alphabets, digits, underscores, and hyphens are allowed."),
->>>>>>> develop
 			},
 			"fullname": {
 				Description: "replication rule fullname for s3 source bucket",

--- a/duplocloud/resource_duplo_s3_replication.go
+++ b/duplocloud/resource_duplo_s3_replication.go
@@ -29,6 +29,7 @@ func ruleSchema() *schema.Resource {
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]+$`), "Invalid rule name: only alphabetic characters (A-Z, a-z) are allowed"),
+				ForceNew:     false,
 			},
 			"fullname": {
 				Description: "replication rule fullname for s3 source bucket",
@@ -52,6 +53,7 @@ func ruleSchema() *schema.Resource {
 				Optional:         true,
 				Default:          false,
 				DiffSuppressFunc: diffSuppressWhenNotCreating,
+				ForceNew:         false,
 			},
 			"storage_class": {
 				Description: "storage_class type: STANDARD, INTELLIGENT_TIERING, STANDARD_IA, ONEZONE_IA, GLACIER_IR, GLACIER, DEEP_ARCHIVE, REDUCED_REDUNDANCY. Can be set only during creation",
@@ -68,6 +70,7 @@ func ruleSchema() *schema.Resource {
 					"DEEP_ARCHIVE",
 					"REDUCED_REDUNDANCY",
 				}, false),
+				ForceNew: false,
 			},
 		},
 	}

--- a/duplocloud/resource_duplo_s3_replication.go
+++ b/duplocloud/resource_duplo_s3_replication.go
@@ -88,6 +88,7 @@ func s3BucketReplicationSchema() map[string]*schema.Schema {
 			Required:    true,
 			MaxItems:    1,
 			Elem:        ruleSchema(),
+			ForceNew:    true,
 		},
 
 		"source_bucket": {
@@ -105,7 +106,7 @@ func resourceS3BucketReplication() *schema.Resource {
 		Description:   "Resource duplocloud_s3_bucket_replication is dependent on duplocloud_s3_bucket. This resource sets replication rules for source bucket",
 		ReadContext:   resourceS3BucketReplicationRead,
 		CreateContext: resourceS3BucketReplicationCreate,
-		UpdateContext: resourceS3BucketReplicationUpdate,
+		//UpdateContext: resourceS3BucketReplicationUpdate,
 		DeleteContext: resourceS3BucketReplicationDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -222,6 +223,7 @@ func resourceS3BucketReplicationCreate(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
+/*
 // UPDATE resource
 func resourceS3BucketReplicationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	log.Printf("[TRACE] resourceS3BucketReplicationUpdate ******** start")
@@ -259,7 +261,7 @@ func resourceS3BucketReplicationUpdate(ctx context.Context, d *schema.ResourceDa
 	log.Printf("[TRACE] resourceS3BucketReplicationUpdate ******** end")
 	return diags
 }
-
+*/
 // DELETE resource
 func resourceS3BucketReplicationDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	log.Printf("[TRACE] resourceS3BucketReplicationDelete ******** start")


### PR DESCRIPTION
## Overview

Removed update context
## Summary of changes
Update not supported , removed update context
This PR does the following:

- Made rule and sub attribute force new and removed update context
- Updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
