### PR TITLE
DUPLO-30500 [TF] Changes to parameter group is not reflected after the RDS is already created

### DIFF
--- a/docs/resources/duplo_service_lbconfigs.md
+++ b/docs/resources/duplo_service_lbconfigs.md
@@ -53,7 +53,7 @@ resource "duplocloud_duplo_service_lbconfigs" "myservice" {
 }
 
 
-resource "duplocloud_duplo_service_lbconfigs" "myservice" {
+resource "duplocloud_duplo_service_lbconfigs" "myservice2" {
   tenant_id                   = duplocloud_duplo_service.myservice.tenant_id
   replication_controller_name = duplocloud_duplo_service.myservice.name
 


### PR DESCRIPTION
## Overview

Change done in parameter_group_name field 
## Summary of changes
Made parameter_group_name field updatable in duplocloud_rds_instance resource

This PR does the following:

- Removed compute attribute
- Added diff suppress function

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
