### PR TITLE
DUPLO-31358  Added retry to DeletedVaults API to avoid 400.

### DIFF
--- a/duplosdk/azure_key_vault.go
+++ b/duplosdk/azure_key_vault.go
@@ -200,10 +200,11 @@ func (c *Client) TenantGetSoftDeletedKeyVault(tenantID, vaultName string) (*Dupl
 
 func (c *Client) TenantKeyVaultListDeletedVaults(tenantID string) (*[]DuploAzureTenantKeyVault, ClientError) {
 	resp := []DuploAzureTenantKeyVault{}
-	err := c.getAPI(
+	conf := NewRetryConf()
+	err := c.getAPIWithRetry(
 		fmt.Sprintf("TenantKeyVaultListDeletedVaults(%s)", tenantID),
 		fmt.Sprintf("v3/subscriptions/%s/azure/keyvault/deleted-vaults", tenantID),
-		&resp,
+		&resp, &conf,
 	)
 	return &resp, err
 }


### PR DESCRIPTION
## Overview

... (don't forget to put your clickup ticket ID in the title) ...

## Summary of changes
Added getRetryAPI to deletedVaults api for azure to avoid 400 error. Cause not known BE fix is needed
This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
