### PR TITLE
DUPLO-31462 TF: duplocloud_aws_lambda_permission cannot unmarshal string into Go Struct

### DIFF
--- a/docs/resources/asg_instance_refresh.md
+++ b/docs/resources/asg_instance_refresh.md
@@ -61,7 +61,7 @@ resource "duplocloud_asg_instance_refresh" "name" {
 - `instance_warmup` (Number) Number of seconds until a newly launched instance is configured and ready to use. Default behavior is to use the Auto Scaling Group's health check grace period.
 - `max_healthy_percentage` (Number) Amount of capacity in the Auto Scaling group that can be in service and healthy, or pending, to support your workload when an instance refresh is in place, as a percentage of the desired capacity of the Auto Scaling group. Defaults to `100`.
 - `min_healthy_percentage` (Number) Amount of capacity in the Auto Scaling group that must remain healthy during an instance refresh to allow the operation to continue, as a percentage of the desired capacity of the Auto Scaling group. Defaults to `90`.
-- `refresh_identifier` (String) To identify refresh or invoke a refresh
+- `refresh_identifier` (String) To identify refresh or invoke a refresh, If not specified system will skip resource creation
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `update_launch_template_version` (String) Launch template version to update
 

--- a/duplocloud/resource_duplo_aws_lambda_permission.go
+++ b/duplocloud/resource_duplo_aws_lambda_permission.go
@@ -162,10 +162,6 @@ func resourceAwsLambdaPermissionCreate(ctx context.Context, d *schema.ResourceDa
 	return diags
 }
 
-func resourceAwsLambdaPermissionUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	return nil
-}
-
 // DELETE resource
 func resourceAwsLambdaPermissionDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 

--- a/duplocloud/resource_duplo_aws_lambda_permission.go
+++ b/duplocloud/resource_duplo_aws_lambda_permission.go
@@ -3,10 +3,11 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -32,6 +33,7 @@ func awsLambdaPermissionSchema() map[string]*schema.Schema {
 			Description: "The Event Source Token to validate.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		"function_name": {
 			Description: "Name of the Lambda function whose resource policy you are updating.",
@@ -49,16 +51,19 @@ func awsLambdaPermissionSchema() map[string]*schema.Schema {
 			Description: "Query parameter to specify function version or alias name. The permission will then apply to the specific qualified ARN.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		"source_account": {
 			Description: "This parameter is used for S3 and SES. The AWS account ID (without a hyphen) of the source owner.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		"source_arn": {
 			Description: "When the principal is an AWS service, the ARN of the specific resource within that service to grant permission to.",
 			Type:        schema.TypeString,
 			Optional:    true,
+			Computed:    true,
 		},
 		"statement_id": {
 			Description: "A unique statement identifier.",
@@ -75,7 +80,7 @@ func resourceAwsLambdaPermission() *schema.Resource {
 
 		ReadContext:   resourceAwsLambdaPermissionRead,
 		CreateContext: resourceAwsLambdaPermissionCreate,
-		UpdateContext: resourceAwsLambdaPermissionUpdate,
+		//UpdateContext: resourceAwsLambdaPermissionUpdate,
 		DeleteContext: resourceAwsLambdaPermissionDelete,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -100,13 +105,25 @@ func resourceAwsLambdaPermissionRead(ctx context.Context, d *schema.ResourceData
 
 	// Get the object from Duplo, detecting a missing object
 	c := m.(*duplosdk.Client)
-	_, clientErr := c.LambdaPermissionGet(tenantID, functionName)
+	rp, clientErr := c.LambdaPermissionGet(tenantID, functionName)
 	if clientErr != nil {
 		if clientErr.Status() == 404 {
 			d.SetId("") // object missing
 			return nil
 		}
 		return diag.Errorf("Unable to retrieve tenant %s lambda permission '%s': %s", tenantID, functionName, clientErr)
+	}
+	for _, permission := range *rp {
+		if permission.Sid == sid {
+			d.Set("tenant_id", tenantID)
+			d.Set("action", permission.Action)
+			d.Set("function_name", functionName)
+			d.Set("principal", permission.Principal.Service)
+			d.Set("qualifier", d.Get("qualifier").(string))
+			d.Set("source_account", d.Get("source_account").(string))
+			d.Set("source_arn", permission.Condition.Arn["AWS:SourceArn"])
+			d.Set("statement_id", permission.Sid)
+		}
 	}
 
 	log.Printf("[TRACE] resourceAwsLambdaPermissionRead(%s, %s): end", tenantID, functionName)

--- a/duplosdk/aws_lambda_function.go
+++ b/duplosdk/aws_lambda_function.go
@@ -141,13 +141,17 @@ type DuploLambdaConfigurationRequest struct {
 }
 
 type DuploLambdaPermissionStatement struct {
-	Sid       string                         `json:"Sid,omitempty"`
-	Effect    string                         `json:"Effect,omitempty"`
-	Principal DuploLambdaPermissionPrincipal `json:"Principal,omitempty"`
-	Action    string                         `json:"Action,omitempty"`
-	Resource  string                         `json:"Resource,omitempty"`
+	Sid       string                          `json:"Sid,omitempty"`
+	Effect    string                          `json:"Effect,omitempty"`
+	Principal DuploLambdaPermissionPrincipal  `json:"Principal,omitempty"`
+	Action    string                          `json:"Action,omitempty"`
+	Resource  string                          `json:"Resource,omitempty"`
+	Condition *DuploLambdaPermissionCondition `json:"Condition,omitempty"`
 }
 
+type DuploLambdaPermissionCondition struct {
+	Arn map[string]string `json:"ArnLike,omitempty"`
+}
 type DuploLambdaPermissionPrincipal struct {
 	Service string `json:"Service,omitempty"`
 }


### PR DESCRIPTION
## Overview

Tackle unmarshall issue
## Summary of changes
Tackling unmarshall issue for duplocloud_aws_lambda_permission resource
This PR does the following:

- Made schema field attribute changes
- Made read context fixes to set field value

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
