### PR TITLE
DUPLO-29590 TF: ASG: Getting 'context deadline exceeded' when try to create ASG with zones type 2 DUPLO-29588 TF: ASG: Unable to create ASG with multiple zones DUPLO-29589 TF: ASG: TF shows 'context deadline exceeded' when tries to re-create resource in case of forces replacement

### DIFF
--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -159,7 +159,7 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
   image_id       = "ami-077e0e0754c311a47" # <== put the AWS duplo docker AMI ID here
   capacity       = "t2.small"
   agent_platform = 0      # Duplo native container agent
-  zones          = [1, 2] # [Zone A, Zone B]
+  zones          = [0, 1] # [Zone A, Zone B]
   user_account   = duplocloud_tenant.duplo-app.account_name
 
   metadata {

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -319,14 +319,7 @@ func diffUserData(ctx context.Context, diff *schema.ResourceDiff, m interface{})
 			}
 		}
 	}
-	if diff.HasChange("zones") {
-		zones := diff.Get("zones").([]interface{})
-		for _, z := range zones {
-			if z.(int) == 0 && len(zones) > 1 {
-				return fmt.Errorf("[Error] Cannot set automatic zone along with other zones")
-			}
-		}
-	}
+
 	return nil
 }
 

--- a/examples/resources/duplocloud_asg_profile/resource.tf
+++ b/examples/resources/duplocloud_asg_profile/resource.tf
@@ -144,7 +144,7 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
   image_id       = "ami-077e0e0754c311a47" # <== put the AWS duplo docker AMI ID here
   capacity       = "t2.small"
   agent_platform = 0      # Duplo native container agent
-  zones          = [1, 2] # [Zone A, Zone B]
+  zones          = [0, 1] # [Zone A, Zone B]
   user_account   = duplocloud_tenant.duplo-app.account_name
 
   metadata {


### PR DESCRIPTION
## Overview

Tested create asg for multiple zone
## Summary of changes

This PR does the following:

- Removed custom validation for zones
- Documentation update

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
