### PR TITLE
DUPLO-30932 duplocloud_gcp_k8_node_pools thrwoing error on upgrade_settings startegy.

### DIFF
--- a/docs/resources/gcp_node_pool.md
+++ b/docs/resources/gcp_node_pool.md
@@ -18,10 +18,10 @@ resource "duplocloud_tenant" "myapp" {
   plan_id      = "default"
 }
 
-#EXample for upgrade strategy NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED
+#Example for upgrade strategy NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED
 resource "duplocloud_gcp_node_pool" "myNodePool" {
   tenant_id              = duplocloud_tenant.myapp.tenant_id
-  name                   = "myNodePool"
+  name                   = "mynodepool"
   is_autoscaling_enabled = false
   accelerator {
     accelerator_count  = "2"

--- a/docs/resources/gcp_node_pool.md
+++ b/docs/resources/gcp_node_pool.md
@@ -18,7 +18,7 @@ resource "duplocloud_tenant" "myapp" {
   plan_id      = "default"
 }
 
-
+#EXample for upgrade strategy NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED
 resource "duplocloud_gcp_node_pool" "myNodePool" {
   tenant_id              = duplocloud_tenant.myapp.tenant_id
   name                   = "myNodePool"
@@ -34,11 +34,6 @@ resource "duplocloud_gcp_node_pool" "myNodePool" {
     gpu_driver_installation_config {
       gpu_driver_version = "DEFAULT"
     }
-  }
-  upgrade_settings {
-    strategy        = "NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED"
-    max_surge       = 4
-    max_unavailable = 2
   }
   zones           = ["us-east1-c"]
   location_policy = "BALANCED"

--- a/duplocloud/resource_duplo_gcp_k8_node_pool.go
+++ b/duplocloud/resource_duplo_gcp_k8_node_pool.go
@@ -330,6 +330,7 @@ func gcpK8NodePoolFunctionSchema() map[string]*schema.Schema {
 		"taints": {
 			Type:     schema.TypeList,
 			Optional: true,
+			Computed: true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"key": {
@@ -753,6 +754,9 @@ func setGCPNodePoolStateField(d *schema.ResourceData, duplo *duplosdk.DuploGCPK8
 	d.Set("auto_upgrade", duplo.AutoUpgrade)
 	d.Set("zones", duplo.Zones)
 	d.Set("image_type", strings.ToLower(duplo.ImageType))
+	if duplo.LocationPolicy == "" {
+		duplo.LocationPolicy = "BALANCED"
+	}
 	d.Set("location_policy", duplo.LocationPolicy)
 	d.Set("max_node_count", duplo.MaxNodeCount)
 	d.Set("min_node_count", duplo.MinNodeCount)
@@ -856,13 +860,13 @@ func gcpNodePoolAcceleratortoState(accelerator *duplosdk.Accelerator) []map[stri
 	if accelerator.GPUSharingConfig.MaxSharedClientPerGPU != 0 {
 		gpuSharingConfigMap["max_shared_clients_per_gpu"] = strconv.Itoa(accelerator.GPUSharingConfig.MaxSharedClientPerGPU)
 	}
-	state["gpu_sharing_config"] = gpuSharingConfigMap
+	state["gpu_sharing_config"] = []interface{}{gpuSharingConfigMap}
 
 	driverConfig := make(map[string]interface{})
 	if accelerator.GPUDriverInstallationConfig.GPUDriverVersion != "" {
 		driverConfig["gpu_driver_version"] = accelerator.GPUDriverInstallationConfig.GPUDriverVersion
 	}
-	state["gpu_driver_installation_config"] = driverConfig
+	state["gpu_driver_installation_config"] = []interface{}{driverConfig}
 
 	return []map[string]interface{}{state}
 }

--- a/examples/resources/duplocloud_gcp_node_pool/resource.tf
+++ b/examples/resources/duplocloud_gcp_node_pool/resource.tf
@@ -3,10 +3,10 @@ resource "duplocloud_tenant" "myapp" {
   plan_id      = "default"
 }
 
-#EXample for upgrade strategy NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED
+#Example for upgrade strategy NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED
 resource "duplocloud_gcp_node_pool" "myNodePool" {
   tenant_id              = duplocloud_tenant.myapp.tenant_id
-  name                   = "myNodePool"
+  name                   = "mynodepool"
   is_autoscaling_enabled = false
   accelerator {
     accelerator_count  = "2"

--- a/examples/resources/duplocloud_gcp_node_pool/resource.tf
+++ b/examples/resources/duplocloud_gcp_node_pool/resource.tf
@@ -3,7 +3,7 @@ resource "duplocloud_tenant" "myapp" {
   plan_id      = "default"
 }
 
-
+#EXample for upgrade strategy NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED
 resource "duplocloud_gcp_node_pool" "myNodePool" {
   tenant_id              = duplocloud_tenant.myapp.tenant_id
   name                   = "myNodePool"
@@ -19,11 +19,6 @@ resource "duplocloud_gcp_node_pool" "myNodePool" {
     gpu_driver_installation_config {
       gpu_driver_version = "DEFAULT"
     }
-  }
-  upgrade_settings {
-    strategy        = "NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED"
-    max_surge       = 4
-    max_unavailable = 2
   }
   zones           = ["us-east1-c"]
   location_policy = "BALANCED"


### PR DESCRIPTION

## Overview

Fixed usage
## Summary of changes
Document update
Diff fix
Fix for variable setting to state error
This PR does the following:

- Document update for NODE_POOL_UPDATE_STRATEGY_UNSPECIFIED update strategy usage
- Made taints field computed
- fixed setting fields to state

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
