### PR TITLE
DUPLO-25619: DOC:TF: ASG: Add example block for secondary volume in example usage of duplocloud_asg_profile (Resource)

### DIFF
--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -85,9 +85,43 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
   custom_node_labels = {
     "key1" = "value1"
     "key2" = "value2"
-
   }
 
+}
+
+#secondary volume example
+resource "duplocloud_asg_profile" "duplo-test-asg" {
+  tenant_id             = duplocloud_tenant.duplo-app.tenant_id
+  friendly_name         = "duplo-test-asg"
+  instance_count        = 1
+  min_instance_count    = 1
+  max_instance_count    = 1
+  image_id              = "ami-077e0e0754c311a47" # <== put the AWS duplo docker AMI ID here
+  capacity              = "t3a.small"
+  agent_platform        = 7 # Duplo native container agent
+  zone                  = 0 # Zone A
+  user_account          = duplocloud_tenant.duplo-app.account_name
+  keypair_type          = 2
+  prepend_user_data     = false
+  use_spot_instances    = true
+  can_scale_from_zero   = false
+  is_cluster_autoscaled = false
+
+  metadata {
+    key   = "OsDiskSize" # <== This is the size of the OS disk in GB
+    value = "100"
+  }
+
+  minion_tags {
+    key   = "AllocationTags"
+    value = "test"
+  }
+
+  volume {
+    name        = "/dev/sda2"
+    volume_type = "gp3"
+    size        = 100
+  }
 }
 ```
 

--- a/examples/resources/duplocloud_asg_profile/resource.tf
+++ b/examples/resources/duplocloud_asg_profile/resource.tf
@@ -70,7 +70,41 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
   custom_node_labels = {
     "key1" = "value1"
     "key2" = "value2"
-
   }
 
+}
+
+#secondary volume example
+resource "duplocloud_asg_profile" "duplo-test-asg" {
+  tenant_id             = duplocloud_tenant.duplo-app.tenant_id
+  friendly_name         = "duplo-test-asg"
+  instance_count        = 1
+  min_instance_count    = 1
+  max_instance_count    = 1
+  image_id              = "ami-077e0e0754c311a47" # <== put the AWS duplo docker AMI ID here
+  capacity              = "t3a.small"
+  agent_platform        = 7 # Duplo native container agent
+  zone                  = 0 # Zone A
+  user_account          = duplocloud_tenant.duplo-app.account_name
+  keypair_type          = 2
+  prepend_user_data     = false
+  use_spot_instances    = true
+  can_scale_from_zero   = false
+  is_cluster_autoscaled = false
+
+  metadata {
+    key   = "OsDiskSize" # <== This is the size of the OS disk in GB
+    value = "100"
+  }
+
+  minion_tags {
+    key   = "AllocationTags"
+    value = "test"
+  }
+
+  volume {
+    name        = "/dev/sda2"
+    volume_type = "gp3"
+    size        = 100
+  }
 }


### PR DESCRIPTION
## Overview

Add an example block for secondary volume in example usage of duplocloud_asg_profile (Resource)

## Summary of changes

This PR does the following:

- Added example block for secondary volume in example of duplocloud_asg_profile (Resource)

## Testing performed

- [ ] Manually, on my local system
