### PR TITLE
DUPLO-29246 SQS Queue Name limited characters on 0.10.54

### DIFF
--- a/docs/resources/aws_sqs_queue.md
+++ b/docs/resources/aws_sqs_queue.md
@@ -50,7 +50,7 @@ resource "duplocloud_aws_sqs_queue" "sqs_queue_with_dlq" {
 
 ### Required
 
-- `name` (String) The name of the queue. Queue names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 80 characters long.
+- `name` (String) The name of the queue. Queue names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and have up to 80 characters long.
 - `tenant_id` (String) The GUID of the tenant that the SQS queue will be created in.
 
 ### Optional

--- a/duplocloud/resource_duplo_aws_sqs_queue.go
+++ b/duplocloud/resource_duplo_aws_sqs_queue.go
@@ -29,11 +29,11 @@ func duploAwsSqsQueueSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.IsUUID,
 		},
 		"name": {
-			Description:  "The name of the queue. Queue names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and must be between 1 and 80 characters long.",
+			Description:  "The name of the queue. Queue names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and have up to 80 characters long.",
 			Type:         schema.TypeString,
 			ForceNew:     true,
 			Required:     true,
-			ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_-]{1,33}$"), "invalid name format. Name can contain alphabet, numbers, hyphen and underscores, it should start with a alphabet and should be minimum 2  and max 34 character long"),
+			ValidateFunc: validation.StringMatch(regexp.MustCompile("^[a-zA-Z][a-zA-Z0-9_-]{0,79}$"), "invalid name format. Name can contain alphabet, numbers, hyphen and underscores, it should start with a alphabet and have up to 80 character long"),
 		},
 		"fifo_queue": {
 			Description: "Boolean designating a FIFO queue. If not set, it defaults to `false` making it standard.",


### PR DESCRIPTION
## Overview

Fixed name length of sqs to 80
## Summary of changes
Fixed name length of to 80 duplocloud_aws_sqs_queue
This PR does the following:

- Updated regex validation for duplocloud_aws_sqs_queue
- Updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
