### PR TITLE
DUPLO-25464 DOC:TF:S3: Replication: Change name of source_bucket and destination_bucket to fullname in document

### DIFF
--- a/docs/resources/s3_bucket_replication.md
+++ b/docs/resources/s3_bucket_replication.md
@@ -41,7 +41,7 @@ resource "duplocloud_s3_bucket_replication" "rep" {
 ### Required
 
 - `rules` (Block List, Min: 1, Max: 1) replication rules for source bucket (see [below for nested schema](#nestedblock--rules))
-- `source_bucket` (String) name of source bucket.
+- `source_bucket` (String) fullname of the source bucket.
 - `tenant_id` (String) The GUID of the tenant that the S3 bucket replication rule will be created in.
 
 ### Optional
@@ -57,7 +57,7 @@ resource "duplocloud_s3_bucket_replication" "rep" {
 
 Required:
 
-- `destination_bucket` (String) name of destination bucket.
+- `destination_bucket` (String) fullname of the destination bucket.
 - `name` (String) replication rule name for s3 source bucket
 - `priority` (Number) replication priority. Priority must be unique between multiple rules.
 

--- a/duplocloud/resource_duplo_s3_replication.go
+++ b/duplocloud/resource_duplo_s3_replication.go
@@ -19,7 +19,7 @@ func ruleSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"destination_bucket": {
-				Description: "name of destination bucket.",
+				Description: "fullname of the destination bucket.",
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
@@ -95,7 +95,7 @@ func s3BucketReplicationSchema() map[string]*schema.Schema {
 		},
 
 		"source_bucket": {
-			Description: "name of source bucket.",
+			Description: "fullname of the source bucket.",
 			Type:        schema.TypeString,
 			Required:    true,
 			ForceNew:    true,


### PR DESCRIPTION
## Overview

Update documentation

## Summary of changes
 Document updation for duplocloud_s3_bucket_replication resource

This PR does the following:

- update documentation for destination_bucket and source_bucket field
- ...

## Testing performed

- [ ] Using unit tests
- [ ✔︎] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
