### PR TITLE
Duplo 26704 DOC:TF:Security Rule: 'sctp' protocol is missing in schema of ports_and_protocols

### DIFF
--- a/docs/resources/gcp_infra_security_rule.md
+++ b/docs/resources/gcp_infra_security_rule.md
@@ -69,7 +69,7 @@ Required:
 
 Optional:
 
-- `ports` (List of String) The list of ports to which this rule applies. This field is only applicable for UDP or TCP protocol.
+- `ports` (List of String) The list of ports to which this rule applies. This field is only applicable for UDP, TCP and SCTP protocol.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/docs/resources/gcp_tenant_security_rule.md
+++ b/docs/resources/gcp_tenant_security_rule.md
@@ -79,7 +79,7 @@ Required:
 
 Optional:
 
-- `ports` (List of String) The list of ports to which this rule applies. This field is only applicable for UDP or TCP protocol.
+- `ports` (List of String) The list of ports to which this rule applies. This field is only applicable for UDP, TCP and SCTP protocol.
 
 
 <a id="nestedblock--timeouts"></a>

--- a/duplocloud/resource_duplo_gcp_infra_security_rule.go
+++ b/duplocloud/resource_duplo_gcp_infra_security_rule.go
@@ -39,7 +39,7 @@ func schemaSecurityRule() map[string]*schema.Schema {
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"ports": {
-						Description: "The list of ports to which this rule applies. This field is only applicable for UDP or TCP protocol.",
+						Description: "The list of ports to which this rule applies. This field is only applicable for UDP, TCP and SCTP protocol.",
 						Type:        schema.TypeList,
 						Optional:    true,
 						Elem:        &schema.Schema{Type: schema.TypeString},


### PR DESCRIPTION
## Overview

Documentation update
## Summary of changes

This PR does the following:

- Documentation update

- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
