### PR TITLE
Duplo 29827 TF:ALB: Backend protocol version should be optional field and defaults should be set to 'HTTP1' DUPLO-29828 TF:ALB: Backend protocol version is not getting updated.  DUPLO-29829  TF:ALB: Unable to create resource 'duplocloud_duplo_service_lbconfigs' with - protocol = "https" DUPLO-29830 TF:Doc: Provide more details for attribute 'backend_protocol_version'

### DIFF
--- a/docs/resources/duplo_service_lbconfigs.md
+++ b/docs/resources/duplo_service_lbconfigs.md
@@ -78,7 +78,6 @@ resource "duplocloud_duplo_service_lbconfigs" "myservice" {
 
 Required:
 
-- `backend_protocol_version` (String) Is used for communication between the load balancer and the target instances. This is a required field for ALB load balancer
 - `lb_type` (Number) The numerical index of the type of load balancer configuration to create.
 Should be one of:
 
@@ -96,6 +95,7 @@ Should be one of:
 Optional:
 
 - `allow_global_access` (Boolean) Applicable for internal lb.
+- `backend_protocol_version` (String) Is used for communication between the load balancer and the target instances. This is a required field for ALB load balancer. Only applicable when protocol is HTTP or HTTPS. The protocol version. Specify GRPC to send requests to targets using gRPC. Specify HTTP2 to send requests to targets using HTTP/2. The default is HTTP1, which sends requests to targets using HTTP/1.1 Defaults to `HTTP1`.
 - `certificate_arn` (String) The ARN of an ACM certificate to associate with this load balancer.  Only applicable for HTTPS.
 - `custom_cidr` (List of String) Specify CIDR Values. This is applicable only for Network Load Balancer if `lb_type` is `6`.
 - `external_port` (Number) The frontend port associated with this load balancer configuration. Required if `lb_type` is not `7`.

--- a/duplocloud/data_source_duplo_service_lbconfigs.go
+++ b/duplocloud/data_source_duplo_service_lbconfigs.go
@@ -3,8 +3,9 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -18,6 +19,7 @@ func duploLbConfigSchemaComputed() map[string]*schema.Schema {
 		v.Required = false
 		v.Optional = true
 		v.ForceNew = false
+		v.Default = nil
 	}
 	return x
 }


### PR DESCRIPTION
## Overview

Updated attribute of the field
Fixed validation logic
Updated Documentation
## Summary of changes

This PR does the following:

- made backend_protocol_version field optional and added default value
- fixed validation logic
- Documentation updation
- Data resource issue fix due to default value set

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [x] Manually, on a remote test system

## Describe any breaking changes

- ...
