### PR TITLE
Duplo-19004 Dynamo db TTL update functionality

### DIFF
--- a/duplocloud/diff_utils.go
+++ b/duplocloud/diff_utils.go
@@ -291,3 +291,22 @@ func diffSuppressListOrdering(k, old, new string, d *schema.ResourceData) bool {
 	// No meaningful difference, suppress the diff
 	return true
 }
+
+func diffSuppressDynamodbTTLHandler(k, old, new string, d *schema.ResourceData) bool {
+	ostate, nstate := d.GetChange("ttl")
+	if len(ostate.([]interface{})) == 0 && len(nstate.([]interface{})) > 0 { //if ttl already disable ignnoring change
+		l := nstate.([]interface{})
+		mp := l[0].(map[string]interface{})
+		if !mp["enabled"].(bool) {
+			return true
+		}
+	} else if len(ostate.([]interface{})) > 0 && len(nstate.([]interface{})) == 0 {
+		l := ostate.([]interface{})
+
+		mp := l[0].(map[string]interface{})
+		if !mp["enabled"].(bool) {
+			return true
+		}
+	}
+	return false
+}

--- a/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
+++ b/duplocloud/resource_duplo_aws_dynamodb_table_v2.go
@@ -1256,7 +1256,13 @@ func resourceAwsDynamoDBTableUpdateV2(ctx context.Context, d *schema.ResourceDat
 
 	// Generate the ID for the resource and set it.
 	id := fmt.Sprintf("%s/%s", tenantID, fullName)
+	if d.HasChanges("ttl") {
+		err := updateDynamoDBTTl(ctx, d, m)
+		if err != nil {
+			return err
+		}
 
+	}
 	err = dynamodbWaitUntilReady(ctx, c, tenantID, fullName, d.Timeout("update"))
 	if err != nil {
 		return diag.FromErr(err)


### PR DESCRIPTION
## Overview

Enable ttl update on dynamodb
## Summary of changes
Enabled ttl updation for duplocloud_aws_dynamodb_table_v2 resource
This PR does the following:

- managed difference for ttl block
- added code for ttl updation in update context
- updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
