### PR TITLE
DUPLO-31001 Helm Repository Fails to create when Optional Fields 'helm_provider' and 'type' are not provided

### DIFF
--- a/duplocloud/resource_duplo_helm_repository.go
+++ b/duplocloud/resource_duplo_helm_repository.go
@@ -92,6 +92,7 @@ func resourceHelmRepository() *schema.Resource {
 			},
 		},
 	}
+
 }
 
 func resourceHelmRepositoryRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/duplosdk/duplo_helm.go
+++ b/duplosdk/duplo_helm.go
@@ -20,11 +20,11 @@ type DuploHelmSpec struct {
 	Chart       *Chart `json:"chart,omitempty"`
 	//Values      map[string]interface{} `json:"values,omitempty"`
 	Values          interface{} `json:"values,omitempty"`
-	Insecure        bool        `json:"Insecure"`
-	PassCredentials bool        `json:"PassCredentials"`
-	Provider        string      `json:"Provider"`
-	Suspend         bool        `json:"Suspend"`
-	Type            string      `json:"Type"`
+	Insecure        bool        `json:"Insecure,omitempty"`
+	PassCredentials bool        `json:"PassCredentials,omitempty"`
+	Provider        string      `json:"Provider,omitempty"`
+	Suspend         bool        `json:"Suspend,omitempty"`
+	Type            string      `json:"Type,omitempty"`
 }
 
 type SourceRef struct {


### PR DESCRIPTION
## Overview

Bug fix
## Summary of changes
Fixed helm repository creation with optional field type and provider for resource duplocloud_k8_helm_repository
This PR does the following:

- Added omitempty to field and provider attribute in helm repository model
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
