### PR TITLE
DUPLO-31221 TF resource duplocloud_rds_instance always shows diff for deletion_protection.

### DIFF
--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -373,6 +373,7 @@ func resourceDuploRdsInstanceRead(ctx context.Context, d *schema.ResourceData, m
 
 	// Get the object from Duplo, detecting a missing object
 	c := m.(*duplosdk.Client)
+
 	duplo, err := c.RdsInstanceGet(d.Id())
 	if err != nil {
 		return diag.FromErr(err)
@@ -381,8 +382,16 @@ func resourceDuploRdsInstanceRead(ctx context.Context, d *schema.ResourceData, m
 		d.SetId("")
 		return nil
 	}
-	d.SetId(fmt.Sprintf("v2/subscriptions/%s/RDSDBInstance/%s", duplo.TenantID, duplo.Name))
+	if isAuroraDB(d) {
+		clust, err := c.DescribeRdsCluster(d.Id())
+		if err != nil {
+			d.SetId("")
+			return diag.Errorf("%s", err.Error())
+		}
+		duplo.DeletionProtection = clust.DeleteProtection
 
+	}
+	d.SetId(fmt.Sprintf("v2/subscriptions/%s/RDSDBInstance/%s", duplo.TenantID, duplo.Name))
 	// Convert the object into Terraform resource data
 	jo := rdsInstanceToState(duplo, d)
 	for key, val := range jo {

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -151,6 +151,10 @@ type DuploMonitoringInterval struct {
 	MonitoringInterval   int    `json:"MonitoringInterval"`
 }
 
+type DuploRDSClusterCompareField struct {
+	DeleteProtection bool `json:"DeletionProtection"`
+}
+
 /*************************************************
  * API CALLS to duplo
  */
@@ -474,4 +478,19 @@ func (c *Client) EnableReadReplicaServerlessCreation(tenantID, cIdentifier strin
 		fmt.Sprintf("ReadReplicaServerlessCreate(%s, %s)", tenantID, cIdentifier),
 		fmt.Sprintf("v3/subscriptions/%s/aws/rds/cluster/%s/auroraToV2Serverless", tenantID, cIdentifier),
 		&rq, nil)
+}
+
+func (c *Client) DescribeRdsCluster(id string) (*DuploRDSClusterCompareField, ClientError) {
+	idParts := strings.SplitN(id, "/", 5)
+	tenantID := idParts[2]
+	name := idParts[4]
+	identifier := EnsureDuploPrefixInRdsIdentifier(name)
+	// Call the API.
+	duploObject := DuploRDSClusterCompareField{}
+	conf := NewRetryConf()
+	err := c.getAPIWithRetry(
+		fmt.Sprintf("RdsInstanceGet(%s, %s)", tenantID, identifier),
+		fmt.Sprintf("v3/subscriptions/%s/aws/rds/cluster/%s", tenantID, identifier+"-cluster"),
+		&duploObject, &conf)
+	return &duploObject, err
 }


### PR DESCRIPTION
## Overview

Fix for Deletion Protection value not getting set

## Summary of changes
Fixed deletion_protection not getting set for rds cluster in duplocloud_rds_instance resource
This PR does the following:

- Added AWS pass through API to fetch deletion protection value
- Calling AWS pass through APi if db is cluster db

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
