### PR TITLE
DUPLO-31364 Doc:TF: The retention_backup field is mentioned as optional in the documentation, but it should be required field

### DIFF
--- a/docs/resources/azure_mssqldb_retention_backup.md
+++ b/docs/resources/azure_mssqldb_retention_backup.md
@@ -18,12 +18,12 @@ duplocloud_azure_mssqldb_retention_backup sets retention backup days to mssql db
 ### Required
 
 - `database_name` (String) The name of mssql database
+- `retention_backup` (Number) Specify retention backup number of days
 - `server_name` (String) The name of mssql server
 - `tenant_id` (String) The GUID of the tenant in which retention backup will be applied for mssql db of an mssql server
 
 ### Optional
 
-- `retention_backup` (Number) Specify retention backup number of days
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/duplocloud/resource_duplo_azure_mssqldb_retention_backup.go
+++ b/duplocloud/resource_duplo_azure_mssqldb_retention_backup.go
@@ -36,8 +36,7 @@ func mssqlDBRetentionBackup() map[string]*schema.Schema {
 		"retention_backup": {
 			Description:  "Specify retention backup number of days",
 			Type:         schema.TypeInt,
-			Optional:     true,
-			Computed:     true,
+			Required:     true,
 			ValidateFunc: validation.IntBetween(1, 35),
 		},
 	}


### PR DESCRIPTION
## Overview

Document update
## Summary of changes
Made retention_backup required field for duplocloud_azure_mssqldb_retention_backup
This PR does the following:

- .Made retention_backup required field.
- ...

## Testing performed

- [ ] Using unit tests
- [ ✔︎] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
