### PR TITLE
DUPLO-26671 DUPLO-26672 DUPLO-26673 DUPLO-26675 DUPLO-26679 DUPLO-26683 DUPLO-26684 DUPLO-26686

### DIFF
--- a/docs/resources/azure_availability_set.md
+++ b/docs/resources/azure_availability_set.md
@@ -33,14 +33,14 @@ resource "duplocloud_azure_availability_set" "st" {
 ### Required
 
 - `name` (String) The name for availability set
-- `platform_fault_domain_count` (Number) Specify platform fault domain count for availability set
-- `platform_update_domain_count` (Number) Specify platform update domain count for availability set.
-- `sku_name` (String) Specify sku name for availability set.
 - `tenant_id` (String) The GUID of the tenant that the host will be created in.
 
 ### Optional
 
+- `platform_fault_domain_count` (Number) Specify platform fault domain count betweem 1-3, for availability set. Virtual machines in the same fault domain share a common power source and physical network switch. Defaults to `2`.
+- `platform_update_domain_count` (Number) Specify platform update domain count between 1-20, for availability set. Virtual machines in the same update domain will be restarted together during planned maintenance. Azure never restarts more than one update domain at a time. Defaults to `5`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
+- `use_managed_disk` (String) Set this to `Aligned` if you plan to create virtual machines in this availability set with managed disks. Defaults to `Classic`.
 
 ### Read-Only
 


### PR DESCRIPTION

## Overview
TF:Availability Set: Make 'sku_name' , 'update_domain_count' and 'fault_domain_count' as optional fields
TF: Availability Set: Define default values for fields  'update_domain_count' and 'fault_domain_count' and sku_name
DOC:TF:Availability Set: Need to make changes in document for resource 'duplocloud_azure_availability_set'
TF: Availability Set: Add validation for field 'name' for resource 'duplocloud_azure_availability_set'
TF: Availability Set: Add count limit validation for field 'platform_update_domain_count' and 'platform_fault_domain_count
TF: Availability Set: TF shows forces replacement for name when re-plan without any modification in code
TF: Availability Set: TF should not allow invalid sku_name and throw user friendly error
TF: Availability Set' Change abbreviation for property 'Use managed disks'

## Summary of changes
changed sku_name field name to use_managed_disk, 
added default values to fields, 
added name validation, 
added description to field, 
added validation to field
made fields optional
updated documentation
This PR does the following:

- changed sku_name field name to use_managed_disk, 
- added default values to fields, 
- added name validation, 
- added description to field, 
- added validation to field
- made fields optional
- updated documentation

## Testing performed

- [ ] Using unit tests
- [ ✔︎] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
