### PR TITLE
DUPLO-30485 DOC:TF:lbconfig: Correct the example usage for resource 'duplocloud_duplo_service_lbconfigs'

### DIFF
--- a/docs/resources/duplo_service_lbconfigs.md
+++ b/docs/resources/duplo_service_lbconfigs.md
@@ -45,8 +45,8 @@ resource "duplocloud_duplo_service_lbconfigs" "myservice" {
     health_check {
       healthy_threshold   = 4
       unhealthy_threshold = 4
-      timeout             = 50
-      interval            = 30
+      timeout             = 30
+      interval            = 50
       http_success_codes  = "200-399"
     }
   }
@@ -69,8 +69,8 @@ resource "duplocloud_duplo_service_lbconfigs" "myservice2" {
     health_check {
       healthy_threshold   = 4
       unhealthy_threshold = 4
-      timeout             = 50
-      interval            = 30
+      timeout             = 30
+      interval            = 50
       http_success_codes  = "200-399"
     }
   }

--- a/examples/resources/duplocloud_duplo_service_lbconfigs/resource.tf
+++ b/examples/resources/duplocloud_duplo_service_lbconfigs/resource.tf
@@ -27,8 +27,8 @@ resource "duplocloud_duplo_service_lbconfigs" "myservice" {
     health_check {
       healthy_threshold   = 4
       unhealthy_threshold = 4
-      timeout             = 50
-      interval            = 30
+      timeout             = 30
+      interval            = 50
       http_success_codes  = "200-399"
     }
   }
@@ -51,8 +51,8 @@ resource "duplocloud_duplo_service_lbconfigs" "myservice2" {
     health_check {
       healthy_threshold   = 4
       unhealthy_threshold = 4
-      timeout             = 50
-      interval            = 30
+      timeout             = 30
+      interval            = 50
       http_success_codes  = "200-399"
     }
   }


### PR DESCRIPTION
## Overview

Example update
## Summary of changes
Example update for duplocloud_duplo_service_lbconfigs resource in health_check block due to fault for timeout > interval
This PR does the following:

- Added lower value to timeout than interval
- Document updated

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
