### PR TITLE
DUPLO-30649 [TF] Load balancer configuration : make backend_protocol_version optional and computed for backward compatability

### DIFF
--- a/docs/resources/duplo_service_lbconfigs.md
+++ b/docs/resources/duplo_service_lbconfigs.md
@@ -128,7 +128,7 @@ Supported protocol based on lb_type:
 Optional:
 
 - `allow_global_access` (Boolean) Applicable for internal lb.
-- `backend_protocol_version` (String) Is used for communication between the load balancer and the target instances. This is a required field for ALB load balancer. Only applicable when protocol is HTTP or HTTPS. The protocol version. Specify GRPC to send requests to targets using gRPC. Specify HTTP2 to send requests to targets using HTTP/2. The default is HTTP1, which sends requests to targets using HTTP/1.1 Defaults to `HTTP1`.
+- `backend_protocol_version` (String) Is used for communication between the load balancer and the target instances. This field is used to set protocol version for ALB load balancer. Only applicable when protocol is HTTP or HTTPS. The protocol version. Specify GRPC to send requests to targets using gRPC. Specify HTTP2 to send requests to targets using HTTP/2. The default is HTTP1, which sends requests to targets using HTTP/1.1
 - `certificate_arn` (String) The ARN of an ACM certificate to associate with this load balancer.  Only applicable for HTTPS.
 - `custom_cidr` (List of String) Specify CIDR Values. This is applicable only for Network Load Balancer if `lb_type` is `6`.
 - `external_port` (Number) The frontend port associated with this load balancer configuration. Required if `lb_type` is not `7`.

--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -126,13 +126,12 @@ func duploLbConfigSchema() map[string]*schema.Schema {
 			Computed:    true,
 		},
 		"backend_protocol_version": {
-			Description:      "Is used for communication between the load balancer and the target instances. This is a required field for ALB load balancer. Only applicable when protocol is HTTP or HTTPS. The protocol version. Specify GRPC to send requests to targets using gRPC. Specify HTTP2 to send requests to targets using HTTP/2. The default is HTTP1, which sends requests to targets using HTTP/1.1",
+			Description:      "Is used for communication between the load balancer and the target instances. This field is used to set protocol version for ALB load balancer. Only applicable when protocol is HTTP or HTTPS. The protocol version. Specify GRPC to send requests to targets using gRPC. Specify HTTP2 to send requests to targets using HTTP/2. The default is HTTP1, which sends requests to targets using HTTP/1.1",
 			Type:             schema.TypeString,
 			Optional:         true,
-			ForceNew:         true,
-			Default:          "HTTP1",
 			DiffSuppressFunc: diffSuppressStringCase,
 			ValidateFunc:     validation.StringInSlice([]string{"HTTP1", "HTTP2", "GRPC"}, true),
+			Computed:         true,
 		},
 		"frontend_ip": {
 			Type:     schema.TypeString,
@@ -643,9 +642,9 @@ func validateLBConfigParameters(ctx context.Context, diff *schema.ResourceDiff, 
 			return fmt.Errorf("backend_protocol_version field is available only for ALB for others load balancer type use protocol")
 
 		}
-		if ok && lb == 1 && bp == "" {
-			return fmt.Errorf("backend_protocol_version is a required field for ALB load balancer type")
-		}
+		//if ok && lb == 1 && bp == "" {
+		//	return fmt.Errorf("backend_protocol_version is a required field for ALB load balancer type")
+		//}
 		if p == "http" && bp == "grpc" {
 			return fmt.Errorf("cannot set backend_protocol_version = %s with protocol= %s", bp, pr)
 		}


### PR DESCRIPTION


## Overview

Backward compatibility fix
## Summary of changes
Removed force new and default value attribute and added computed attribute for the optional backward_protocol_version filed of duplocloud_duplo_service_lbconfigs.
Removed validation to check if backward_protocol_version is passed if lb_type is ALB (1)
This PR does the following:

- Removed force new ,default value added compute true to backward_protocol_version
- Removed validation logic to check backward_protocol_version is passed if lb_type=1

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
