### PR TITLE
fixed ordering diff for duplocloud_tenant_config

### DIFF
--- a/duplocloud/resource_duplo_tenant_config.go
+++ b/duplocloud/resource_duplo_tenant_config.go
@@ -40,10 +40,11 @@ func resourceTenantConfig() *schema.Resource {
 				ValidateFunc: validation.IsUUID,
 			},
 			"setting": {
-				Description: "A list of configuration settings to manage, expressed as key / value pairs.",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        KeyValueSchema(),
+				Description:      "A list of configuration settings to manage, expressed as key / value pairs.",
+				Type:             schema.TypeList,
+				Optional:         true,
+				Elem:             KeyValueSchema(),
+				DiffSuppressFunc: diffSuppressListOrdering,
 			},
 			"delete_unspecified_settings": {
 				Description: "Whether or not this resource should delete any settings not specified by this resource. " +


### PR DESCRIPTION
## Overview

fixed ordering diff for duplocloud_tenant_config
## Summary of changes

This PR does the following:

- Added diff suppress function to suppress diff if order in list has change
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✓] Manually, on a remote test system

## Describe any breaking changes

- ...
<img width="653" alt="Screenshot 2024-11-12 at 16 55 45" src="https://github.com/user-attachments/assets/546cd584-2760-4ced-81b1-aa2165035b4b">
==========================
After reordering
<img width="753" alt="Screenshot 2024-11-12 at 16 57 34" src="https://github.com/user-attachments/assets/31fba9c9-bed0-4278-929f-e85eea187f66">
==========================
After change
<img width="577" alt="Screenshot 2024-11-12 at 16 58 19" src="https://github.com/user-attachments/assets/8f9e777d-8aad-449c-a121-4665dac902dd">
