### PR TITLE
DUPLO-30317 DOC:TF:ValkeyCache: Add usage example for cache_type = Valkey

### DIFF
--- a/docs/resources/asg_instance_refresh.md
+++ b/docs/resources/asg_instance_refresh.md
@@ -3,7 +3,7 @@
 page_title: "duplocloud_asg_instance_refresh Resource - terraform-provider-duplocloud"
 subcategory: ""
 description: |-
-  duplocloud_asg_instance_refresh triggers the instance refresh of asg in duplo
+  duplocloudasginstance_refresh triggers the instance refresh of asg in duplo
 ---
 
 # duplocloud_asg_instance_refresh (Resource)

--- a/docs/resources/duplo_service_lbconfigs.md
+++ b/docs/resources/duplo_service_lbconfigs.md
@@ -123,7 +123,7 @@ Supported protocol based on lb_type:
 	- `4 (K8S Service w/ Node Port)` : TCP, UDP
 	- `5 (Azure Shared Application Gateway)`: HTTP, HTTPS
 	- `6 (NLB)` : TCP, UDP, TLS
-	- `7 (Target Group Only)` : HTTP, HTTPS
+	- `7 (Target Group Only)` : HTTP, HTTPS, TCP, UDP, TLS
 
 Optional:
 

--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -199,6 +199,7 @@ Should be one of:
 
    - `0` : Redis
    - `1` : Memcache
+   - `2` : Valkey
 
  Defaults to `0`.
 - `enable_cluster_mode` (Boolean) Flag to enable/disable redis/valkey cluster mode.

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -75,7 +75,8 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			Description: "The numerical index of elasticache instance type.\n" +
 				"Should be one of:\n\n" +
 				"   - `0` : Redis\n" +
-				"   - `1` : Memcache\n\n",
+				"   - `1` : Memcache\n" +
+				"   - `2` : Valkey\n\n",
 			Type:         schema.TypeInt,
 			Optional:     true,
 			ForceNew:     true,


### PR DESCRIPTION
## Overview

Document update
## Summary of changes
Document update for duplocloud_rds_instance 
This PR does the following:

- Added instance type index for valkey
- ...

## Testing performed

- [ ] Using unit tests
- [ ✔︎] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
