### PR TITLE
[DUPLO-29564] - TF: Support Allocation tags on hosts

### DIFF
--- a/duplocloud/resource_duplo_gcp_k8_node_pool.go
+++ b/duplocloud/resource_duplo_gcp_k8_node_pool.go
@@ -3,13 +3,13 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -74,6 +74,13 @@ func gcpK8NodePoolFunctionSchema() map[string]*schema.Schema {
 			Type:     schema.TypeString,
 			Optional: true,
 			Computed: true,
+		},
+		"allocation_tags": {
+			Description: `Allocation tag to give to the nodes 
+			if specified it would be added as a label and that can be used while creating services`,
+			Type:     schema.TypeString,
+			Optional: true,
+			Required: false,
 		},
 		"spot": {
 			Description: "Spot flag for enabling Spot VM",
@@ -545,6 +552,10 @@ func expandGCPNodePoolConfig(d *schema.ResourceData, req *duplosdk.DuploGCPK8Nod
 	req.MachineType = d.Get("machine_type").(string)
 	req.DiscSizeGb = d.Get("disc_size_gb").(int)
 	req.ImageType = d.Get("image_type").(string)
+
+	if val, ok := d.Get("allocation_tags").(string); ok {
+		req.AllocationTags = val
+	}
 	for _, tag := range d.Get("tags").([]interface{}) {
 		req.Tags = append(req.Tags, tag.(string))
 	}
@@ -929,6 +940,7 @@ func resourceGCPK8NodePoolUpdate(ctx context.Context, d *schema.ResourceData, m 
 
 		}
 	}
+
 	if d.HasChange("taints") || d.HasChange("labels") || d.HasChange("tags") || d.HasChange("resource_labels") {
 		_, err = gcpNodePoolUpdateTaintAndTags(c, tenantID, fullName, rq)
 		if err != nil {

--- a/duplosdk/gcp_node_pools.go
+++ b/duplosdk/gcp_node_pools.go
@@ -8,6 +8,7 @@ import (
 type DuploGCPK8NodePool struct {
 	AutoRepair           bool                   `json:"AutoRepair"`
 	AutoUpgrade          bool                   `json:"AutoUpgrade" default:"true"`
+	AllocationTags       string                 `json:"AllocationTags"`
 	DiscSizeGb           int                    `json:"DiscSizeGb" default:"100"`
 	DiscType             string                 `json:"DiscType" default:"pd-standard"`
 	ImageType            string                 `json:"ImageType" default:"cos_containerd"`


### PR DESCRIPTION
[DUPLO-29564] - TF: Support Allocation tags on hosts
1. Added allocation tag attribute

## Overview

[DUPLO-29564] - TF: Support Allocation tags on hosts
1. Added allocation tag attribute

## Summary of changes

This PR does the following:

- [DUPLO-29564] - TF: Support Allocation tags on hosts
1. Added allocation tag attribute
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
