### PR TITLE
DUPLO-31051 TF resource duplocloud_rds_instance always shows diff for multi-az and deletion_protection.

### DIFF
--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -1137,6 +1137,10 @@ func validateRDSParameters(ctx context.Context, diff *schema.ResourceDiff, m int
 			return fmt.Errorf("Cannot set v2 scaling configuration for provisioned rds instance")
 		}
 	}
+	if diff.Get("multi_az").(bool) && (eng == 8 || eng == 9 || eng == 16) {
+		return fmt.Errorf("Cannot set multi_az for %s", engines[eng])
+
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Overview

Added Validation
## Summary of changes
Validation to not allow multi-az enable for Aurora dbs
This PR does the following:

- Added validation logic in custom diff for not allowing multi-az enable for aurora db
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
