### PR TITLE
DUPLO-26807 TF: Node Pool: re-plan and apply is failing for resource 'duplocloud_gcp_node_pool (Resource)'

### DIFF
--- a/duplosdk/gcp_node_pools.go
+++ b/duplosdk/gcp_node_pools.go
@@ -34,6 +34,7 @@ type DuploGCPK8NodePool struct {
 	TotalMinNodeCount    *int                   `json:"TotalMinNodeCount"`
 	Accelerator          *Accelerator           `json:"Accelerator,omitempty"`
 	ResourceLabels       map[string]string      `json:"ResourceLabels"`
+	Status               string                 `json:"Status"`
 }
 
 type Accelerator struct {


### PR DESCRIPTION
## Overview

Fixed diff issue for taints  which gcp adds explicitly
## Summary of changes

This PR does the following:

- Added map that holds taint effects explicitly to skip setting such taints
- Added polling function 

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
