### PR TITLE
DUPLO-26128 TF:Ingress with TLS: No error when only  tls secret is passed with no host. Ingress gets created with no tls configmade hosts as required for tls body

### DIFF
--- a/docs/resources/k8_ingress.md
+++ b/docs/resources/k8_ingress.md
@@ -182,6 +182,7 @@ resource "duplocloud_k8_ingress" "ingress" {
 
   tls {
     secret_name = "tlssecret"
+    hosts       = ["example.com", "https-example.foo.com", "abc.com"]
   }
   depends_on = [time_sleep.wait_45_seconds]
 
@@ -254,7 +255,7 @@ Optional:
 <a id="nestedblock--tls"></a>
 ### Nested Schema for `tls`
 
-Optional:
+Required:
 
 - `hosts` (List of String) The list of hosts included in the TLS certificate. Each value in this list must match the name(s) specified in the TLS secret. If not specified, it defaults to the wildcard host setting for the load balancer controller managing this Ingress.
 - `secret_name` (String) The name of the secret used to terminate TLS traffic on port 443. This field is optional, enabling TLS routing based solely on the SNI hostname. If the SNI host in a listener conflicts with the 'Host' header in an IngressRule, the SNI host is used for termination, while the 'Host' header value is used for routing.

--- a/duplocloud/resource_duplo_k8_ingress.go
+++ b/duplocloud/resource_duplo_k8_ingress.go
@@ -148,14 +148,12 @@ func k8sIngressSchema() map[string]*schema.Schema {
 						Elem: &schema.Schema{
 							Type: schema.TypeString,
 						},
-						Optional: true,
-						Computed: true,
+						Required: true,
 					},
 					"secret_name": {
 						Description: "The name of the secret used to terminate TLS traffic on port 443. This field is optional, enabling TLS routing based solely on the SNI hostname. If the SNI host in a listener conflicts with the 'Host' header in an IngressRule, the SNI host is used for termination, while the 'Host' header value is used for routing.",
 						Type:        schema.TypeString,
-						Optional:    true,
-						Computed:    true,
+						Required:    true,
 					},
 				},
 			},

--- a/examples/resources/duplocloud_k8_ingress/resource.tf
+++ b/examples/resources/duplocloud_k8_ingress/resource.tf
@@ -167,6 +167,7 @@ resource "duplocloud_k8_ingress" "ingress" {
 
   tls {
     secret_name = "tlssecret"
+    hosts       = ["example.com", "https-example.foo.com", "abc.com"]
   }
   depends_on = [time_sleep.wait_45_seconds]
 


### PR DESCRIPTION
## Overview

TLS body attribute update
## Summary of changes
Made attribute host and secrete_name required of tls required
This PR does the following:

- For optional tls body made its nested attribute required
- Updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✓ ] Manually, on a remote test system

## Describe any breaking changes

- ...
