### PR TITLE
DUPLO-26078: add new airflow version 2.10.1

### DIFF
--- a/duplocloud/resource_duplo_aws_mwaa_environment.go
+++ b/duplocloud/resource_duplo_aws_mwaa_environment.go
@@ -85,7 +85,7 @@ func duploMwaaAirflowSchema() map[string]*schema.Schema {
 			Optional:    true,
 			ForceNew:    true,
 			ValidateFunc: validation.StringInSlice([]string{
-				"2.4.3", "2.5.1", "2.6.3", "2.7.2", "2.8.1", "2.9.2",
+				"2.4.3", "2.5.1", "2.6.3", "2.7.2", "2.8.1", "2.9.2", "2.10.1",
 			}, false),
 		},
 		"environment_class": {


### PR DESCRIPTION
## Overview

 DUPLO-26078: add new airflow version 2.10.1
 
## Summary of changes

This PR does the following:

- add new airflow version 2.10.1

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [x] Manually, on a remote test system

## Describe any breaking changes

- none
