### PR TITLE
DUPLO-29744 TF: Resource 'duplocloud_k8_secret' shows update in place for labels for re-plan without any modification

### DIFF
--- a/duplocloud/resource_duplo_k8_secret.go
+++ b/duplocloud/resource_duplo_k8_secret.go
@@ -232,9 +232,7 @@ func flattenK8sSecret(d *schema.ResourceData, duplo *duplosdk.DuploK8sSecret, re
 	m := d.Get("secret_labels")
 	if m != nil {
 		for k := range m.(map[string]interface{}) {
-			if _, ok := filter[k]; ok {
-				delete(filter, k)
-			}
+			delete(filter, k)
 		}
 	}
 	op := make(map[string]interface{})

--- a/duplocloud/resource_duplo_k8_secret.go
+++ b/duplocloud/resource_duplo_k8_secret.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -222,7 +223,30 @@ func flattenK8sSecret(d *schema.ResourceData, duplo *duplosdk.DuploK8sSecret, re
 
 	// Finally, set the map
 	d.Set("secret_annotations", duplo.SecretAnnotations)
-	d.Set("secret_labels", duplo.SecretLabels)
+	filter := map[string]struct{}{
+		"app":        {},
+		"owner":      {},
+		"tenantid":   {},
+		"tenantname": {},
+	}
+	m := d.Get("secret_labels")
+	if m != nil {
+		for k := range m.(map[string]interface{}) {
+			if _, ok := filter[k]; ok {
+				delete(filter, k)
+			}
+		}
+	}
+	op := make(map[string]interface{})
+
+	if duplo.SecretLabels != nil {
+		for k, v := range duplo.SecretLabels {
+			if _, ok := filter[k]; !ok {
+				op[k] = v
+			}
+		}
+	}
+	d.Set("secret_labels", op)
 	log.Printf("[TRACE] K8SecretGetList(%s): received response: %s", duplo.TenantID, duplo)
 
 }


### PR DESCRIPTION
## Overview

filter default secrete label keys
## Summary of changes
Added filter to filter out default labels in secret_labels field if not specified in duplocloud_k8_secret
This PR does the following:

- Added logic to filter out default lable if not mentioned
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
