### PR TITLE
 DUPLO-26301 TF:RDS: Customer reporting that terraform plan fails when this is already updated

### DIFF
--- a/duplocloud/version_utils.go
+++ b/duplocloud/version_utils.go
@@ -7,8 +7,9 @@ import (
 )
 
 func extractVersion(input string) string {
-	// Regular expression to match version-like patterns (e.g., 3.07.1, 4.01.2)
-	re := regexp.MustCompile(`\d+\.\d+\.\d+`)
+	// Regular expression to match version-like patterns (e.g. 3, 3.0, 3.07.1, 4.01.2)
+	//re := regexp.MustCompile(`\d+\.\d+\.\d+`)
+	re := regexp.MustCompile(`\d+(?:\.\d+){0,2}`)
 
 	// Find the first version number match
 	version := re.FindString(input)


### PR DESCRIPTION
## Overview

Fixed regex to evaluate version comparision for storage_type
## Summary of changes
Fix for regex failing to fetch version string of type 14, 14.0 patterns while comparing the version
This PR does the following:

- Updated regex logic
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
