### PR TITLE
DUPLO-30689 Error: context deadline exceeded for ASG and EC2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install_window: build
 #	mv ${BINARY} bin
 test:
 	go test -i $(TEST) || exit 1
-	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=180s -parallel=4
+	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=90s -parallel=4
 
 testacc:
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ install_window: build
 #	mv ${BINARY} bin
 test:
 	go test -i $(TEST) || exit 1
-	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=90s -parallel=4
+	echo $(TEST) | xargs -t -n4 go test $(TESTARGS) -timeout=180s -parallel=4
 
 testacc:
 	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 120m

--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -316,13 +316,9 @@ func resourceAwsASGRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	// Get the object from Duplo, detecting a missing object
 	c := m.(*duplosdk.Client)
-	profile, err := c.AsgProfileGet(tenantID, friendlyName)
-	if err != nil {
-		// backend may return a 400 instead of a 404
-		exists, err2 := c.AsgProfileExists(tenantID, friendlyName)
-		if exists || err2 != nil {
-			return diag.Errorf("Unable to retrieve ASG profile '%s': %s", id, err)
-		}
+	profile, cerr := c.AsgProfileGet(tenantID, friendlyName)
+	if cerr != nil && cerr.Status() != 404 {
+		return diag.Errorf("Unable to retrieve ASG profile '%s': %s", id, err)
 	}
 	if profile == nil {
 		d.SetId("") // object missing

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -386,14 +386,9 @@ func resourceAwsHostRead(ctx context.Context, d *schema.ResourceData, m interfac
 
 	// Get the object from Duplo, detecting a missing object
 	c := m.(*duplosdk.Client)
-	duplo, err := c.NativeHostGet(tenantID, instanceID)
-	if err != nil {
-
-		// backend may return a 400 instead of a 404
-		exists, err2 := c.NativeHostExists(tenantID, instanceID)
-		if exists || err2 != nil {
-			return diag.Errorf("Unable to retrieve AWS host '%s': %s", id, err)
-		}
+	duplo, cerr := c.NativeHostGet(tenantID, instanceID)
+	if cerr != nil && cerr.Status() != 404 {
+		return diag.Errorf("Unable to retrieve AWS host '%s': %s", id, cerr)
 	}
 	if duplo == nil {
 		d.SetId("") // object missing

--- a/duplocloud/resource_duplo_aws_host_test.go
+++ b/duplocloud/resource_duplo_aws_host_test.go
@@ -2,10 +2,11 @@ package duplocloud
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"github.com/duplocloud/terraform-provider-duplocloud/internal/duplocloudtest"
 	"github.com/duplocloud/terraform-provider-duplocloud/internal/duplosdktest"
-	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/duplosdk/asg.go
+++ b/duplosdk/asg.go
@@ -49,10 +49,12 @@ type DuploAsgProfileDeleteReq struct {
 // AsgProfileGetList retrieves a list of ASG profiles via the Duplo API.
 func (c *Client) AsgProfileGetList(tenantID string) (*[]DuploAsgProfile, ClientError) {
 	log.Printf("[DEBUG] Duplo API - Get ASG Profile List(TenantId-%s)", tenantID)
+	conf := NewRetryConf()
+
 	rp := []DuploAsgProfile{}
-	err := c.getAPI(fmt.Sprintf("AsgProfileGetList(%s)", tenantID),
+	err := c.getAPIWithRetry(fmt.Sprintf("AsgProfileGetList(%s)", tenantID),
 		fmt.Sprintf("subscriptions/%s/GetTenantAsgProfiles", tenantID),
-		&rp)
+		&rp, &conf)
 	return &rp, err
 }
 

--- a/duplosdk/client_with_retry_rate_exceeded.go
+++ b/duplosdk/client_with_retry_rate_exceeded.go
@@ -67,8 +67,8 @@ func retryApiCall(apiCaller string, operationApiCall func() ClientError, conf *R
 		delay := calculateBackoffInterval(apiCaller, attempt, conf.MaxStartingDelay, conf.MaxStartingDelay, conf.MinDelay, conf.MaxDelay, conf.MinJitterDelay)
 		sleepDuration += delay
 		log.Printf("[TRACE] retryApiCall START sleep start (loop_sleep, retry_attempts, api) (%d,%d,%s)", int(delay.Seconds()), attempt, apiCaller)
-		time.Sleep(delay)
 		if attempt > 1 {
+			time.Sleep(delay)
 			log.Printf("[WARN] retryApiCall sleep done (loop_sleep, retry_attempts, api) (%d,%d,%s)", int(delay.Seconds()), attempt, apiCaller)
 		}
 		err = operationApiCall()

--- a/duplosdk/native_hosts.go
+++ b/duplosdk/native_hosts.go
@@ -195,10 +195,12 @@ func (c *Client) LegacyNativeHostImageGetList(tenantID string) (*[]DuploNativeHo
 
 // NativeHostGetList retrieves a list of native hosts via the Duplo API.
 func (c *Client) NativeHostGetList(tenantID string) (*[]DuploNativeHost, ClientError) {
+	conf := NewRetryConf()
+
 	rp := []DuploNativeHost{}
-	err := c.getAPI(fmt.Sprintf("NativeHostGetList(%s)", tenantID),
+	err := c.getAPIWithRetry(fmt.Sprintf("NativeHostGetList(%s)", tenantID),
 		fmt.Sprintf("v2/subscriptions/%s/NativeHostV2", tenantID),
-		&rp)
+		&rp, &conf)
 	return &rp, err
 }
 
@@ -225,10 +227,12 @@ func (c *Client) NativeHostExists(tenantID, instanceID string) (bool, ClientErro
 
 // NativeHostGet retrieves an native host via the Duplo API.
 func (c *Client) NativeHostGet(tenantID, instanceID string) (*DuploNativeHost, ClientError) {
+	conf := NewRetryConf()
+
 	rp := DuploNativeHost{}
-	err := c.getAPI(fmt.Sprintf("NativeHostGet(%s, %s)", tenantID, instanceID),
+	err := c.getAPIWithRetry(fmt.Sprintf("NativeHostGet(%s, %s)", tenantID, instanceID),
 		fmt.Sprintf("v2/subscriptions/%s/NativeHostV2/%s", tenantID, instanceID),
-		&rp)
+		&rp, &conf)
 	return &rp, err
 }
 


### PR DESCRIPTION
## Overview

Retry mechanism for asg and host resource
## Summary of changes
Retries add for get api for 400 errors in duplocloud_aws_host and duplocloud_asg_profile
This PR does the following:

- Retires added for asg and host get apis
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
