### PR TITLE
 DUPLO-29828 TF:ALB: Backend protocol version is not getting updated

### DIFF
--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -489,7 +489,7 @@ func resourceDuploServiceLbConfigsDelete(ctx context.Context, d *schema.Resource
 
 	// Wait 40 more seconds to deal with consistency issues.
 	if diags == nil {
-		time.Sleep(40 * time.Second)
+		time.Sleep(140 * time.Second)
 	}
 
 	log.Printf("[TRACE] resourceDuploServiceLbConfigsDelete(%s, %s): end", tenantID, name)


### PR DESCRIPTION
## Overview

Fix AWS inconsistency
## Summary of changes
Fixed AWS inconsistency after duplocloud_duplo_service_lbconfigs destroy
This PR does the following:

- Increased sleep time after destroy to manage AWS consistency
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
