### PR TITLE
DUPLO-16771 TF: Force replacement of resource should be shown for `duplocloud_duplo_service` when `agent_platform` value is updated

### DIFF
--- a/duplocloud/resource_duplo_service.go
+++ b/duplocloud/resource_duplo_service.go
@@ -121,6 +121,7 @@ func duploServiceSchema() map[string]*schema.Schema {
 			Type:     schema.TypeInt,
 			Optional: true,
 			Required: false,
+			ForceNew: true,
 			Default:  0,
 		},
 		"replicas": {


### PR DESCRIPTION
## Overview

Force replace service when agent platform is changed
## Summary of changes

This PR does the following:

- made agent_platform force new for duplocloud_duplo_service
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
