### PR TITLE
DUPLO-30973 TF: GCP SQL Takes forever to change label I didn't change

### DIFF
--- a/duplocloud/resource_duplo_gcp_sql_database.go
+++ b/duplocloud/resource_duplo_gcp_sql_database.go
@@ -254,7 +254,10 @@ func resourceGcpSqlDBInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 			return diag.Errorf("Error updating tenant %s sql database '%s': %s", tenantID, resp.Name, err)
 		}
 		if d.Get("wait_until_ready") == nil || d.Get("wait_until_ready").(bool) {
-			gcpSqlDBInstanceWaitUntilUnavailable(ctx, c, tenantID, fullName, time.Duration(5*time.Minute))
+			err := gcpSqlDBInstanceWaitUntilUnavailable(ctx, c, tenantID, fullName, time.Duration(5*time.Minute))
+			if err != nil {
+				return diag.FromErr(err)
+			}
 			clientErr := gcpSqlDBInstanceWaitUntilReady(ctx, c, tenantID, fullName, d.Timeout("update"))
 			if clientErr != nil {
 				return diag.FromErr(clientErr)

--- a/duplocloud/resource_duplo_gcp_sql_database.go
+++ b/duplocloud/resource_duplo_gcp_sql_database.go
@@ -3,10 +3,11 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
@@ -253,6 +254,7 @@ func resourceGcpSqlDBInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 			return diag.Errorf("Error updating tenant %s sql database '%s': %s", tenantID, resp.Name, err)
 		}
 		if d.Get("wait_until_ready") == nil || d.Get("wait_until_ready").(bool) {
+			gcpSqlDBInstanceWaitUntilUnavailable(ctx, c, tenantID, fullName, time.Duration(5*time.Minute))
 			clientErr := gcpSqlDBInstanceWaitUntilReady(ctx, c, tenantID, fullName, d.Timeout("update"))
 			if clientErr != nil {
 				return diag.FromErr(clientErr)
@@ -346,7 +348,7 @@ func parseGcpSqlDatabaseIdParts(id string) (tenantID, name string, err error) {
 
 func gcpSqlDBInstanceWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {
 	log.Printf("[DEBUG] gcpSqlDBInstanceWaitUntilReady(%s, %s)", tenantID, name)
-	stateChange := false
+	//stateChange := false
 	stateConf := &retry.StateChangeConf{
 		Pending: []string{"pending"},
 		Target:  []string{"ready"},
@@ -356,11 +358,6 @@ func gcpSqlDBInstanceWaitUntilReady(ctx context.Context, c *duplosdk.Client, ten
 			log.Printf("[TRACE] Gcp sql database instance state is (%s).", rp.Status)
 			status := "pending"
 			if err == nil {
-				if rp.Status == "RUNNABLE" && !stateChange {
-					return rp, status, err
-				} else {
-					stateChange = true
-				}
 				if rp.Status == "RUNNABLE" {
 					status = "ready"
 				} else {
@@ -411,4 +408,27 @@ func passwordRequiredForVersion(ctx context.Context, c *duplosdk.Client, tenantI
 		}
 	}
 	return false, nil
+}
+
+func gcpSqlDBInstanceWaitUntilUnavailable(ctx context.Context, c *duplosdk.Client, id, name string, timeout time.Duration) error {
+	stateConf := &retry.StateChangeConf{
+		Target:       []string{"unavailable"},
+		Pending:      []string{"RUNNABLE"},
+		MinTimeout:   10 * time.Second,
+		PollInterval: 30 * time.Second,
+		Timeout:      timeout,
+		Refresh: func() (interface{}, string, error) {
+			resp, err := c.GCPSqlDBInstanceGet(id, name)
+			if err != nil {
+				return 0, "", err
+			}
+			if resp.Status != "RUNNABLE" {
+				resp.Status = "unavailable"
+			}
+			return resp, resp.Status, nil
+		},
+	}
+	log.Printf("[DEBUG] RdsInstanceWaitUntilUnavailable (%s)", id)
+	_, err := stateConf.WaitForStateContext(ctx)
+	return err
 }

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -780,7 +780,7 @@ func flattenStringMap(duplo map[string]string) map[string]interface{} {
 }
 
 func flattenGcpLabels(d *schema.ResourceData, duplo map[string]string) {
-	duploManagedLabels := []string{"duplo-allow-public-access", "duplo-encryption"}
+	duploManagedLabels := []string{"duplo-allow-public-access", "duplo-encryption", "duplo-tenant"}
 	mp := flattenStringMap(duplo)
 	for _, v := range duploManagedLabels {
 		delete(mp, v)


### PR DESCRIPTION
## Overview

Fixed Default label usage and context out issue on update
## Summary of changes
Added default label to filter , added waituntilunavailable function to resolve context timeout
This PR does the following:

- Added duplo-tenant label key to filter
- Added waituntilunavailable with timeout of 5 min which will poll for 5 min to check status has change from runnable to non runnable state on modifying

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
