### PR TITLE
Duplo 29713 TF: OpenSearch: Not able to edit EBS storage type to Non EBS storage type

### DIFF
--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -900,11 +900,11 @@ func validateEBSStorage(ctx context.Context, diff *schema.ResourceDiff, m interf
 	instanceType := mp["instance_type"].(string)
 
 	//non ebs no need storage
-	if strings.Contains(instanceType, "im4gn.") || strings.Contains(instanceType, "i3.") {
-		if storage > 0 {
-			return fmt.Errorf("storage_size must be 0 for non-EBS-backed instance types (im4gn./i3.)")
+	nonEBSInstanceTypes := []string{"im4gn.", "i3."}
+	for _, prefix := range nonEBSInstanceTypes {
+		if strings.Contains(instanceType, prefix) && storage > 0 {
+			return fmt.Errorf("storage_size must be 0 for non-EBS-backed instance types (%s)", strings.Join(nonEBSInstanceTypes, "/"))
 		}
 	}
-
 	return nil
 }

--- a/duplocloud/resource_duplo_aws_elasticsearch.go
+++ b/duplocloud/resource_duplo_aws_elasticsearch.go
@@ -3,11 +3,12 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -897,8 +898,13 @@ func validateEBSStorage(ctx context.Context, diff *schema.ResourceDiff, m interf
 	}
 	mp := clusterConfig[0].(map[string]interface{})
 	instanceType := mp["instance_type"].(string)
-	if (!strings.Contains(instanceType, "im4gn.") && !strings.Contains(instanceType, "i3.")) && (storage == 0) {
-		return fmt.Errorf("storage_size cannot be 0 for non ebs storage instance_type (im4gn./i3.)")
+
+	//non ebs no need storage
+	if strings.Contains(instanceType, "im4gn.") || strings.Contains(instanceType, "i3.") {
+		if storage > 0 {
+			return fmt.Errorf("storage_size must be 0 for non-EBS-backed instance types (im4gn./i3.)")
+		}
 	}
+
 	return nil
 }


### PR DESCRIPTION
## Overview

EBS to Non EBS update fix
## Summary of changes
Updated validation for storage size check for ebs and non ebs
This PR does the following:

- Updated validation 
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
