### PR TITLE
DUPLO-29614 docs: add opensearch TLS 1.2 requirement for govcloud environments to documentation

### DIFF
--- a/docs/resources/aws_elasticsearch.md
+++ b/docs/resources/aws_elasticsearch.md
@@ -52,7 +52,7 @@ resource "duplocloud_aws_elasticsearch" "es-doc" {
 - `selected_zone` (Number) The numerical index of the zone to launch this ElasticSearch instance in.
 - `storage_size` (Number) The storage volume size, in GB, for the ElasticSearch instance.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `use_latest_tls_cipher` (Boolean) Whether or not to use the latest TLS cipher for this ElasticSearch instance.
+- `use_latest_tls_cipher` (Boolean) Whether or not to use the latest TLS cipher for this ElasticSearch instance. For govcloud environments this should be set to true
 - `vpc_options` (Block List) (see [below for nested schema](#nestedblock--vpc_options))
 
 ### Read-Only

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -74,7 +74,7 @@ func awsElasticSearchSchema() map[string]*schema.Schema {
 			Computed:    true,
 		},
 		"use_latest_tls_cipher": {
-			Description: "Whether or not to use the latest TLS cipher for this ElasticSearch instance.",
+			Description: "Whether or not to use the latest TLS cipher for this ElasticSearch instance. For govcloud environments this should be set to true",
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Computed:    true,


### PR DESCRIPTION
## Overview

Add TLS 1.2 requirement for govcloud setups to the docs for opensearch useLatestTlsCipher property

## Summary of changes

This PR does the following:

- read description

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

No
