### PR TITLE
DUPLO-31028 Getting 404 while TF apply for duplocloud_k8s_job after removing k8s job from Duplo UI

### DIFF
--- a/duplocloud/resource_duplo_k8s_job.go
+++ b/duplocloud/resource_duplo_k8s_job.go
@@ -145,11 +145,12 @@ func resourceKubernetesJobV1Read(ctx context.Context, d *schema.ResourceData, me
 	c := meta.(*duplosdk.Client)
 	job, err := c.K8sJobGet(tenantId, jobName)
 	if err != nil {
-		log.Printf("[DEBUG] Received error: %#v", err)
 		return diag.Errorf("Failed to read Job. API error: %s", err)
 	}
-	log.Printf("[INFO] Received Job: %#v", job)
-
+	if job == nil {
+		d.SetId("")
+		return nil
+	}
 	isAnyHostAllowed := GetIsAnyHostAllowed(job.Metadata.Annotations)
 	job.IsAnyHostAllowed = isAnyHostAllowed
 

--- a/duplosdk/k8s_cron_job.go
+++ b/duplosdk/k8s_cron_job.go
@@ -45,6 +45,9 @@ func (c *Client) K8sCronJobGet(tenantId, jobName string) (*DuploK8sCronJob, Clie
 		&rp)
 
 	if err != nil {
+		if err.Status() == 404 {
+			return nil, nil
+		}
 		return nil, newClientError(fmt.Sprintf("cronjob %s not found. %s", jobName, err))
 	}
 	// Add the tenant ID, then return the result.

--- a/duplosdk/k8s_job.go
+++ b/duplosdk/k8s_job.go
@@ -45,12 +45,15 @@ func (c *Client) K8sJobGet(tenantId, jobName string) (*DuploK8sJob, ClientError)
 		&rp)
 
 	if err != nil {
+		if err.Status() == 404 {
+			return nil, nil
+		}
 		return nil, newClientError(fmt.Sprintf("job %s not found. %s", jobName, err))
 	}
 	// Add the tenant ID, then return the result.
 	rp.TenantId = tenantId
 
-	return &rp, err
+	return &rp, nil
 }
 
 // K8sJobCreate creates a k8s job via the Duplo API.


### PR DESCRIPTION
## Overview

Fix for 404 
## Summary of changes
Set resource id empty on 404 so tf would re create resources on reapply of duplocloud_k8s_cron_job and duplocloud_k8s_job resource.

This PR does the following:

- Setting ID to null if 404
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
