### PR TITLE
DUPLO-30496 TF:lbconfig: Add validation for timeout and interval while creation

### DIFF
--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -661,6 +661,13 @@ func validateLBConfigParameters(ctx context.Context, diff *schema.ResourceDiff, 
 		if lb == 0 && p == "tls" {
 			return fmt.Errorf("protocol = %s not supported for lb_type=%d", pr, lb)
 		}
+		healthCheck := m["health_check"].([]interface{})
+		if len(healthCheck) > 0 {
+			hm := healthCheck[0].(map[string]interface{})
+			if hm["timeout"].(int) >= hm["interval"].(int) {
+				return fmt.Errorf("health check timeout must be less than health check interval")
+			}
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Overview

Validation fix
## Summary of changes
Added validation to check if interval is greater than timeout
This PR does the following:

- Added validation to throw error if health check timeout is greater than or equal to health check interval
- ...

## Testing performed

- [ ] Using unit tests
- [ ✔︎] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
