### PR TITLE
DUPLO-29276 TF:RDS: Add support of parameter group for read replica DUPLO-29278 Doc:TF:RDS: Add sample usage example for RDS with parameter group DUPLO-29264 TF:RDS: Add validation for 'cluster_parameter_group_name' for non applicable engine types

### DIFF
--- a/docs/resources/rds_read_replica.md
+++ b/docs/resources/rds_read_replica.md
@@ -162,12 +162,15 @@ See AWS documentation for the [available instance types](https://aws.amazon.com/
 ### Optional
 
 - `availability_zone` (String) The AZ for the RDS instance.
+- `engine_type` (Number) Engine type required to validate applicable parameter group setting for different instance. Should be referred from writer
+- `parameter_group_name` (String) A RDS parameter group name to apply to the RDS instance. This field will behave as computed field for rds instances like MySQL, PostgreSQL, MariaDB
 - `performance_insights` (Block List, Max: 1) Amazon RDS Performance Insights is a database performance tuning and monitoring feature that helps you quickly assess the load on your database, and determine when and where to take action. Perfomance Insights get apply when enable is set to true. (see [below for nested schema](#nestedblock--performance_insights))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `arn` (String) The ARN of the RDS read replica.
+- `cluster_parameter_group_name` (String) Parameter group associated with this instance's DB Cluster.
 - `enable_logging` (Boolean) Whether or not to enable the RDS instance logging. This setting is not applicable for document db cluster instance.
 - `encrypt_storage` (Boolean) Whether or not to encrypt the RDS instance storage.
 - `endpoint` (String) The endpoint of the RDS read replica.

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -361,7 +361,7 @@ func resourceDuploRdsInstance() *schema.Resource {
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(45 * time.Minute),
 			Update: schema.DefaultTimeout(20 * time.Minute),
-			Delete: schema.DefaultTimeout(20 * time.Minute),
+			Delete: schema.DefaultTimeout(45 * time.Minute),
 		},
 		Schema:        rdsInstanceSchema(),
 		CustomizeDiff: customdiff.All(validateRDSParameters, validateRDSGroupParameters),

--- a/duplocloud/resource_duplo_rds_read_replica.go
+++ b/duplocloud/resource_duplo_rds_read_replica.go
@@ -94,6 +94,12 @@ func rdsReadReplicaSchema() map[string]*schema.Schema {
 			Type:        schema.TypeInt,
 			Computed:    true,
 		},
+		"engine_type": {
+			Description: "Engine type required to validate applicable parameter group setting for different instance. Should be referred from writer",
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Computed:    true,
+		},
 		"engine_version": {
 			Description: "The database engine version to be used the for the RDS read replica.",
 			Type:        schema.TypeString,
@@ -121,6 +127,21 @@ func rdsReadReplicaSchema() map[string]*schema.Schema {
 		},
 		"replica_status": {
 			Description: "The current status of the RDS read replica.",
+			Type:        schema.TypeString,
+			Computed:    true,
+		},
+		"parameter_group_name": {
+			Description: "A RDS parameter group name to apply to the RDS instance. This field will behave as computed field for rds instances like MySQL, PostgreSQL, MariaDB",
+			Type:        schema.TypeString,
+			Optional:    true,
+			ValidateFunc: validation.All(
+				validation.StringLenBetween(1, 255),
+				validation.StringDoesNotMatch(regexp.MustCompile(`-$`), "DB parameter group name cannot end with a hyphen"),
+				validation.StringDoesNotMatch(regexp.MustCompile(`--`), "DB parameter group name cannot contain two hyphens"),
+			),
+		},
+		"cluster_parameter_group_name": {
+			Description: "Parameter group associated with this instance's DB Cluster.",
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
@@ -181,7 +202,7 @@ func resourceDuploRdsReadReplica() *schema.Resource {
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
 		Schema:        rdsReadReplicaSchema(),
-		CustomizeDiff: customdiff.All(validateRDSParameters),
+		CustomizeDiff: customdiff.All(validateRDSParameters, validateRDSReplicaUse),
 	}
 }
 
@@ -308,7 +329,27 @@ func resourceDuploRdsReadReplicaUpdate(ctx context.Context, d *schema.ResourceDa
 	tenantID := d.Get("tenant_id").(string)
 	id := d.Id()
 	identifier := d.Get("identifier").(string)
+	eng := d.Get("engine_type").(int)
+	if d.HasChange("parameter_group_name") && eng != 0 && eng != 1 && eng != 14 {
+		req := duplosdk.DuploRdsUpdatePayload{}
+		if v, ok := d.GetOk("parameter_group_name"); ok {
+			req.DbParameterGroupName = v.(string)
+		}
+		err := c.RdsInstanceUpdateParameterGroupName(tenantID, identifier, &req)
+		if err != nil {
+			return diag.FromErr(err)
+		}
 
+		err = rdsInstanceWaitUntilAvailable(ctx, c, id, 7*time.Minute)
+		if err != nil {
+			return diag.Errorf("Error waiting for RDS DB instance '%s' to be unavailable: %s", id, err)
+		}
+		err = rdsInstanceSyncParameterGroup(ctx, c, id, 20*time.Minute, req.DbParameterGroupName, "DBPARAM")
+		if err != nil {
+			return diag.Errorf("Error waiting for RDS DB instance '%s' to update db parameter group name: %s", id, err.Error())
+
+		}
+	}
 	obj := duplosdk.DuploRdsUpdatePerformanceInsights{}
 	pI := expandPerformanceInsight(d)
 	if pI != nil {
@@ -441,7 +482,10 @@ func rdsReadReplicaFromState(d *schema.ResourceData) (*duplosdk.DuploRdsInstance
 	duploObject.Identifier = d.Get("name").(string)
 	duploObject.SizeEx = d.Get("size").(string)
 	duploObject.AvailabilityZone = d.Get("availability_zone").(string)
-
+	eng := d.Get("engine_type").(int)
+	if eng != 0 && eng != 1 && eng != 14 {
+		duploObject.DBParameterGroupName = d.Get("parameter_group_name").(string)
+	}
 	return duploObject, nil
 }
 
@@ -477,6 +521,9 @@ func rdsReadReplicaToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Res
 	jo["enable_logging"] = duploObject.EnableLogging
 	jo["multi_az"] = duploObject.MultiAZ
 	jo["replica_status"] = duploObject.InstanceStatus
+	jo["parameter_group_name"] = duploObject.DBParameterGroupName
+	jo["cluster_parameter_group_name"] = duploObject.ClusterParameterGroupName
+
 	clusterIdentifier := duploObject.ClusterIdentifier
 	if len(clusterIdentifier) == 0 {
 		clusterIdentifier = duploObject.ReplicationSourceIdentifier
@@ -520,4 +567,40 @@ func isEngineAuroraType(engineCode int) bool {
 func hasPerformanceInsightConfigurations(tfRdsReplicaSpecification *schema.ResourceData) bool {
 	configuration := tfRdsReplicaSpecification.Get("performance_insights").([]interface{})
 	return len(configuration) > 0
+}
+
+func validateRDSReplicaUse(ctx context.Context, diff *schema.ResourceDiff, m interface{}) error {
+	engines := map[int]string{
+		0:  "MySQL",
+		1:  "PostgreSQL",
+		2:  "MsftSQL-Express",
+		3:  "MsftSQL-Standard",
+		8:  "Aurora-MySQL",
+		9:  "Aurora-PostgreSQL",
+		10: "MsftSQL-Web",
+		11: "Aurora-Serverless-MySql",
+		12: "Aurora-Serverless-PostgreSql",
+		13: "DocumentDB",
+		14: "MariaDB",
+		16: "Aurora",
+	}
+
+	eng := diff.Get("engine_type").(int)
+
+	if eng == 13 && diff.Get("parameter_group_name").(string) != "" {
+		return fmt.Errorf("parameter group is not applicable for %s engine read replica", engines[eng])
+
+	}
+	if eng == 2 || eng == 3 || eng == 10 {
+		return fmt.Errorf("resource duplocloud_read_replica is not applicable for %s engine", engines[eng])
+	}
+
+	if eng == 0 || eng == 1 || eng == 14 {
+		diff.SetNewComputed("parameter_group_name")
+		//if diff.HasChange("parameter_group_name") {
+		//	return fmt.Errorf("cannot update parameter_group_name for %s engine", engines[eng])
+		//
+		//}
+	}
+	return nil
 }

--- a/templates/resources/rds_instance.md.tmpl
+++ b/templates/resources/rds_instance.md.tmpl
@@ -349,3 +349,75 @@ Import is supported using the following syntax:
 #
 terraform import duplocloud_rds_instance.mydb v2/subscriptions/*TENANT_ID*/RDSDBInstance/*SHORTNAME*
 ```
+
+Example to showcase use of parameter group in writer and read replica for auroro cluster instance
+
+```
+resource "random_password" "mypassword" {
+  length  = 16
+  special = false
+}
+
+resource "duplocloud_rds_instance" "app" {
+  tenant_id      = data.duplocloud_tenant.tenant.id
+  name           = "writer1-sqlnew"
+  engine         = 8 
+  engine_version = "5.7.mysql_aurora.2.11.5"
+  size           = "db.r5.large"
+  master_username              = "myuser"
+  master_password              = random_password.mypassword.result
+  encrypt_storage         = true
+  backup_retention_period = 10
+  db_name         =  "auroradb"
+  skip_final_snapshot = true
+  store_details_in_secret_manager = false
+  enhanced_monitoring = 0
+  availability_zone = "us-west-2b"
+  storage_type                    = "aurora"
+  cluster_parameter_group_name = "c-aurora-mysql"
+  parameter_group_name = "aurora-mysql-dbparam"
+}
+
+resource "duplocloud_rds_read_replica" "replica1" {
+  tenant_id          = duplocloud_rds_instance.app.tenant_id
+  name               = "aurora-replica-new"
+  size               = "db.r5.large"
+  cluster_identifier = duplocloud_rds_instance.app.cluster_identifier
+  availability_zone = "us-west-2a"
+  parameter_group_name = "aurora-mysql-dbparam"
+  engine_type=duplocloud_rds_instance.app.engine
+}
+```
+Example to showcase use of parameter group in writer and read replica for standalone instance
+
+
+```
+resource "duplocloud_rds_instance" "mydb" {
+  tenant_id      = data.duplocloud_tenant.tenant.id
+  name           = "tf-postgresql1"
+  engine         = 1// PostgreSQL
+  engine_version = "13.11"
+  size           = "db.t3.medium"
+  master_username = "myuser"
+  master_password = "Qaazwedd#1"
+  cluster_parameter_group_name = "postgresql17-clusterparamgroup"
+  parameter_group_name = "psql13dbparam"
+  encrypt_storage                 = false
+  store_details_in_secret_manager = false
+  enhanced_monitoring             = 0
+  storage_type                    = "gp2"
+}
+
+resource "duplocloud_rds_read_replica" "replica" {
+  tenant_id          = duplocloud_rds_instance.mydb.tenant_id
+  name               = "postgresql-rep1"
+  size               = "db.t3.medium"
+  cluster_identifier = duplocloud_rds_instance.mydb.cluster_identifier
+  #availability_zone = "us-east-1b"
+  performance_insights {
+    enabled          = true
+    retention_period = 31
+  }
+  engine_type=duplocloud_rds_instance.mydb.engine
+}
+```


### PR DESCRIPTION
## Overview

Support for paramater group field in read replica resource
## Summary of changes
Support for paramater group field in duplocloud_rds_read_replica resource
Document updation
This PR does the following:

- Added support for parameter group name for duplocloud_rds_read_replica
- Added example and updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
