### PR TITLE
DUPLO-30373 TF Azure duplocloud_azure_mssql_database ass support for max_size_bytes

### DIFF
--- a/docs/resources/azure_mssql_database.md
+++ b/docs/resources/azure_mssql_database.md
@@ -61,6 +61,7 @@ resource "duplocloud_azure_mssql_database" "mssql_database" {
 
 - `collation` (String) Specifies the collation of the database.
 - `elastic_pool_id` (String) Specifies the id of the elastic pool containing this database.
+- `max_size_bytes` (String) DB size in byte
 - `sku` (Block List, Max: 1) (see [below for nested schema](#nestedblock--sku))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/duplosdk/azure_mssql_database.go
+++ b/duplosdk/azure_mssql_database.go
@@ -19,6 +19,7 @@ type DuploAzureMsSqlDatabaseRequest struct {
 	Sku                     *DuploAzureMsSqlDatabaseSku `json:"sku"`
 	PropertiesCollation     string                      `json:"properties.collation,omitempty"`
 	PropertiesElasticPoolId string                      `json:"properties.elasticPoolId,omitempty"`
+	MaxSizeBytes            int64                       `json:"properties.MaxSizeBytes"`
 }
 
 type DuploAzureMsSqlElasticPoolRequest struct {


### PR DESCRIPTION
## Overview

Added support for maxsizebytes for duplocloud_azure_mssql_database
## Summary of changes

This PR does the following:

- Added max_size_bytes to duplocloud_azure_mssql_database
- Document updated

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
