### PR TITLE
DUPLO-31965: Add support for tenant names in uppercase and camelCase formats.

### DIFF
--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -44,7 +44,7 @@ func resourceTenant() *schema.Resource {
 					return strings.ToLower(val.(string))
 				},
 				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-					return strings.ToLower(old) == strings.ToLower(new)
+					return strings.EqualFold(old, new)
 				},
 			},
 			"plan_id": {

--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -36,10 +36,16 @@ func resourceTenant() *schema.Resource {
 		},
 		Schema: map[string]*schema.Schema{
 			"account_name": {
-				Description: "The name of the tenant. Tenant names are globally unique, and cannot be a prefix of any other tenant name.",
+				Description: "The name of the tenant. Tenant names are globally unique, and cannot be a prefix of any other tenant name. Will be converted to lowercase.",
 				Type:        schema.TypeString,
 				ForceNew:    true, // Change tenant name
 				Required:    true,
+				StateFunc: func(val interface{}) string {
+					return strings.ToLower(val.(string))
+				},
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.ToLower(old) == strings.ToLower(new)
+				},
 			},
 			"plan_id": {
 				Description:  "The name of the plan under which the tenant will be created.",
@@ -160,8 +166,11 @@ func resourceTenantRead(ctx context.Context, d *schema.ResourceData, m interface
 
 // CREATE resource
 func resourceTenantCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	// Convert account_name to lowercase
+	accountName := strings.ToLower(d.Get("account_name").(string))
+
 	rq := duplosdk.DuploTenant{
-		AccountName:          d.Get("account_name").(string),
+		AccountName:          accountName,
 		PlanID:               d.Get("plan_id").(string),
 		ExistingK8sNamespace: d.Get("existing_k8s_namespace").(string),
 	}


### PR DESCRIPTION
## Overview

- Add support for tenant names in uppercase and camelCase formats.

## Summary of changes

This PR does the following:

- Add support for tenant names in uppercase and camelCase formats.

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [x] Manually, on a remote test system

## Describe any breaking changes

- Tenant creation.
- Tenant Plan.
