### PR TITLE
DUPLO-26030 Ingress `host` property of rules can't be removed in Terraform

### DIFF
--- a/duplocloud/resource_duplo_k8_ingress.go
+++ b/duplocloud/resource_duplo_k8_ingress.go
@@ -113,7 +113,6 @@ func k8sIngressSchema() map[string]*schema.Schema {
 					"host": {
 						Description: "If a host is provided (for e.g. example, foo.bar.com), the rules apply to that host.",
 						Type:        schema.TypeString,
-						Computed:    true,
 						Optional:    true,
 					},
 					"service_name": {


### PR DESCRIPTION
## Overview
Host field in rule block of duplocloud_k8_ingress doesnt show diff on change
## Summary of changes
Fixed non removal of host field in rule block of ingress resource
This PR does the following:

- Removed compute attribute fro host field of duplocloud_k8_ingress resource
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
