### PR TITLE
DUPLO-29711 TF: S3 bucket validation incorrect

### DIFF
--- a/duplocloud/resource_duplo_s3_bucket.go
+++ b/duplocloud/resource_duplo_s3_bucket.go
@@ -3,15 +3,20 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const (
+	TOTALS3NAMELENGTH = 63
 )
 
 func s3BucketSchema() map[string]*schema.Schema {
@@ -192,13 +197,6 @@ func resourceS3BucketCreate(ctx context.Context, d *schema.ResourceData, m inter
 	c := m.(*duplosdk.Client)
 	features, _ := c.AdminGetSystemFeatures()
 
-	s3MaxLength := 63 - MAX_DUPLOSERVICES_AND_SUFFIX_LENGTH
-	if features != nil && features.IsTagsBasedResourceMgmtEnabled {
-		s3MaxLength = 63
-	}
-	if len(name) > s3MaxLength {
-		return diag.Errorf("resourceS3BucketCreate: Invalid s3 bucket name: %s, Length must be in the range: (1 - %d)", name, s3MaxLength)
-	}
 	tenantID := d.Get("tenant_id").(string)
 
 	// prefix + name based on settings
@@ -209,7 +207,10 @@ func resourceS3BucketCreate(ctx context.Context, d *schema.ResourceData, m inter
 	if errname != nil {
 		return diag.Errorf("resourceS3BucketCreate: Unable to retrieve duplo service name (name: %s, error: %s)", name, errname.Error())
 	}
+	if !validateStringLength(fullName, TOTALS3NAMELENGTH) {
+		return diag.Errorf("resourceS3BucketCreate: fullname %s exceeds allowable bucket name length %d)", fullName, TOTALS3NAMELENGTH)
 
+	}
 	// Create the request object.
 	duploObject := duplosdk.DuploS3BucketSettingsRequest{
 		Name: name,

--- a/duplocloud/validators.go
+++ b/duplocloud/validators.go
@@ -251,3 +251,11 @@ func validateDateTimeFormat(v interface{}, p cty.Path) diag.Diagnostics {
 
 	return diagnostics
 }
+
+// validateStringLength returns true if string length is less than max length
+func validateStringLength(input string, maxLength int) bool {
+	if len(input) > maxLength {
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
## Overview

validation change for s3bucket name
## Summary of changes
New validation for name, will be adjusted based on tenant name + duploprefix and sufix having limit of 63 character
This PR does the following:

- Updated validation logic
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
