### PR TITLE
DUPLO-30732 : Bug Fix: The computed attribute endpoint and host are not set if ecache cluster mode is enabled.

### DIFF
--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -604,9 +604,13 @@ func flattenEcacheInstance(duplo *duplosdk.DuploEcacheInstance, d *schema.Resour
 	d.Set("name", duplo.Name)
 	d.Set("identifier", duplo.Identifier)
 	d.Set("arn", duplo.Arn)
-	d.Set("endpoint", duplo.Endpoint)
-	if duplo.Endpoint != "" {
-		uriParts := strings.SplitN(duplo.Endpoint, ":", 2)
+	endpoint := duplo.Endpoint
+	if endpoint == "" {
+		endpoint = duplo.ConfigurationEndpoint
+	}
+	d.Set("endpoint", endpoint)
+	if endpoint != "" {
+		uriParts := strings.SplitN(endpoint, ":", 2)
 		d.Set("host", uriParts[0])
 		if len(uriParts) == 2 {
 			port, _ := strconv.Atoi(uriParts[1])

--- a/duplosdk/ecache_instance.go
+++ b/duplosdk/ecache_instance.go
@@ -15,6 +15,7 @@ type DuploEcacheInstance struct {
 	Identifier               string   `json:"Identifier"`
 	Arn                      string   `json:"Arn"`
 	Endpoint                 string   `json:"Endpoint,omitempty"`
+	ConfigurationEndpoint    string   `json:"ConfigurationEndpoint,omitempty"`
 	CacheType                int      `json:"CacheType,omitempty"`
 	EngineVersion            string   `json:"EngineVersion,omitempty"`
 	Size                     string   `json:"Size,omitempty"`


### PR DESCRIPTION
## Overview

- The computed attribute endpoint and host are not set if ecache cluster mode is enabled.

## Summary of changes

This PR does the following:

- The computed attribute set for both clustered and non-clustered redis caches.

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [x] Manually, on a remote test system

## Describe any breaking changes

- 
