### PR TITLE
DUPLO-30216 TF: Job is always replaced because of the node_selector DUPLO-29742 TF:Resource 'duplocloud_k8s_cron_job' shows update in-place for re-plan without any modification in code.

### DIFF
--- a/duplocloud/structures_k8s.go
+++ b/duplocloud/structures_k8s.go
@@ -2,10 +2,11 @@ package duplocloud
 
 import (
 	"fmt"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"net/url"
 	"regexp"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	api "k8s.io/api/core/v1"
@@ -91,10 +92,16 @@ func removeInternalKeys(m map[string]string, d map[string]interface{}) map[strin
 // In that case, they won't be available in the TF state file and will be ignored during apply/plan operations.
 func removeKeys(m map[string]string, d map[string]interface{}, ignoreKubernetesMetadataKeys []string) map[string]string {
 	for k := range m {
+		if _, ok := d[k]; !ok {
+			delete(m, k)
+		}
+	}
+	for k := range m {
 		if ignoreKey(k, ignoreKubernetesMetadataKeys) && !isKeyInMap(k, d) {
 			delete(m, k)
 		}
 	}
+
 	return m
 }
 

--- a/duplocloud/structures_k8s_pod.go
+++ b/duplocloud/structures_k8s_pod.go
@@ -95,6 +95,7 @@ func flattenPodSpec(in v1.PodSpec, podSpec interface{}) ([]interface{}, error) {
 		filter := map[string]struct{}{
 			"kubernetes.io/os": {},
 			"tenantname":       {},
+			"allocationtags":   {},
 		}
 
 		temp := make(map[string]interface{})

--- a/duplocloud/structures_k8s_pod.go
+++ b/duplocloud/structures_k8s_pod.go
@@ -25,7 +25,7 @@ var builtInTolerations = map[string]string{
 
 // Flatteners
 
-func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
+func flattenPodSpec(in v1.PodSpec, podSpec interface{}) ([]interface{}, error) {
 	att := make(map[string]interface{})
 	if in.ActiveDeadlineSeconds != nil {
 		att["active_deadline_seconds"] = *in.ActiveDeadlineSeconds
@@ -92,7 +92,30 @@ func flattenPodSpec(in v1.PodSpec) ([]interface{}, error) {
 		att["node_name"] = in.NodeName
 	}
 	if len(in.NodeSelector) > 0 {
-		att["node_selector"] = in.NodeSelector
+		filter := map[string]struct{}{
+			"kubernetes.io/os": {},
+			"tenantname":       {},
+		}
+
+		temp := make(map[string]interface{})
+
+		psm, ok := podSpec.([]interface{})
+		if ok && len(psm) > 0 {
+			mp := psm[0].(map[string]interface{})
+			ns, ok := mp["node_selector"].(map[string]interface{})
+			if ok {
+				for k := range ns {
+					delete(filter, k)
+				}
+			}
+		}
+		for k, v := range in.NodeSelector {
+			if _, ok := filter[k]; !ok {
+				temp[k] = v
+			}
+		}
+
+		att["node_selector"] = temp
 	}
 	if in.RuntimeClassName != nil {
 		att["runtime_class_name"] = *in.RuntimeClassName

--- a/duplocloud/structures_stateful_set.go
+++ b/duplocloud/structures_stateful_set.go
@@ -10,12 +10,19 @@ import (
 func flattenPodTemplateSpec(t corev1.PodTemplateSpec, d *schema.ResourceData, meta interface{}, prefix ...string) ([]interface{}, error) {
 	template := make(map[string]interface{})
 
-	metaPrefix := "spec.0.template.0."
+	jobPrefix := "spec.0.template.0." //schema tree from job
 	if len(prefix) > 0 {
-		metaPrefix = prefix[0]
+		jobPrefix = prefix[0]
 	}
-	template["metadata"] = flattenMetadata(t.ObjectMeta, d, meta, metaPrefix)
-	spec, err := flattenPodSpec(t.Spec)
+	//spec.0.job_template.0.spec.0.template.0.spec
+	template["metadata"] = flattenMetadata(t.ObjectMeta, d, meta, jobPrefix)
+	var podSpec interface{}
+	if len(prefix) > 0 {
+		podSpec = d.Get(prefix[0] + "spec")
+	} else {
+		podSpec = d.Get(jobPrefix + "spec")
+	}
+	spec, err := flattenPodSpec(t.Spec, podSpec)
 	if err != nil {
 		return []interface{}{template}, err
 	}


### PR DESCRIPTION
## Overview

Diff fix
## Summary of changes
Fixed diff issues at node selector and labels for duplocloud_k8s_cron_job and duplocloud_k8s_job
This PR does the following:

- Fixed diff issues at node selector and labels
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
