### PR TITLE
DUPLO-26458 TF:GCP:Security Rule: Add support for multiple ports and protocols

### DIFF
--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -256,6 +256,9 @@ Required:
 Required:
 
 - `effect` (String) Update strategy of the node. Effect types <br>      - NoSchedule<br>     - PreferNoSchedule<br>     - NoExecute
+
+Optional:
+
 - `key` (String)
 - `value` (String)
 

--- a/docs/resources/aws_host.md
+++ b/docs/resources/aws_host.md
@@ -226,6 +226,9 @@ Required:
 Required:
 
 - `effect` (String) Update strategy of the node. Effect types <br>      - NoSchedule<br>     - PreferNoSchedule<br>     - NoExecute
+
+Optional:
+
 - `key` (String)
 - `value` (String)
 

--- a/docs/resources/gcp_infra_security_rule.md
+++ b/docs/resources/gcp_infra_security_rule.md
@@ -14,13 +14,21 @@ description: |-
 
 ```terraform
 resource "duplocloud_gcp_infra_security_rule" "irule" {
-  infra_name       = "nonprod"
-  name             = "nonprod-firewall-rule"
-  description      = "firewall rule for infra nonprod"
-  ports            = ["24", "23-89"]
-  service_protocol = "tcp"
-  source_ranges    = ["0.0.0.0/32"]
-  rule_type        = "ALLOW"
+  infra_name  = "test"
+  name        = "test-infra-r14"
+  description = "test rule for infra test"
+  ports_and_protocols {
+    ports            = ["24", "23-89"]
+    service_protocol = "tcp"
+
+  }
+  ports_and_protocols {
+    ports            = ["100"]
+    service_protocol = "udp"
+
+  }
+  source_ranges = ["0.0.0.0/32"]
+  rule_type     = "ALLOW"
 
 }
 ```
@@ -33,13 +41,12 @@ resource "duplocloud_gcp_infra_security_rule" "irule" {
 - `infra_name` (String) The name of the infrastructure where rule gets applied
 - `name` (String) Specify rule name
 - `rule_type` (String) Specify type of access rule (ALLOW , DENY)
-- `service_protocol` (String) The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, sctp, ipip, all), or the IP protocol number.
 - `source_ranges` (List of String) The lists of IPv4 or IPv6 addresses in CIDR format that specify the source of traffic for a firewall rule
 
 ### Optional
 
 - `description` (String) The description related to the rule
