### PR TITLE
DUPLO-31438 TF: Importing duplocloud_tenant_network_security_rule force adds description

### DIFF
--- a/duplocloud/resource_duplo_tenant_network_security_rule.go
+++ b/duplocloud/resource_duplo_tenant_network_security_rule.go
@@ -3,11 +3,12 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -118,7 +119,7 @@ func resourceTenantNetworkSecurityRuleRead(ctx context.Context, d *schema.Resour
 	d.Set("from_port", duplo.FromPort)
 	d.Set("to_port", duplo.ToPort)
 	d.Set("protocol", duplo.Protocol)
-
+	d.Set("description", (*duplo.Sources)[0].Description)
 	if rq.Type == duplosdk.SGSourceTypeTenant {
 		d.Set("source_address", nil)
 		d.Set("source_tenant", (*duplo.Sources)[0].Value)

--- a/duplosdk/tenant.go
+++ b/duplosdk/tenant.go
@@ -430,7 +430,7 @@ func (c *Client) TenantGetExtConnSecurityGroupRule(rq *DuploTenantExtConnSecurit
 						FromPort: rq.FromPort,
 						ToPort:   rq.ToPort,
 						Sources: &[]DuploTenantExtConnSecurityGroupSource{{
-							Description: source.Description,
+							Description: (*rule.Sources)[0].Description,
 							Type:        source.Type,
 							Value:       source.Value,
 						}},


### PR DESCRIPTION
## Overview

Fix resource destruction after import
## Summary of changes
Fixed resource getting destroyed after import for duplocloud_tenant_network_security_rule resource
This PR does the following:

- Set missing description value to description field
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
