### PR TITLE
issueFix: DUPLO-25454: TF: S3: Replication: Add validation for rule name 

### DIFF
--- a/duplocloud/resource_duplo_s3_replication.go
+++ b/duplocloud/resource_duplo_s3_replication.go
@@ -28,7 +28,7 @@ func ruleSchema() *schema.Resource {
 				Description:  "replication rule name for s3 source bucket",
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z]+$`), "Invalid rule name: only alphabetic characters (A-Z, a-z) are allowed"),
+				ValidateFunc: validation.StringMatch(regexp.MustCompile(`[a-zA-Z0-9_-]}`), "Invalid rule name: only alphabets, digits, underscores, and hyphens are allowed."),
 			},
 			"fullname": {
 				Description: "replication rule fullname for s3 source bucket",


### PR DESCRIPTION
## Overview

Add proper validation for rule name for terraform code

## Summary of changes

This PR does the following:

- Validation function added which will validate name. Only alphabets, digits, underscores, and hyphens are allowed.