### PR TITLE
DUPLO-30525 LB Config protocol attribute validation is breaking backward compatibility

### DIFF
--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -55,7 +55,7 @@ func duploLbConfigSchema() map[string]*schema.Schema {
 			Type:             schema.TypeString,
 			Required:         true,
 			DiffSuppressFunc: diffSuppressStringCase,
-			ValidateFunc:     validation.StringInSlice([]string{"HTTP", "HTTPS", "TCP", "UDP", "TLS"}, false),
+			ValidateFunc:     validation.StringInSlice([]string{"HTTP", "HTTPS", "TCP", "UDP", "TLS"}, true),
 		},
 		"port": {
 			Description: "The backend port associated with this load balancer configuration.",
@@ -126,12 +126,13 @@ func duploLbConfigSchema() map[string]*schema.Schema {
 			Computed:    true,
 		},
 		"backend_protocol_version": {
-			Description:  "Is used for communication between the load balancer and the target instances. This is a required field for ALB load balancer. Only applicable when protocol is HTTP or HTTPS. The protocol version. Specify GRPC to send requests to targets using gRPC. Specify HTTP2 to send requests to targets using HTTP/2. The default is HTTP1, which sends requests to targets using HTTP/1.1",
-			Type:         schema.TypeString,
-			Optional:     true,
-			ForceNew:     true,
-			Default:      "HTTP1",
-			ValidateFunc: validation.StringInSlice([]string{"HTTP1", "HTTP2", "GRPC"}, false),
+			Description:      "Is used for communication between the load balancer and the target instances. This is a required field for ALB load balancer. Only applicable when protocol is HTTP or HTTPS. The protocol version. Specify GRPC to send requests to targets using gRPC. Specify HTTP2 to send requests to targets using HTTP/2. The default is HTTP1, which sends requests to targets using HTTP/1.1",
+			Type:             schema.TypeString,
+			Optional:         true,
+			ForceNew:         true,
+			Default:          "HTTP1",
+			DiffSuppressFunc: diffSuppressStringCase,
+			ValidateFunc:     validation.StringInSlice([]string{"HTTP1", "HTTP2", "GRPC"}, true),
 		},
 		"frontend_ip": {
 			Type:     schema.TypeString,
@@ -390,7 +391,7 @@ func resourceDuploServiceLBConfigsCreateOrUpdate(ctx context.Context, d *schema.
 					TenantId:                  tenantID,
 					ReplicationControllerName: name,
 					LbType:                    lbc["lb_type"].(int),
-					Protocol:                  lbc["protocol"].(string),
+					Protocol:                  strings.ToUpper(lbc["protocol"].(string)),
 					Port:                      lbc["port"].(string),
 					HealthCheckURL:            lbc["health_check_url"].(string),
 					CertificateArn:            lbc["certificate_arn"].(string),
@@ -402,7 +403,7 @@ func resourceDuploServiceLBConfigsCreateOrUpdate(ctx context.Context, d *schema.
 					SkipHttpToHttps:           lbc["skip_http_to_https"].(bool),
 				}
 				if v, ok := lbc["backend_protocol_version"]; ok && item.LbType == 1 {
-					item.BeProtocolVersion = v.(string)
+					item.BeProtocolVersion = strings.ToUpper(v.(string))
 				}
 				if v, ok := lbc["health_check"]; ok && len(v.([]interface{})) > 0 {
 					healthcheck := v.([]interface{})[0].(map[string]interface{})
@@ -579,7 +580,7 @@ func flattenDuploServiceLbConfiguration(lb *duplosdk.DuploLbConfiguration) map[s
 		"name":                        lb.ReplicationControllerName,
 		"replication_controller_name": lb.ReplicationControllerName,
 		"lb_type":                     lb.LbType,
-		"protocol":                    lb.Protocol,
+		"protocol":                    strings.ToUpper(lb.Protocol),
 		"port":                        lb.Port,
 		"host_port":                   lb.HostPort,
 		"external_port":               lb.ExternalPort,

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -1021,8 +1021,7 @@ func diffSuppressSpecifiedMetadata(k, old, new string, d *schema.ResourceData) b
 }
 
 func diffSuppressStringCase(k, old, new string, d *schema.ResourceData) bool {
-	b := strings.EqualFold(old, new)
-	return b
+	return strings.EqualFold(old, new)
 }
 
 func diffSuppressAsgZones(k, old, new string, d *schema.ResourceData) bool {

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -1021,7 +1021,8 @@ func diffSuppressSpecifiedMetadata(k, old, new string, d *schema.ResourceData) b
 }
 
 func diffSuppressStringCase(k, old, new string, d *schema.ResourceData) bool {
-	return strings.EqualFold(old, new)
+	b := strings.EqualFold(old, new)
+	return b
 }
 
 func diffSuppressAsgZones(k, old, new string, d *schema.ResourceData) bool {


### PR DESCRIPTION
## Overview

Backward Compatibility 
## Summary of changes
Allowing protocol and backward_protocol to be passed irrespective of case
This PR does the following:

- Allow ignore case in validation
- DiffSuppress function to ignore change based on case
- Passing protocol and backend_version_protocol to request in uppercase

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
