### PR TITLE
DUPLO-30391 TF: lbconfigs issue with backend protocol version  DUPLO-30198 setting backend_protocol on lbconfigs in terraform causes target groups to disappear

### DIFF
--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -591,7 +591,7 @@ func flattenDuploServiceLbConfiguration(lb *duplosdk.DuploLbConfiguration) map[s
 		"custom_cidr":                 lb.CustomCidrs,
 		"allow_global_access":         lb.AllowGlobalAccess,
 		"skip_http_to_https":          lb.SkipHttpToHttps,
-		"backend_protocol_version":    lb.BeProtocolVersion,
+		"backend_protocol_version":    strings.ToUpper(lb.BeProtocolVersion),
 	}
 
 	if lb.HealthCheckConfig != nil {


### PR DESCRIPTION
## Overview
Potential fix 

## Summary of changes
Converting backend_version_protocol to uppercase while setting to tf state
This PR does the following:

- used strings.ToUpper function while flattening backend_protocol_version field

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
