### PR TITLE
DUPLO-29894 TF:Helm Release: Add validation for field 'source_name' DUPLO-29896 TF:Helm Release: Unable to create resource 'duplocloud_k8_helm_release' when values are not defined

### DIFF
--- a/docs/resources/k8_helm_release.md
+++ b/docs/resources/k8_helm_release.md
@@ -46,13 +46,13 @@ resource "duplocloud_k8_helm_release" "release" {
 
 ### Required
 
+- `chart` (Block List, Min: 1) Helm chart (see [below for nested schema](#nestedblock--chart))
 - `name` (String) The name of the helm chart
 - `release_name` (String) Provide release name to identify specific deployment of helm chart.
 - `tenant_id` (String) The GUID of the tenant that the storage bucket will be created in.
 
 ### Optional
 
-- `chart` (Block List) Helm chart (see [below for nested schema](#nestedblock--chart))
 - `interval` (String) Interval related to helm release Defaults to `5m0s`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `values` (String) Customise an helm chart.

--- a/duplosdk/duplo_helm.go
+++ b/duplosdk/duplo_helm.go
@@ -14,11 +14,12 @@ type DuploHelmMetadata struct {
 }
 
 type DuploHelmSpec struct {
-	URL         string                 `json:"url,omitempty"`
-	Interval    string                 `json:"interval"`
-	ReleaseName string                 `json:"releaseName,omitempty"`
-	Chart       *Chart                 `json:"chart,omitempty"`
-	Values      map[string]interface{} `json:"values,omitempty"`
+	URL         string `json:"url,omitempty"`
+	Interval    string `json:"interval"`
+	ReleaseName string `json:"releaseName,omitempty"`
+	Chart       *Chart `json:"chart,omitempty"`
+	//Values      map[string]interface{} `json:"values,omitempty"`
+	Values interface{} `json:"values,omitempty"`
 }
 
 type SourceRef struct {


### PR DESCRIPTION
## Overview

Make chart require block
Handle values datatype issue
## Summary of changes
Made chart block required
Changed values datatype to interface to make it generic
This PR does the following:

- Made chart block required
- Changed values datatype to interface to make it generic
- Documentation Updated

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
