### PR TITLE
DUPLO-30487 TF:lbconfig: HealthCheckTimeoutSeconds range should be between 2–120 seconds

### DIFF
--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -204,7 +204,7 @@ func duploLbConfigSchema() map[string]*schema.Schema {
 						Type:         schema.TypeInt,
 						Optional:     true,
 						Computed:     true,
-						ValidateFunc: validation.IntBetween(2, 100),
+						ValidateFunc: validation.IntBetween(2, 120),
 					},
 					"interval": {
 						Description: "Approximate amount of time, in seconds, between health checks of an individual target. Minimum value 5 seconds, Maximum value 300 seconds.",


### PR DESCRIPTION
## Overview

Validation fix
## Summary of changes
Updated validation boundary value.
This PR does the following:

- Updated validation for health_check.timeout from 2 - 100  to 2 - 120
- ...

## Testing performed

- [ ] Using unit tests
- [ ✔︎] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
