### PR TITLE
Duplo 29812 (Hotfix-0.11.1) - TF - Fix volume block typo for duplocloud k8 cron job

### DIFF
--- a/duplocloud/resource_duplo_k8s_cron_job.go
+++ b/duplocloud/resource_duplo_k8s_cron_job.go
@@ -3,11 +3,12 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"regexp"
 	"strconv"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 

--- a/duplocloud/schema_k8s_pod_spec.go
+++ b/duplocloud/schema_k8s_pod_spec.go
@@ -478,12 +478,24 @@ func podSpecFields(isUpdatable, isComputed bool) map[string]*schema.Schema {
 			},
 		},
 		"volume": {
-			Type:        schema.TypeList,
-			Optional:    true,
-			Description: "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
-			Elem:        volumeSchema(isUpdatable),
+			Type:          schema.TypeList,
+			Optional:      true,
+			Computed:      true,
+			Deprecated:    "This attribute has been deprecated; please use `volumes` instead.",
+			ConflictsWith: []string{"volumes"},
+			Description:   "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+			Elem:          volumeSchema(isUpdatable),
+		},
+		"volumes": {
+			Type:          schema.TypeList,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"volume"},
+			Description:   "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes",
+			Elem:          volumeSchema(isUpdatable),
 		},
 	}
+
 	return s
 }
 

--- a/duplocloud/structures_k8s_pod.go
+++ b/duplocloud/structures_k8s_pod.go
@@ -25,7 +25,7 @@ var builtInTolerations = map[string]string{
 
 // Flatteners
 
-func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
+func flattenPodSpec(in v1.PodSpec, d *schema.ResourceData) ([]interface{}, error) {
 	att := make(map[string]interface{})
 	if in.ActiveDeadlineSeconds != nil {
 		att["active_deadline_seconds"] = *in.ActiveDeadlineSeconds
@@ -152,8 +152,11 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 		if err != nil {
 			return []interface{}{att}, err
 		}
-		att["volumes"] = v
-		att["volume"] = v
+		if _, ok := d.GetOk("volumes"); ok {
+			att["volumes"] = v
+		} else if _, ok := d.GetOk("volume"); ok {
+			att["volume"] = v
+		}
 	}
 	return []interface{}{att}, nil
 }

--- a/duplocloud/structures_k8s_pod.go
+++ b/duplocloud/structures_k8s_pod.go
@@ -152,6 +152,7 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 		if err != nil {
 			return []interface{}{att}, err
 		}
+		att["volumes"] = v
 		att["volume"] = v
 	}
 	return []interface{}{att}, nil
@@ -771,13 +772,18 @@ func expandPodSpec(p []interface{}) (*v1.PodSpec, error) {
 	if v, ok := in["termination_grace_period_seconds"].(int); ok {
 		obj.TerminationGracePeriodSeconds = ptrToInt64(int64(v))
 	}
-	if v, ok := in["volume"]; ok {
+	if v, ok := in["volumes"]; ok {
 		r, err := expandPodSpecVolumes(v.([]interface{}))
 		if err != nil {
 			return nil, err
 		}
 		obj.Volumes = r
-
+	} else if v, ok := in["volume"]; ok { // Support for deprecated attribute
+		r, err := expandPodSpecVolumes(v.([]interface{}))
+		if err != nil {
+			return nil, err
+		}
+		obj.Volumes = r
 	}
 	return obj, nil
 }

--- a/duplocloud/structures_stateful_set.go
+++ b/duplocloud/structures_stateful_set.go
@@ -15,7 +15,7 @@ func flattenPodTemplateSpec(t corev1.PodTemplateSpec, d *schema.ResourceData, me
 		metaPrefix = prefix[0]
 	}
 	template["metadata"] = flattenMetadata(t.ObjectMeta, d, meta, metaPrefix)
-	spec, err := flattenPodSpec(t.Spec)
+	spec, err := flattenPodSpec(t.Spec, d)
 	if err != nil {
 		return []interface{}{template}, err
 	}


### PR DESCRIPTION
## Overview

Duplo 29812 (Hotfix-0.11.1) - TF - Fix volume block typo for duplocloud k8 cron job

## Summary of changes

This PR does the following:

- Deprecated existing `volume` attribute added new `volumes`


## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
