### PR TITLE
DUPLO-25434 TF: S3: Replication: Storage class is not getting set for resource 'duplocloud_s3_bucket_replication'

### DIFF
--- a/duplocloud/resource_duplo_s3_replication.go
+++ b/duplocloud/resource_duplo_s3_replication.go
@@ -201,6 +201,7 @@ func resourceS3BucketReplicationCreate(ctx context.Context, d *schema.ResourceDa
 			SourceBucket:            sourceBucket,
 			Priority:                kv["priority"].(int),
 			DeleteMarkerReplication: kv["delete_marker_replication"].(bool),
+			StorageClass:            kv["storage_class"].(string),
 		}
 
 		// Post the object to Duplo


### PR DESCRIPTION
## Overview

fixed storage class tfstate attribute set issue
## Summary of changes

This PR does the following:
Fixed storage_class is not getting set for resource 'duplocloud_s3_bucket_replication'
- Added missing attribute initialization in create context
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
