### PR TITLE
DUPLO-21148 TF:AWS:K8s nodes: Update and apply of 'Node Labels' shows no changes for resource 'duplocloud_asg_profile'

### DIFF
--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -259,12 +259,15 @@ func nativeHostSchema() map[string]*schema.Schema {
 			},
 		},
 		"custom_node_labels": {
-			Description:      "Specify the labels to attach to the nodes.",
-			Type:             schema.TypeMap,
-			Optional:         true,
-			Computed:         true,
-			Elem:             &schema.Schema{Type: schema.TypeString},
-			DiffSuppressFunc: diffSuppressWhenNotCreating,
+			Description: "Specify the labels to attach to the nodes.",
+			Type:        schema.TypeMap,
+			Optional:    true,
+			Computed:    true,
+			Elem: &schema.Schema{
+				Type: schema.TypeString,
+			},
+			//	DiffSuppressFunc: diffSuppressWhenNotCreating,
+			ForceNew: true,
 		},
 
 		"taints": {
@@ -722,7 +725,7 @@ func nativeHostToState(ctx context.Context, d *schema.ResourceData, duplo *duplo
 	//d.Set("metadata", keyValueToState("metadata", duplo.MetaData))
 	d.Set("volume", flattenNativeHostVolumes(duplo.Volumes))
 	d.Set("network_interface", flattenNativeHostNetworkInterfaces(duplo.NetworkInterfaces))
-	if duplo.IsMinion {
+	if duplo.IsMinion && duplo.AgentPlatform == 7 {
 		obj, _ := c.GetMinionForHost(ctx, duplo.TenantID, duplo.InstanceID)
 		if obj != nil && len(obj.Taints) > 0 {
 			d.Set("taints", flattenMinionTaints(obj.Taints))


### PR DESCRIPTION
## Overview

Node labels change should recreate resource
## Summary of changes
made custom_node_labels field force new on resource duplocloud_asg_profile
This PR does the following:

- made custom_node_labels field force new
- tested native host side planning fixed waiting issue

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
