### PR TITLE
DUPLO-30481 TF: AWS:Support EC2 Capacity provider for ECS

### DIFF
--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -168,19 +168,21 @@ Should be one of:
    - `0` : Redis
    - `1` : Memcache
 
+   - `2` : Valkey
+
  Defaults to `0`.
-- `enable_cluster_mode` (Boolean) Flag to enable/disable redis cluster mode.
+- `enable_cluster_mode` (Boolean) Flag to enable/disable redis/valkey cluster mode.
 - `encryption_at_rest` (Boolean) Enables encryption-at-rest. Defaults to `false`.
 - `encryption_in_transit` (Boolean) Enables encryption-in-transit. Defaults to `false`.
 - `engine_version` (String) The engine version of the elastic instance.
-See AWS documentation for the [available Redis instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) or the [available Memcached instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions-mc.html).
+See AWS documentation for the [available Redis and Valkey instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) or the [available Memcached instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions-mc.html).
 - `kms_key_id` (String) The globally unique identifier for the key.
 - `log_delivery_configuration` (Block Set, Max: 2) (see [below for nested schema](#nestedblock--log_delivery_configuration))
 - `number_of_shards` (Number) The number of shards to create. Applicable only if enable_cluster_mode is set to true
-- `parameter_group_name` (String) The REDIS parameter group to supply.
+- `parameter_group_name` (String) The REDIS/Valkey parameter group to supply.
 - `replicas` (Number) The number of replicas to create. Supported number of replicas is 1 to 6 Defaults to `1`.
-- `snapshot_arns` (List of String) Specify the ARN of a Redis RDB snapshot file stored in Amazon S3. User should have the access to export snapshot to s3 bucket. One can find steps to provide access to export snapshot to s3 on following link https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-exporting.html
-- `snapshot_name` (String) Select the snapshot/backup you want to use for creating redis.
+- `snapshot_arns` (List of String) Specify the ARN of a Redis/Valkey RDB snapshot file stored in Amazon S3. User should have the access to export snapshot to s3 bucket. One can find steps to provide access to export snapshot to s3 on following link https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-exporting.html
+- `snapshot_name` (String) Select the snapshot/backup you want to use for creating redis/valkey.
 - `snapshot_retention_limit` (Number) Specify retention limit in days. Accepted values - 1-35.
 - `snapshot_window` (String) Specify snapshot window limit The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard). Example: 05:00-09:00. If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/docs/resources/ecs_service.md
+++ b/docs/resources/ecs_service.md
@@ -26,6 +26,7 @@ resource "duplocloud_ecs_task_definition" "myservice" {
 # Deploy NGINX using ECS
 resource "duplocloud_ecs_service" "myservice" {
   tenant_id       = duplocloud_tenant.myapp.tenant_id
+  name            = "myecsservice"
   task_definition = duplocloud_ecs_task_definition.myservice.arn
   replicas        = 2
   load_balancer {
@@ -36,6 +37,20 @@ resource "duplocloud_ecs_service" "myservice" {
     enable_access_logs   = false
     drop_invalid_headers = true
     health_check_url     = "https://example.healthcheckurl.com/healthcheck"
+    target_group_count   = 1
+  }
+}
+
+# Example to create ecs service having asg as capacity_provider, for asg created with agent platform ecs
+resource "duplocloud_ecs_service" "myservice" {
+  tenant_id       = duplocloud_tenant.myapp.tenant_id
+  name            = "myservice"
+  task_definition = duplocloud_ecs_task_definition.myservice.arn
+  replicas        = 1
+  capacity_provider_strategy {
+    base              = 0
+    weight            = 1
+    capacity_provider = "<asg-fullname>"
   }
 }
 ```

--- a/duplocloud/resource_duplo_ecs_service.go
+++ b/duplocloud/resource_duplo_ecs_service.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -273,10 +274,6 @@ func ecsServiceSchema() map[string]*schema.Schema {
 						Description: "Name of the capacity provider.",
 						Type:        schema.TypeString,
 						Required:    true,
-						ValidateFunc: validation.StringInSlice([]string{
-							"FARGATE",
-							"FARGATE_SPOT",
-						}, false),
 					},
 				},
 			},

--- a/examples/resources/duplocloud_ecs_service/resource.tf
+++ b/examples/resources/duplocloud_ecs_service/resource.tf
@@ -11,6 +11,7 @@ resource "duplocloud_ecs_task_definition" "myservice" {
 # Deploy NGINX using ECS
 resource "duplocloud_ecs_service" "myservice" {
   tenant_id       = duplocloud_tenant.myapp.tenant_id
+  name            = "myecsservice"
   task_definition = duplocloud_ecs_task_definition.myservice.arn
   replicas        = 2
   load_balancer {
@@ -21,5 +22,19 @@ resource "duplocloud_ecs_service" "myservice" {
     enable_access_logs   = false
     drop_invalid_headers = true
     health_check_url     = "https://example.healthcheckurl.com/healthcheck"
+    target_group_count   = 1
+  }
+}
+
+# Example to create ecs service having asg as capacity_provider, for asg created with agent platform ecs
+resource "duplocloud_ecs_service" "myservice" {
+  tenant_id       = duplocloud_tenant.myapp.tenant_id
+  name            = "myservice"
+  task_definition = duplocloud_ecs_task_definition.myservice.arn
+  replicas        = 1
+  capacity_provider_strategy {
+    base              = 0
+    weight            = 1
+    capacity_provider = "<asg-fullname>"
   }
 }


### PR DESCRIPTION
## Overview
Support for EC2 capacity

## Summary of changes
Allowed passing host as capacity provider created with agent platform as ecs This PR does the following:

* Removed validation on capacity_provider, BE has validation in place to check if correct host is passed
* Updated document with example

## Testing performed
* [ ]  Using unit tests
* [ ]  Manually, on my local system
* [ ✔︎] Manually, on a remote test system

## Describe any breaking changes
* ...

