### PR TITLE
DUPLO-32856 TF Provider crash with Invalid Memory Address Error

### DIFF
--- a/duplocloud/resource_duplo_aws_lambda_function.go
+++ b/duplocloud/resource_duplo_aws_lambda_function.go
@@ -3,11 +3,12 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -244,6 +245,7 @@ func awsLambdaFunctionSchema() map[string]*schema.Schema {
 			Type:        schema.TypeList,
 			MaxItems:    1,
 			Optional:    true,
+			Computed:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 	}

--- a/duplosdk/aws_lambda_function.go
+++ b/duplosdk/aws_lambda_function.go
@@ -143,7 +143,7 @@ type DuploLambdaConfigurationRequest struct {
 type DuploLambdaPermissionStatement struct {
 	Sid       string                          `json:"Sid,omitempty"`
 	Effect    string                          `json:"Effect,omitempty"`
-	Principal DuploLambdaPermissionPrincipal  `json:"Principal,omitempty"`
+	Principal *DuploLambdaPermissionPrincipal `json:"Principal,omitempty"`
 	Action    string                          `json:"Action,omitempty"`
 	Resource  string                          `json:"Resource,omitempty"`
 	Condition *DuploLambdaPermissionCondition `json:"Condition,omitempty"`


### PR DESCRIPTION
## Overview
Plugin crash fix
## Summary of changes
Fixed plugin crash on duplocloud_aws_lambda_permission resource caused due to permission removal outside TF
This PR does the following:

- Fixed plugin crash
- Handled diff at duplocloud_aws_lambda_function

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