-- `ports` (List of String) The list of ports to which this rule applies. This field is only applicable for UDP or TCP protocol.
+- `ports_and_protocols` (Block List) (see [below for nested schema](#nestedblock--ports_and_protocols))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -52,6 +59,18 @@ resource "duplocloud_gcp_infra_security_rule" "irule" {
 - `priority` (Number)
 - `self_link` (String)
 - `source_tags` (List of String)
+
+<a id="nestedblock--ports_and_protocols"></a>
+### Nested Schema for `ports_and_protocols`
+
+Required:
+
+- `service_protocol` (String) The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, sctp, ipip, all), or the IP protocol number.
+
+Optional:
+
+- `ports` (List of String) The list of ports to which this rule applies. This field is only applicable for UDP or TCP protocol.
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/gcp_tenant_security_rule.md
+++ b/docs/resources/gcp_tenant_security_rule.md
@@ -20,11 +20,19 @@ resource "duplocloud_tenant" "myapp" {
 
 
 resource "duplocloud_gcp_tenant_security_rule" "trule" {
-  tenant_id        = duplocloud_tenant.myapp.tenant_id
-  name             = "tenant-rule"
-  description      = "security rule for target tenant"
-  ports            = ["24", "23-89"]
-  service_protocol = "tcp"
+  tenant_id   = duplocloud_tenant.myapp.tenant_id
+  name        = "tenant-rule"
+  description = "security rule for target tenant"
+  ports_and_protocols {
+    ports            = ["24", "23-89"]
+    service_protocol = "tcp"
+
+  }
+  ports_and_protocols {
+    ports            = ["100"]
+    service_protocol = "udp"
+
+  }
   source_ranges    = ["0.0.0.0/32"]
   rule_type        = "ALLOW"
   target_tenant_id = "<target-tenant-id>"
@@ -39,7 +47,6 @@ resource "duplocloud_gcp_tenant_security_rule" "trule" {
 
 - `name` (String) Specify rule name
 - `rule_type` (String) Specify type of access rule (ALLOW , DENY)
-- `service_protocol` (String) The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, sctp, ipip, all), or the IP protocol number.
 - `source_ranges` (List of String) The lists of IPv4 or IPv6 addresses in CIDR format that specify the source of traffic for a firewall rule
 - `target_tenant_id` (String) The GUID of the tenant to which security rule need to be applied
 - `tenant_id` (String) The GUID of the tenant.
@@ -47,7 +54,7 @@ resource "duplocloud_gcp_tenant_security_rule" "trule" {
 ### Optional
 
 - `description` (String) The description related to the rule
-- `ports` (List of String) The list of ports to which this rule applies. This field is only applicable for UDP or TCP protocol.
+- `ports_and_protocols` (Block List) (see [below for nested schema](#nestedblock--ports_and_protocols))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
@@ -62,6 +69,18 @@ resource "duplocloud_gcp_tenant_security_rule" "trule" {
 - `source_service_account` (List of String)
 - `source_tags` (List of String)
 - `target_service_account` (List of String)
+
+<a id="nestedblock--ports_and_protocols"></a>
+### Nested Schema for `ports_and_protocols`
+
+Required:
+
+- `service_protocol` (String) The IP protocol to which this rule applies. The protocol type is required when creating a firewall rule. This value can either be one of the following well known protocol strings (tcp, udp, icmp, esp, ah, sctp, ipip, all), or the IP protocol number.
+
+Optional:
+
+- `ports` (List of String) The list of ports to which this rule applies. This field is only applicable for UDP or TCP protocol.
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/duplocloud/validators.go
+++ b/duplocloud/validators.go
@@ -251,3 +251,26 @@ func validateDateTimeFormat(v interface{}, p cty.Path) diag.Diagnostics {
 
 	return diagnostics
 }
+
+func ValidateNoDuplicatesInList() schema.SchemaValidateFunc {
+	return func(i interface{}, k string) (warnings []string, errors []error) {
+		// Convert the input to a slice of strings
+		values, ok := i.([]interface{})
+		if !ok {
+			errors = append(errors, fmt.Errorf("%s: expected type list", k))
+			return warnings, errors
+		}
+
+		// Use a map to track duplicates
+		seen := make(map[string]bool)
+		for _, v := range values {
+			str := v.(string)
+			if seen[str] {
+				errors = append(errors, fmt.Errorf("%s: duplicate value '%s' found", k, str))
+			}
+			seen[str] = true
+		}
+
+		return warnings, errors
+	}
+}

--- a/duplocloud/validators.go
+++ b/duplocloud/validators.go
@@ -251,26 +251,3 @@ func validateDateTimeFormat(v interface{}, p cty.Path) diag.Diagnostics {
 
 	return diagnostics
 }
-
-func ValidateNoDuplicatesInList() schema.SchemaValidateFunc {
-	return func(i interface{}, k string) (warnings []string, errors []error) {
-		// Convert the input to a slice of strings
-		values, ok := i.([]interface{})
-		if !ok {
-			errors = append(errors, fmt.Errorf("%s: expected type list", k))
-			return warnings, errors
-		}
-
-		// Use a map to track duplicates
-		seen := make(map[string]bool)
-		for _, v := range values {
-			str := v.(string)
-			if seen[str] {
-				errors = append(errors, fmt.Errorf("%s: duplicate value '%s' found", k, str))
-			}
-			seen[str] = true
-		}
-
-		return warnings, errors
-	}
-}

--- a/examples/resources/duplocloud_gcp_infra_security_rule/resource.tf
+++ b/examples/resources/duplocloud_gcp_infra_security_rule/resource.tf
@@ -1,10 +1,19 @@
+
 resource "duplocloud_gcp_infra_security_rule" "irule" {
-  infra_name       = "nonprod"
-  name             = "nonprod-firewall-rule"
-  description      = "firewall rule for infra nonprod"
-  ports            = ["24", "23-89"]
-  service_protocol = "tcp"
-  source_ranges    = ["0.0.0.0/32"]
-  rule_type        = "ALLOW"
+  infra_name  = "test"
+  name        = "test-infra-r14"
+  description = "test rule for infra test"
+  ports_and_protocols {
+    ports            = ["24", "23-89"]
+    service_protocol = "tcp"
+
+  }
+  ports_and_protocols {
+    ports            = ["100"]
+    service_protocol = "udp"
+
+  }
+  source_ranges = ["0.0.0.0/32"]
+  rule_type     = "ALLOW"
 
 }

--- a/examples/resources/duplocloud_gcp_tenant_security_rule/resource.tf
+++ b/examples/resources/duplocloud_gcp_tenant_security_rule/resource.tf
@@ -5,13 +5,22 @@ resource "duplocloud_tenant" "myapp" {
 
 
 resource "duplocloud_gcp_tenant_security_rule" "trule" {
-  tenant_id        = duplocloud_tenant.myapp.tenant_id
-  name             = "tenant-rule"
-  description      = "security rule for target tenant"
-  ports            = ["24", "23-89"]
-  service_protocol = "tcp"
+  tenant_id   = duplocloud_tenant.myapp.tenant_id
+  name        = "tenant-rule"
+  description = "security rule for target tenant"
+  ports_and_protocols {
+    ports            = ["24", "23-89"]
+    service_protocol = "tcp"
+
+  }
+  ports_and_protocols {
+    ports            = ["100"]
+    service_protocol = "udp"
+
+  }
   source_ranges    = ["0.0.0.0/32"]
   rule_type        = "ALLOW"
   target_tenant_id = "<target-tenant-id>"
 
 }
+


### PR DESCRIPTION
…

## Overview
Add support for multiple ports and protocols for gcp sg rule

## Summary of changes
Added support for multiple port and protocol. Added validation for duplicate source_ranges for duplocloud_gcp_tenant_security_rule and duplocloud_gcp_infra_security_rule resources

This PR does the following:

- Updated schema for ports and protocols. 
- Updated code to set and get ports and protocols
- Added duplicate check validation for source_ranges
- updated example and documentation
## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [x] Manually, on a remote test system

## Describe any breaking changes

- ...
