### PR TITLE
DUPLO-32577 Terraform - Destroy/Create of ASG doesn't create new asg

### DIFF
--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -181,7 +181,9 @@ func resourceAwsASGCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	// Build a request.
 	rq := expandAsgProfile(d)
 	log.Printf("[TRACE] resourceAwsASGCreate(%s, %s): start", rq.TenantId, rq.FriendlyName)
-
+	currentTime := time.Now()
+	formatted := currentTime.Format("02012006150405")
+	rq.FriendlyName += "-" + formatted
 	// Create the ASG Prfoile in Duplo.
 	c := m.(*duplosdk.Client)
 	rp, err := c.AsgProfileCreate(rq)
@@ -191,7 +193,6 @@ func resourceAwsASGCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	if rp == "" {
 		return diag.Errorf("Error creating ASG profile '%s': no friendly name was received", rq.FriendlyName)
 	}
-
 	id := fmt.Sprintf("%s/%s", rq.TenantId, rp)
 	log.Printf("[DEBUG] ASG Profile Resource ID- (%s)", id)
 


### PR DESCRIPTION
## Overview

Fixed issue of asg not getting created when lifecycle policy create_before_destroy is used
## Summary of changes
Updated asg name
This PR does the following:

- Adding system time to asg name before creation
- 

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
