### PR TITLE
Duplo-26128 Terraform always recreates duplocloud_aws_host when encrypt_disk is true

### DIFF
--- a/docs/data-sources/asg_profiles.md
+++ b/docs/data-sources/asg_profiles.md
@@ -62,7 +62,6 @@ Read-Only:
 - `user_account` (String)
 - `volume` (List of Object) (see [below for nested schema](#nestedobjatt--asg_profiles--volume))
 - `wait_for_capacity` (Boolean)
-- `zone` (Number)
 - `zones` (List of Number)
 
 <a id="nestedobjatt--asg_profiles--metadata"></a>

--- a/docs/resources/aws_host.md
+++ b/docs/resources/aws_host.md
@@ -141,7 +141,6 @@ resource "duplocloud_aws_host" "host" {
 - `base64_user_data` (String) Base64 encoded EC2 user data to associated with the host.
 - `cloud` (Number) The numeric ID of the cloud provider to launch the host in. Defaults to `0`.
 - `custom_node_labels` (Map of String) Specify the labels to attach to the nodes.
-- `encrypt_disk` (Boolean) Defaults to `false`.
 - `is_ebs_optimized` (Boolean) Defaults to `false`.
 - `is_minion` (Boolean) Defaults to `true`.
 - `keypair_type` (Number) The numeric ID of the keypair type being used.Should be one of:

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -343,7 +343,7 @@ func resourceAwsHost() *schema.Resource {
 		Default:          true,
 		DiffSuppressFunc: diffSuppressWhenNotCreating,
 	}
-
+	delete(awsHostSchema, "encrypt_disk")
 	return &schema.Resource{
 		Description: "The duplocloud_aws_host represents an AWS resource, such as an EC2 instance, that is managed and automated through DuploCloud. It provides seamless integration and governance within AWS, enabling efficient deployment, management, and scaling of cloud infrastructure through DuploCloud’s platform.",
 

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -610,7 +610,6 @@ func expandNativeHost(d *schema.ResourceData) *duplosdk.DuploNativeHost {
 		AllocatedPublicIP: d.Get("allocated_public_ip").(bool),
 		Cloud:             d.Get("cloud").(int),
 		KeyPairType:       d.Get("keypair_type").(int),
-		EncryptDisk:       d.Get("encrypt_disk").(bool),
 		MetaData:          keyValueFromState("metadata", d),
 		Tags:              keyValueFromState("tags", d),
 		MinionTags:        keyValueFromState("minion_tags", d),
@@ -702,7 +701,6 @@ func nativeHostToState(ctx context.Context, d *schema.ResourceData, duplo *duplo
 	d.Set("is_ebs_optimized", duplo.IsEbsOptimized)
 	d.Set("cloud", duplo.Cloud)
 	d.Set("keypair_type", duplo.KeyPairType)
-	d.Set("encrypt_disk", duplo.EncryptDisk)
 	d.Set("status", duplo.Status)
 	d.Set("identity_role", duplo.IdentityRole)
 	d.Set("private_ip_address", duplo.PrivateIPAddress)


### PR DESCRIPTION
## Overview

Removed irrelevant field
## Summary of changes
Removed encrypt_disk field from duplocloud_aws_host resource
This PR does the following:

- Removed encrypt_disk field from duplocloud_aws_host
- Updated document

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
