### PR TITLE
DUPLO-31538 [TF] Infrastructure resource should wait till destroy of infra resource if wait_until_deleted is true

### DIFF
--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -303,11 +303,10 @@ func resourceInfrastructure() *schema.Resource {
 				Elem:        infrastructureVnetSecurityGroupsSchema(),
 			},
 			"wait_until_deleted": {
-				Description:      "Whether or not to wait until Duplo has destroyed the infrastructure.",
-				Type:             schema.TypeBool,
-				Optional:         true,
-				Default:          false,
-				DiffSuppressFunc: diffSuppressFuncIgnore,
+				Description: "Whether or not to wait until Duplo has destroyed the infrastructure.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
 			},
 			"cluster_ip_cidr": {
 				Description: "cluster IP CIDR defines a private IP address range used for internal Kubernetes services.",
@@ -475,8 +474,13 @@ func resourceInfrastructureDelete(ctx context.Context, d *schema.ResourceData, m
 	// Wait for 20 minutes to allow infrastructure deletion.
 	// TODO: wait for it completely deleted (add an API that will actually show the status)
 	if d.Get("wait_until_deleted").(bool) {
-		log.Printf("[TRACE] resourceInfrastructureDelete(%s): waiting for 20 minutes because 'wait_until_deleted' is 'true'", infraName)
-		time.Sleep(time.Duration(20) * time.Minute)
+		diag := waitForResourceToBeMissingAfterDelete(ctx, d, "azure key vault secret", infraName, func() (interface{}, duplosdk.ClientError) {
+			return c.InfrastructureGet(infraName)
+		})
+
+		if diag != nil {
+			return diag
+		}
 	}
 
 	log.Printf("[TRACE] resourceInfrastructureDelete(%s): end", infraName)
@@ -594,6 +598,8 @@ func infrastructureRead(c *duplosdk.Client, d *schema.ResourceData, name string)
 			return true, nil // object missing
 		}
 	}
+	wud := d.Get("wait_until_deleted").(bool)
+	d.Set("wait_until_deleted", wud)
 
 	d.Set("infra_name", infra.Name)
 	d.Set("account_id", infra.AccountId)


### PR DESCRIPTION
## Overview

Fixed bug for resource not waiting infra to be deleted if wait_until_delete is enabled
## Summary of changes
Added polling function waitForResourceToBeMissingAfterDelete inside if wait_until_delete is enabled block
This PR does the following:

- Added polling function waitForResourceToBeMissingAfterDelete inside if wait_until_delete is enabled block 
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
