### PR TITLE
DUPLO-29275 TF:RDS: .tfstate file contains 'DB parameter_group_name' for DocumentDB

### DIFF
--- a/docs/resources/aws_sqs_queue.md
+++ b/docs/resources/aws_sqs_queue.md
@@ -50,7 +50,7 @@ resource "duplocloud_aws_sqs_queue" "sqs_queue_with_dlq" {
 
 ### Required
 
-- `name` (String) The name of the queue. Queue names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and have up to 80 characters long which is inclusive of duplo prefix (duploservices-{tenant_name}-) appended by the system, allowed input length for name field is 47 .
+- `name` (String) The name of the queue. Queue names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and have up to 80 characters long which is inclusive of duplo prefix (duploservices-{tenant_name}-) appended by the system.
 - `tenant_id` (String) The GUID of the tenant that the SQS queue will be created in.
 
 ### Optional

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -15,6 +15,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -363,7 +364,7 @@ func resourceDuploRdsInstance() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 		Schema:        rdsInstanceSchema(),
-		CustomizeDiff: validateRDSParameters,
+		CustomizeDiff: customdiff.All(validateRDSParameters, validateRDSGroupParameters),
 	}
 }
 
@@ -1108,11 +1109,6 @@ func validateRDSParameters(ctx context.Context, diff *schema.ResourceDiff, m int
 			}
 		}
 	}
-	if isOnlyClusterGroupParameterSupportDb(eng) && diff.Get("parameter_group_name").(string) != "" {
-		return fmt.Errorf("RDS engine %s  do not support  parameter_group_name ", engines[eng])
-	} else if !isClusterGroupParameterSupportDb(eng) && diff.Get("cluster_parameter_group_name").(string) != "" && eng != 13 {
-		return fmt.Errorf("RDS engine %s  do not support  cluster_parameter_group_name ", engines[eng])
-	}
 	return nil
 }
 
@@ -1215,4 +1211,29 @@ func rdsInstanceSyncParameterGroup(ctx context.Context, c *duplosdk.Client, id s
 	log.Printf("[DEBUG] RdsInstanceWaitUntilUnavailable (%s)", id)
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
+}
+
+func validateRDSGroupParameters(ctx context.Context, diff *schema.ResourceDiff, m interface{}) error {
+	engines := map[int]string{
+		0:  "MySQL",
+		1:  "PostgreSQL",
+		2:  "MsftSQL-Express",
+		3:  "MsftSQL-Standard",
+		8:  "Aurora-MySQL",
+		9:  "Aurora-PostgreSQL",
+		10: "MsftSQL-Web",
+		11: "Aurora-Serverless-MySql",
+		12: "Aurora-Serverless-PostgreSql",
+		13: "DocumentDB",
+		14: "MariaDB",
+		16: "Aurora",
+	}
+
+	eng := diff.Get("engine").(int)
+	if isOnlyClusterGroupParameterSupportDb(eng) && diff.Get("parameter_group_name").(string) != "" {
+		return fmt.Errorf("RDS engine %s  do not support  parameter_group_name ", engines[eng])
+	} else if !isClusterGroupParameterSupportDb(eng) && diff.Get("cluster_parameter_group_name").(string) != "" && eng != 13 {
+		return fmt.Errorf("RDS engine %s  do not support  cluster_parameter_group_name ", engines[eng])
+	}
+	return nil
 }


### PR DESCRIPTION
## Overview

Restricting parameter_group_name for document db

## Summary of changes
Not allowing to set parameter_group_name for document db for duplocloud_rds_instance resource
This PR does the following:

- Added validation to check supported parameter group for a dbtype
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
