### PR TITLE
DUPLO-30397 TF:DOC: Add usage example with 'Backend protocol version' for resource 'duplocloud_duplo_service_lbconfigs'

### DIFF
--- a/docs/resources/duplo_service_lbconfigs.md
+++ b/docs/resources/duplo_service_lbconfigs.md
@@ -35,13 +35,37 @@ resource "duplocloud_duplo_service_lbconfigs" "myservice" {
   replication_controller_name = duplocloud_duplo_service.myservice.name
 
   lbconfigs {
-    external_port    = 80
-    health_check_url = "/"
-    is_native        = false
-    lb_type          = 1 # Application load balancer
-    port             = "80"
-    protocol         = "http"
+    external_port            = 80
+    health_check_url         = "/"
+    is_native                = false
+    lb_type                  = 1 # Application load balancer
+    port                     = "80"
+    protocol                 = "HTTP"
+    backend_protocol_version = "HTTP1"
+    health_check {
+      healthy_threshold   = 4
+      unhealthy_threshold = 4
+      timeout             = 50
+      interval            = 30
+      http_success_codes  = "200-399"
+    }
+  }
+}
 
+
+resource "duplocloud_duplo_service_lbconfigs" "myservice" {
+  tenant_id                   = duplocloud_duplo_service.myservice.tenant_id
+  replication_controller_name = duplocloud_duplo_service.myservice.name
+
+  lbconfigs {
+    external_port            = 80
+    health_check_url         = "/"
+    is_native                = false
+    lb_type                  = 1 # Application load balancer
+    port                     = "80"
+    protocol                 = "HTTPS"
+    certificate_arn          = "certificate:arn"
+    backend_protocol_version = "HTTP2"
     health_check {
       healthy_threshold   = 4
       unhealthy_threshold = 4

--- a/examples/resources/duplocloud_duplo_service_lbconfigs/resource.tf
+++ b/examples/resources/duplocloud_duplo_service_lbconfigs/resource.tf
@@ -17,13 +17,37 @@ resource "duplocloud_duplo_service_lbconfigs" "myservice" {
   replication_controller_name = duplocloud_duplo_service.myservice.name
 
   lbconfigs {
-    external_port    = 80
-    health_check_url = "/"
-    is_native        = false
-    lb_type          = 1 # Application load balancer
-    port             = "80"
-    protocol         = "http"
+    external_port            = 80
+    health_check_url         = "/"
+    is_native                = false
+    lb_type                  = 1 # Application load balancer
+    port                     = "80"
+    protocol                 = "HTTP"
+    backend_protocol_version = "HTTP1"
+    health_check {
+      healthy_threshold   = 4
+      unhealthy_threshold = 4
+      timeout             = 50
+      interval            = 30
+      http_success_codes  = "200-399"
+    }
+  }
+}
 
+
+resource "duplocloud_duplo_service_lbconfigs" "myservice2" {
+  tenant_id                   = duplocloud_duplo_service.myservice.tenant_id
+  replication_controller_name = duplocloud_duplo_service.myservice.name
+
+  lbconfigs {
+    external_port            = 80
+    health_check_url         = "/"
+    is_native                = false
+    lb_type                  = 1 # Application load balancer
+    port                     = "80"
+    protocol                 = "HTTPS"
+    certificate_arn          = "certificate:arn"
+    backend_protocol_version = "HTTP2"
     health_check {
       healthy_threshold   = 4
       unhealthy_threshold = 4


### PR DESCRIPTION
## Overview

Document update
## Summary of changes
Document update for duplocloud_duplo_service_lbconfigs
This PR does the following:

- Added example with backend_protocol_version usage
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
