### PR TITLE
DUPLO-31520 TF: Target Group: TF throws 'Plugin Crashed' for target type 'instance'

### DIFF
--- a/duplosdk/aws_target_group_target_manager.go
+++ b/duplosdk/aws_target_group_target_manager.go
@@ -35,12 +35,17 @@ func (c *Client) DuploAwsTargetGroupTargetGet(tenantID, name string) (*DuploTarg
 	if err == nil {
 		for _, v := range rp {
 			m := v.(map[string]interface{})
-
-			obj.Targets = append(obj.Targets, DuploTargetId{
-				Id:               m["Id"].(string),
-				Port:             int(m["Port"].(float64)),
-				AvailabilityZone: m["AvailabilityZone"].(string),
-			})
+			tId := DuploTargetId{}
+			if v, ok := m["Id"]; ok {
+				tId.Id = v.(string)
+			}
+			if v, ok := m["AvailabilityZone"]; ok {
+				tId.AvailabilityZone = v.(string)
+			}
+			if v, ok := m["Port"]; ok {
+				tId.Port = int(v.(float64))
+			}
+			obj.Targets = append(obj.Targets, tId)
 		}
 	}
 


### PR DESCRIPTION
## Overview

Crash fix
## Summary of changes
Plugin crash fix for duplocloud_aws_target_group_target_register resource
This PR does the following:

- map value validation
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
