### PR TITLE
DUPLO-29963 Support for allocation tags field

### DIFF
--- a/docs/data-sources/k8s_cron_job.md
+++ b/docs/data-sources/k8s_cron_job.md
@@ -35,6 +35,7 @@ output "metadata" {
 
 ### Optional
 
+- `allocation_tags` (String) Allocation tags is the simplest way to constraint containers/pods with hosts/nodes. DuploCloud/Kubernetes Orchestrator will make sure containers will run on the hosts having same allocation tags.
 - `is_any_host_allowed` (Boolean) Defaults to `false`.
 
 ### Read-Only

--- a/docs/data-sources/k8s_job.md
+++ b/docs/data-sources/k8s_job.md
@@ -35,6 +35,7 @@ output "metadata" {
 
 ### Optional
 
+- `allocation_tags` (String) Allocation tags is the simplest way to constraint containers/pods with hosts/nodes. DuploCloud/Kubernetes Orchestrator will make sure containers will run on the hosts having same allocation tags.
 - `is_any_host_allowed` (Boolean) Defaults to `false`.
 
 ### Read-Only

--- a/docs/resources/k8s_cron_job.md
+++ b/docs/resources/k8s_cron_job.md
@@ -51,6 +51,7 @@ resource "duplocloud_k8s_cron_job" "myapp" {
 
 ### Optional
 
+- `allocation_tags` (String) Allocation tags is the simplest way to constraint containers/pods with hosts/nodes. DuploCloud/Kubernetes Orchestrator will make sure containers will run on the hosts having same allocation tags.
 - `is_any_host_allowed` (Boolean) Defaults to `false`.
 - `spec` (Block List) Spec of the cron job owned by the cluster (see [below for nested schema](#nestedblock--spec))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/k8s_job.md
+++ b/docs/resources/k8s_job.md
@@ -46,6 +46,7 @@ resource "duplocloud_k8s_job" "myapp" {
 
 ### Optional
 
+- `allocation_tags` (String) Allocation tags is the simplest way to constraint containers/pods with hosts/nodes. DuploCloud/Kubernetes Orchestrator will make sure containers will run on the hosts having same allocation tags.
 - `is_any_host_allowed` (Boolean) Defaults to `false`.
 - `spec` (Block List) Spec of the job owned by the cluster (see [below for nested schema](#nestedblock--spec))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/duplocloud/resource_duplo_k8s_cron_job.go
+++ b/duplocloud/resource_duplo_k8s_cron_job.go
@@ -58,12 +58,18 @@ func resourceKubernetesCronJobSchemaV1Beta1(readonly bool) map[string]*schema.Sc
 			Optional: true,
 			Default:  false,
 		},
+		"allocation_tags": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Allocation tags is the simplest way to constraint containers/pods with hosts/nodes. DuploCloud/Kubernetes Orchestrator will make sure containers will run on the hosts having same allocation tags.",
+		},
 	}
 }
 
 func resourceKubernetesCronJobV1Beta1Create(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	tenantId := d.Get("tenant_id").(string)
 	isAnyHostAllowed := d.Get("is_any_host_allowed").(bool)
+	allocationTags := d.Get("allocation_tags").(string)
 	log.Printf("[TRACE] resourceKubernetesJobV1Create(%s): start", tenantId)
 
 	name, err := getK8sJobName(d)
@@ -82,7 +88,7 @@ func resourceKubernetesCronJobV1Beta1Create(ctx context.Context, d *schema.Resou
 	rq.Spec = spec
 	rq.TenantId = tenantId
 	rq.IsAnyHostAllowed = isAnyHostAllowed
-
+	rq.AllocationTags = allocationTags
 	c := meta.(*duplosdk.Client)
 	err = c.K8sCronJobCreate(&rq)
 	if err != nil {
@@ -99,6 +105,7 @@ func resourceKubernetesCronJobV1Beta1Create(ctx context.Context, d *schema.Resou
 func resourceKubernetesCronJobV1Beta1Update(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	tenantId := d.Get("tenant_id").(string)
 	isAnyHostAllowed := d.Get("is_any_host_allowed").(bool)
+	allocationTags := d.Get("allocation_tags").(string)
 	log.Printf("[TRACE] resourceKubernetesCronJobV1Update(%s): end", tenantId)
 
 	name, err := getK8sJobName(d)
@@ -117,6 +124,7 @@ func resourceKubernetesCronJobV1Beta1Update(ctx context.Context, d *schema.Resou
 		Metadata:         metadata,
 		Spec:             spec,
 		IsAnyHostAllowed: isAnyHostAllowed,
+		AllocationTags:   allocationTags,
 	}
 
 	// initiate update Job
@@ -183,6 +191,8 @@ func resourceKubernetesCronJobV1Beta1Read(ctx context.Context, d *schema.Resourc
 		return diag.FromErr(err)
 	}
 	d.Set("tenant_id", tenantId)
+	allocationTags := GetAllocationTags(job.Spec.JobTemplate.Spec.Template.Spec.NodeSelector)
+	d.Set("allocation_tags", allocationTags)
 	return diag.Diagnostics{}
 }
 
@@ -196,6 +206,13 @@ func GetIsAnyHostAllowed(annotations map[string]string) bool {
 		return boolValue
 	}
 	return false
+}
+
+func GetAllocationTags(nodeSelector map[string]string) string {
+	if val, ok := nodeSelector["allocationtags"]; ok {
+		return val
+	}
+	return ""
 }
 
 func resourceKubernetesCronJobV1Beta1Delete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/duplosdk/k8s_cron_job.go
+++ b/duplosdk/k8s_cron_job.go
@@ -15,6 +15,7 @@ type DuploK8sCronJob struct {
 	Spec             v1beta1.CronJobSpec   `json:"spec"`
 	Status           v1beta1.CronJobStatus `json:"status"`
 	IsAnyHostAllowed bool                  `json:"IsAnyHostAllowed"`
+	AllocationTags   string                `json:"AllocationTags"`
 }
 
 // K8sCronJobGetList retrieves a list of k8s jobs via the Duplo API.

--- a/duplosdk/k8s_job.go
+++ b/duplosdk/k8s_job.go
@@ -15,6 +15,7 @@ type DuploK8sJob struct {
 	Spec             batchv1.JobSpec   `json:"spec"`
 	Status           batchv1.JobStatus `json:"status"`
 	IsAnyHostAllowed bool              `json:"IsAnyHostAllowed"`
+	AllocationTags   string            `json:"AllocationTags"`
 }
 
 // K8sJobGetList retrieves a list of k8s jobs via the Duplo API.


### PR DESCRIPTION
## Overview

support for allocation tags field
## Summary of changes
support for allocation tags field for duplocloud_k8s_cron_job and duplocloud_k8s_job resource

This PR does the following:

- support for allocation tags field
- updated documentation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
