### PR TITLE
DUPLO-26665 TF:EKS: Value should be optional field for taints

### DIFF
--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -257,6 +257,9 @@ Required:
 
 - `effect` (String) Update strategy of the node. Effect types <br>      - NoSchedule<br>     - PreferNoSchedule<br>     - NoExecute
 - `key` (String)
+
+Optional:
+
 - `value` (String)
 
 

--- a/docs/resources/aws_host.md
+++ b/docs/resources/aws_host.md
@@ -227,6 +227,9 @@ Required:
 
 - `effect` (String) Update strategy of the node. Effect types <br>      - NoSchedule<br>     - PreferNoSchedule<br>     - NoExecute
 - `key` (String)
+
+Optional:
+
 - `value` (String)
 
 

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -284,7 +284,7 @@ func nativeHostSchema() map[string]*schema.Schema {
 					},
 					"value": {
 						Type:         schema.TypeString,
-						Required:     true,
+						Optional:     true,
 						ForceNew:     true,
 						ValidateFunc: validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9-]{0,62}$`), "Invalid value format: taint value must begin with a letter or number, can contain letters, numbers, hyphens(-), and be up to 63 characters long"),
 					},


### PR DESCRIPTION
## Overview

made values optional for taints
## Summary of changes
made values optional for taints in duplocloud_aws_host resource
This PR does the following:

- made values optional for taints
- documentation update

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
