### PR TITLE
DUPLO-25372: Missing Scope attribute in response under exclusion

### DIFF
--- a/duplocloud/resource_duplo_gcp_infra_maintenance_window.go
+++ b/duplocloud/resource_duplo_gcp_infra_maintenance_window.go
@@ -201,7 +201,11 @@ func flattenWindowMaintenance(d *schema.ResourceData, rb duplosdk.DuploGcpInfraM
 			mp := map[string]interface{}{
 				"start_time": v.StartTime,
 				"end_time":   v.EndTime,
-				"scope":      v.Scope,
+			}
+			if v.Scope != "" {
+				mp["scope"] = v.Scope
+			} else {
+				mp["scope"] = "NO_UPGRADES"
 			}
 			i = append(i, mp)
 		}


### PR DESCRIPTION
## Overview

Missing Scope attribute in response under exclusion for duplocloud_gcp_infra_maintenance_window

## Summary of changes

This PR does the following:

- v.Scope != "": This checks whether v.Scope is not an empty string, which is the default value for an uninitialized string in Go.
- If v.Scope is an empty string, set a default value in the mp map.

## Testing performed

- [ ] Manually, on my local system
