### PR TITLE
DUPLO-31151 [TF] support TCP, UDP and TLS protocol for Target Group LB type

### DIFF
--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -51,7 +51,7 @@ func duploLbConfigSchema() map[string]*schema.Schema {
 				"	- `4 (K8S Service w/ Node Port)` : TCP, UDP\n" +
 				"	- `5 (Azure Shared Application Gateway)`: HTTP, HTTPS\n" +
 				"	- `6 (NLB)` : TCP, UDP, TLS\n" +
-				"	- `7 (Target Group Only)` : HTTP, HTTPS\n",
+				"	- `7 (Target Group Only)` : HTTP, HTTPS, TCP, UDP, TLS\n",
 			Type:             schema.TypeString,
 			Required:         true,
 			DiffSuppressFunc: diffSuppressStringCase,
@@ -649,7 +649,7 @@ func validateLBConfigParameters(ctx context.Context, diff *schema.ResourceDiff, 
 			return fmt.Errorf("cannot set backend_protocol_version = %s with protocol= %s", bp, pr)
 		}
 
-		if (lb == 1 || lb == 7 || lb == 5) && (p != "http" && p != "https") {
+		if (lb == 1 || lb == 5) && (p != "http" && p != "https") {
 			return fmt.Errorf("protocol = %s not supported for lb_type=%d", pr, lb)
 		}
 		if lb == 6 && (p != "tcp" && p != "udp" && p != "tls") {


### PR DESCRIPTION
## Overview

TCP, UDP, TLS protocol support for  Target Group
## Summary of changes
Validation fix
This PR does the following:

- Allowed tcp,udp,tls for lb_type=7 along with http and https protocol
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
