### PR TITLE
DUPLO-29297 TF: duplocloud_rds_instance enable_iam_auth parameter doesn't update existing databases

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -441,7 +441,7 @@ See AWS documentation for the [available instance types](https://aws.amazon.com/
 - `db_name` (String) The name of the database to create when the DB instance is created. This is not applicable for update.
 - `db_subnet_group_name` (String) Name of DB subnet group. DB instance will be created in the VPC associated with the DB subnet group.
 - `deletion_protection` (Boolean) If the DB instance should have deletion protection enabled.The database can't be deleted when this value is set to `true`. This setting is not applicable for document db cluster instance. Defaults to `false`.
-- `enable_iam_auth` (Boolean) Whether or not to enable the RDS IAM authentication.
+- `enable_iam_auth` (Boolean) Whether or not to enable the RDS IAM authentication. It can only be set during instance creation.
 - `enable_logging` (Boolean) Whether or not to enable the RDS instance logging. This setting is not applicable for document db cluster instance.
 - `encrypt_storage` (Boolean) Whether or not to encrypt the RDS instance storage.
 - `engine_version` (String) The database engine version to use the for the RDS instance.

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -287,10 +287,11 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			Default:  false,
 		},
 		"enable_iam_auth": {
-			Description: "Whether or not to enable the RDS IAM authentication.",
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Computed:    true,
+			Description:      "Whether or not to enable the RDS IAM authentication. It can only be set during instance creation.",
+			Type:             schema.TypeBool,
+			Optional:         true,
+			Computed:         true,
+			DiffSuppressFunc: diffSuppressWhenExisting,
 		},
 		"enhanced_monitoring": {
 			Description:  "Interval to capture metrics in real time for the operating system (OS) that your Amazon RDS DB instance runs on.",


### PR DESCRIPTION
## Overview


## Summary of changes
Duplo does not suppport updation for enable_iam_auth field in duplocloud_rds_instance
This PR does the following:

- Diff suppress function added to enable_iam_auth
- Document updation

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
