### PR TITLE
[TF] Creating an RDS with name starting with duplo fails

### DIFF
--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -40,7 +40,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 				validation.StringMatch(regexp.MustCompile(`^[a-z0-9-]*$`), "Invalid RDS instance name"),
 				validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "RDS instance name cannot end with a hyphen"),
 				validation.StringDoesNotMatch(regexp.MustCompile(`--`), "RDS instance name cannot contain two hyphens"),
-
+				duplosdk.ValidateRdsNoDoubleDuploPrefix,
 				// NOTE: some validations are moot, because Duplo provides a prefix and suffix for the name:
 				//
 				// - First character must be a letter

--- a/duplocloud/resource_duplo_rds_read_replica.go
+++ b/duplocloud/resource_duplo_rds_read_replica.go
@@ -37,7 +37,7 @@ func rdsReadReplicaSchema() map[string]*schema.Schema {
 				validation.StringMatch(regexp.MustCompile(`^[a-z0-9-]*$`), "Invalid RDS read replica name"),
 				validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "RDS read replica name cannot end with a hyphen"),
 				validation.StringDoesNotMatch(regexp.MustCompile(`--`), "RDS read replica name cannot contain two hyphens"),
-
+				duplosdk.ValidateRdsNoDoubleDuploPrefix,
 				// NOTE: some validations are moot, because Duplo provides a prefix and suffix for the name:
 				//
 				// - First character must be a letter

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -203,11 +203,11 @@ func (c *Client) RdsInstanceDelete(id string) (*DuploRdsInstance, ClientError) {
 	idParts := strings.SplitN(id, "/", 5)
 	tenantID := idParts[2]
 	name := idParts[4]
-
+	identifier := EnsureDuploPrefixInRdsIdentifier(name)
 	// Call the API.
 	err := c.deleteAPI(
-		fmt.Sprintf("RdsInstanceDelete(%s, duplo%s)", tenantID, name),
-		fmt.Sprintf("v3/subscriptions/%s/aws/rds/instance/duplo%s", tenantID, name),
+		fmt.Sprintf("RdsInstanceDelete(%s, %s)", tenantID, identifier),
+		fmt.Sprintf("v3/subscriptions/%s/aws/rds/instance/%s", tenantID, identifier),
 		nil)
 	if err != nil {
 		return nil, err
@@ -222,12 +222,12 @@ func (c *Client) RdsInstanceGet(id string) (*DuploRdsInstance, ClientError) {
 	idParts := strings.SplitN(id, "/", 5)
 	tenantID := idParts[2]
 	name := idParts[4]
-
+	identifier := EnsureDuploPrefixInRdsIdentifier(name)
 	// Call the API.
 	duploObject := DuploRdsInstance{}
 	err := c.getAPI(
-		fmt.Sprintf("RdsInstanceGet(%s, duplo%s)", tenantID, name),
-		fmt.Sprintf("v3/subscriptions/%s/aws/rds/instance/duplo%s", tenantID, name),
+		fmt.Sprintf("RdsInstanceGet(%s, %s)", tenantID, identifier),
+		fmt.Sprintf("v3/subscriptions/%s/aws/rds/instance/%s", tenantID, identifier),
 		&duploObject)
 	if err != nil || duploObject.Identifier == "" {
 		return nil, err
@@ -239,12 +239,12 @@ func (c *Client) RdsInstanceGet(id string) (*DuploRdsInstance, ClientError) {
 }
 
 func (c *Client) RdsInstanceGetByName(tenantID, name string) (*DuploRdsInstance, ClientError) {
-
+	identifier := EnsureDuploPrefixInRdsIdentifier(name)
 	// Call the API.
 	duploObject := DuploRdsInstance{}
 	err := c.getAPI(
-		fmt.Sprintf("RdsInstanceGet(%s, duplo%s)", tenantID, name),
-		fmt.Sprintf("v3/subscriptions/%s/aws/rds/instance/duplo%s", tenantID, name),
+		fmt.Sprintf("RdsInstanceGet(%s, %s)", tenantID, identifier),
+		fmt.Sprintf("v3/subscriptions/%s/aws/rds/instance/%s", tenantID, identifier),
 		&duploObject)
 	if err != nil || duploObject.Identifier == "" {
 		return nil, err
@@ -421,4 +421,36 @@ func (c *Client) RdsTagDeleteV3(tenantID string, tag DuploRDSTag) ClientError {
 		fmt.Sprintf("v3/subscriptions/%s/aws/rds/%s/%s/tag/%s", tenantID, tag.ResourceType, tag.ResourceId, urlSafeBase64Encode(tag.Key)),
 		nil,
 	)
+}
+
+const (
+	AWSRdsPrefix = "duplo"
+)
+
+func EnsureDuploPrefixInRdsIdentifier(name string) string {
+	identifier := strings.TrimSpace(name)
+	for strings.HasPrefix(identifier, AWSRdsPrefix) {
+		identifier = strings.TrimPrefix(identifier, AWSRdsPrefix)
+		identifier = strings.TrimSpace(identifier)
+	}
+	return AWSRdsPrefix + identifier
+}
+
+func ValidateRdsNoDoubleDuploPrefix(v interface{}, k string) (ws []string, errors []error) {
+	value := v.(string)
+	trimmedValue := strings.TrimSpace(value)
+	if !strings.HasPrefix(trimmedValue, AWSRdsPrefix) {
+		return
+	}
+	// Check for multiple consecutive 'duplo' prefixes
+	count := 0
+	for strings.HasPrefix(trimmedValue, AWSRdsPrefix) {
+		trimmedValue = strings.TrimPrefix(trimmedValue, AWSRdsPrefix)
+		trimmedValue = strings.TrimSpace(trimmedValue)
+		count++
+	}
+	if count > 1 {
+		errors = append(errors, fmt.Errorf("%q cannot contain multiple consecutive '%s' prefixes", k, AWSRdsPrefix))
+	}
+	return
 }


### PR DESCRIPTION
## Overview

[TF] Creating an RDS with name starting with duplo fails
refer images from 

https://github.com/duplocloud-internal/duplo/pull/3541
 
## Summary of changes

This PR does the following:

- rds add validation for duplo prefix
- do not allow double prefix

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
