### PR TITLE
DUPLO-29242 TF: Elasticache redis allows non-cluster mode creation with number_of_shards = 1 which causes the resource to become not able to update

### DIFF
--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -176,7 +176,7 @@ Should be one of:
 See AWS documentation for the [available Redis instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) or the [available Memcached instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions-mc.html).
 - `kms_key_id` (String) The globally unique identifier for the key.
 - `log_delivery_configuration` (Block Set, Max: 2) (see [below for nested schema](#nestedblock--log_delivery_configuration))
-- `number_of_shards` (Number) The number of shards to create.
+- `number_of_shards` (Number) The number of shards to create. Applicable only if enable_cluster_mode is set to true
 - `parameter_group_name` (String) The REDIS parameter group to supply.
 - `replicas` (Number) The number of replicas to create. Supported number of replicas is 1 to 6 Defaults to `1`.
 - `snapshot_arns` (List of String) Specify the ARN of a Redis RDB snapshot file stored in Amazon S3. User should have the access to export snapshot to s3 bucket. One can find steps to provide access to export snapshot to s3 on following link https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-exporting.html


### PR DESCRIPTION
## Overview

Fix for number of shards not getting set
## Summary of changes

Added validation on number of shards using custom diff for duplocloud_ecache_instance

This PR does the following:

- number of shards is only applicable if cluster mode is enabled, Add validation to check if number of shards is set only if enable_cluster_mode is set to true
- updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
