### PR TITLE
DUPLO-25421 TF:RDS:Performance Insight: Plan shows changes in performance insights for Cluster DB replica without any modification

### DIFF
--- a/duplocloud/resource_duplo_rds_read_replica.go
+++ b/duplocloud/resource_duplo_rds_read_replica.go
@@ -129,6 +129,7 @@ func rdsReadReplicaSchema() map[string]*schema.Schema {
 			Type:             schema.TypeList,
 			MaxItems:         1,
 			Optional:         true,
+			Computed:         true,
 			DiffSuppressFunc: suppressIfPerformanceInsightsDisabled,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## Overview

Handled diff for no change on performance insights in replica resource
## Summary of changes
Handled diff on no change on performance insights in duplocloud_rds_read_replica resource
This PR does the following:

- Added computed constraint to performance_insight parent block
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
