### PR TITLE
DUPLO-31508 fix: cherrypick to 11.9

### DIFF
--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -315,7 +315,7 @@ func resourceDuploEcacheInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	}
 	c := m.(*duplosdk.Client)
 
-	fullName, errname := c.GetResourceName("duploservices", tenantID, duplo.Name, false)
+	fullName, errname := c.GetResourceName("duplo", tenantID, duplo.Name, false)
 	if errname != nil {
 		return diag.Errorf("resourceDuploEcacheInstanceCreate: Unable to retrieve duplo service name (name: %s, error: %s)", duplo.Name, errname.Error())
 


### PR DESCRIPTION
## Overview

Ecache instances are prefixed with `duplo-` instead of `duploservices-`

## Summary of changes

This PR does the following:

- fixes wrong prefix

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

No

## Sanity checking

In UI:
Creating
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/872bddcf-9d13-45fb-8fad-5e6b9f05cc06" />

Created with proper prefix
<img width="1306" alt="image" src="https://github.com/user-attachments/assets/e1e73afe-7697-4fa0-9317-a56b3d91fb32" />

