### PR TITLE
DUPLO-26437 TF: Resource 'duplocloud_ecache_instance' should not allow replicas more than 6 for Redis and should throw user friendly validation error

### DIFF
--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -165,7 +165,7 @@ See AWS documentation for the [available Redis instance types](https://docs.aws.
 - `log_delivery_configuration` (Block Set, Max: 2) (see [below for nested schema](#nestedblock--log_delivery_configuration))
 - `number_of_shards` (Number) The number of shards to create.
 - `parameter_group_name` (String) The REDIS parameter group to supply.
-- `replicas` (Number) The number of replicas to create. Defaults to `1`.
+- `replicas` (Number) The number of replicas to create. Supported number of replicas is 1 to 6 Defaults to `1`.
 - `snapshot_arns` (List of String) Specify the ARN of a Redis RDB snapshot file stored in Amazon S3. User should have the access to export snapshot to s3 bucket. One can find steps to provide access to export snapshot to s3 on following link https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-exporting.html
 - `snapshot_name` (String) Select the snapshot/backup you want to use for creating redis.
 - `snapshot_retention_limit` (Number) Specify retention limit in days. Accepted values - 1-35.

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -92,12 +92,12 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^cache\.`), "Elasticache instance types must start with 'cache.'"),
 		},
 		"replicas": {
-			Description:  "The number of replicas to create.",
+			Description:  "The number of replicas to create. Supported number of replicas is 1 to 6",
 			Type:         schema.TypeInt,
 			Optional:     true,
 			ForceNew:     true,
 			Default:      1,
-			ValidateFunc: validation.IntBetween(1, 40),
+			ValidateFunc: validation.IntBetween(1, 6),
 		},
 		"encryption_at_rest": {
 			Description: "Enables encryption-at-rest.",


### PR DESCRIPTION
## Overview

Fix for supported replica count for ecache instance
## Summary of changes
Added replica validation restricted to 6 for duplocloud_ecache_instance resource
This PR does the following:

- added replica validation restricted to 6
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
