### PR TITLE
DUPLO-31508 fix: replace wrong ecache fullname prefix on create

### DIFF
--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -316,7 +316,7 @@ func resourceDuploEcacheInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	}
 	c := m.(*duplosdk.Client)
 
-	fullName, errname := c.GetResourceName("duploservices", tenantID, duplo.Name, false)
+	fullName, errname := c.GetResourceName("duplo", tenantID, duplo.Name, false)
 	if errname != nil {
 		return diag.Errorf("resourceDuploEcacheInstanceCreate: Unable to retrieve duplo service name (name: %s, error: %s)", duplo.Name, errname.Error())
 


### PR DESCRIPTION
## Overview

Duplo prefix for ecache instances is duplo- and not duploservices-

## Summary of changes

This PR does the following:

- fixes wrong hardcoded prefix string on ecache create validation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

No
