### PR TITLE
DUPLO-26485 DUPLO-26486 DUPLO-26488

### DIFF
--- a/docs/resources/gcp_infra_security_rule.md
+++ b/docs/resources/gcp_infra_security_rule.md
@@ -40,13 +40,13 @@ resource "duplocloud_gcp_infra_security_rule" "irule" {
 
 - `infra_name` (String) The name of the infrastructure where rule gets applied
 - `name` (String) Specify rule name
+- `ports_and_protocols` (Block List, Min: 1) (see [below for nested schema](#nestedblock--ports_and_protocols))
 - `rule_type` (String) Specify type of access rule (ALLOW , DENY)
 - `source_ranges` (List of String) The lists of IPv4 or IPv6 addresses in CIDR format that specify the source of traffic for a firewall rule
 
 ### Optional
 
 - `description` (String) The description related to the rule
-- `ports_and_protocols` (Block List) (see [below for nested schema](#nestedblock--ports_and_protocols))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/gcp_tenant_security_rule.md
+++ b/docs/resources/gcp_tenant_security_rule.md
@@ -46,6 +46,7 @@ resource "duplocloud_gcp_tenant_security_rule" "trule" {
 ### Required
 
 - `name` (String) Specify rule name
+- `ports_and_protocols` (Block List, Min: 1) (see [below for nested schema](#nestedblock--ports_and_protocols))
 - `rule_type` (String) Specify type of access rule (ALLOW , DENY)
 - `source_ranges` (List of String) The lists of IPv4 or IPv6 addresses in CIDR format that specify the source of traffic for a firewall rule
 - `target_tenant_id` (String) The GUID of the tenant to which security rule need to be applied
@@ -54,7 +55,6 @@ resource "duplocloud_gcp_tenant_security_rule" "trule" {
 ### Optional
 
 - `description` (String) The description related to the rule
-- `ports_and_protocols` (Block List) (see [below for nested schema](#nestedblock--ports_and_protocols))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/duplocloud/resource_duplo_gcp_infra_security_rule.go
+++ b/duplocloud/resource_duplo_gcp_infra_security_rule.go
@@ -35,7 +35,7 @@ func schemaSecurityRule() map[string]*schema.Schema {
 		},
 		"ports_and_protocols": {
 			Type:     schema.TypeList,
-			Optional: true,
+			Required: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"ports": {
@@ -299,6 +299,20 @@ func validateGCPSecurityRuleAttribute(ctx context.Context, diff *schema.Resource
 			return fmt.Errorf("duplicate value in source_ranges not allowed")
 		}
 		dup[v.(string)] = struct{}{}
+	}
+	pp := diff.Get("ports_and_protocols").([]interface{})
+	hasAll := false
+	for _, v := range pp {
+		mp := v.(map[string]interface{})
+		vl := mp["service_protocol"].(string)
+		if vl == "all" {
+			if len(pp) > 1 {
+				return fmt.Errorf("cannot pass other service_protocol with 'all'")
+			}
+			hasAll = true
+		} else if hasAll {
+			return fmt.Errorf("cannot pass other service_protocol with 'all'")
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Overview

GCP security rule bug fixes
TF:GCP:Security Rule: TF should have 'ports_and_protocols' as 'All' in .tfstate file when 'all' is defined along with other type of protocols
TF:GCP:Security Rule: ports_and_protocols filed is blank in .tfstate when service_protocol = "all"
DOC:TF:GCP:Security Rule: Correct 'ports_and_protocols' as a required field
## Summary of changes

1. Not allowing other service protocol to be requested along with all 
2. all service protocol is getting set in appropriate field
3. documentation update
This PR does the following:

- Added logic to throw error if any other service protocol is mentioned with all
- Documentation updated

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
