### PR TITLE
 DUPLO-29758 Terraform provider doesn't delete tenant created with "allow_deletion" set to false

### DIFF
--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -239,51 +239,41 @@ func resourceTenantDelete(ctx context.Context, d *schema.ResourceData, m interfa
 		return diag.Errorf("Invalid resource ID: %s", id)
 	}
 	log.Printf("[TRACE] resourceTenantDelete(%s): start", tenantID)
-	allowedDeletion := d.Get("allow_deletion").(bool)
-	if !allowedDeletion {
+
+	if d.Get("allow_deletion").(bool) {
+
+		// Delete the object with Duplo
+		c := m.(*duplosdk.Client)
+		duplo, err := c.TenantGetV2(tenantID)
+		if err != nil {
+			if err.Status() == 404 {
+				return nil
+			}
+			return diag.Errorf("Unable to retrieve tenant '%s': %s", tenantID, err)
+		}
+		if duplo == nil {
+			return nil
+		}
+		err = c.TenantDelete(tenantID)
+		if err != nil {
+			if err.Status() == 404 {
+				return nil
+			}
+			return diag.Errorf("Error deleting tenant '%s': %s", tenantID, err)
+		}
+
+		// Wait for 1 minute to allow tenant deletion.
+		if d.Get("wait_until_deleted").(bool) {
+			log.Printf("[TRACE] resourceTenantDelete(%s): waiting for 1 minute because 'wait_until_deleted' is 'true'", tenantID)
+			time.Sleep(time.Duration(1) * time.Minute)
+		}
+	} else {
 		return diag.Errorf("[Error] resourceTenantDelete(%s): will NOT delete the tenant - because 'allow_deletion' is 'false'", tenantID)
-
-	}
-	// Delete the object with Duplo
-	c := m.(*duplosdk.Client)
-	mds, err := c.TenantGetConfig(tenantID)
-	if err != nil {
-		if err.Status() == 404 {
-			return nil
-		}
-		return diag.Errorf("Unable to retrieve tenant config '%s': %s", tenantID, err)
-	}
-	for _, md := range *mds.Metadata {
-		if md.Key == "delete_protection" && md.Value == "true" {
-			return diag.Errorf("Cannot delete tenant delete_protection is enabled")
-		}
-	}
-	duplo, err := c.TenantGetV2(tenantID)
-	if err != nil {
-		if err.Status() == 404 {
-			return nil
-		}
-		return diag.Errorf("Unable to retrieve tenant '%s': %s", tenantID, err)
-	}
-	if duplo == nil {
-		return nil
-	}
-	err = c.TenantDelete(tenantID)
-	if err != nil {
-		if err.Status() == 404 {
-			return nil
-		}
-		return diag.Errorf("Error deleting tenant '%s': %s", tenantID, err)
-	}
-
-	// Wait for 1 minute to allow tenant deletion.
-	if d.Get("wait_until_deleted").(bool) {
-		log.Printf("[TRACE] resourceTenantDelete(%s): waiting for 1 minute because 'wait_until_deleted' is 'true'", tenantID)
-		time.Sleep(time.Duration(1) * time.Minute)
 	}
 
 	log.Printf("[TRACE] resourceTenantDelete(%s): end", tenantID)
 	return nil
+
 }
 
 func parseDuploTenantIdParts(id string) (tenantID string) {


### PR DESCRIPTION
## Overview

Throwing proper error based on allow_deletion and delete_protection setting in duplocloud_tenant resource
## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
