### PR TITLE
DUPLO-33056 [TF] Add "AWS:Support EC2 Capacity provider for ECS" to Hotfix ; DUPLO-32575 Doc:TF: Add allowed capacity_provider details in document for resource 'duplocloud_ecs_service'

### DIFF
--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -182,7 +182,12 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 
 ### Optional
 
-- `agent_platform` (Number) The numeric ID of the container agent pool that this host is added to. Defaults to `0`.
+- `agent_platform` (Number) The numeric ID of the container agent pool that this host is added to.
+ - 0: Linux Docker/Native
+- 	4: None
+- 5: Docker Windows
+- 7: EKS Linux
+- 8: ECS Defaults to `0`.
 - `allocated_public_ip` (Boolean) Whether or not to allocate a public IP. Defaults to `false`.
 - `base64_user_data` (String) Base64 encoded EC2 user data to associated with the host.
 - `can_scale_from_zero` (Boolean) Whether or not ASG should leverage duplocloud's scale from 0 feature

--- a/docs/resources/aws_host.md
+++ b/docs/resources/aws_host.md
@@ -136,7 +136,12 @@ resource "duplocloud_aws_host" "host" {
 
 ### Optional
 
-- `agent_platform` (Number) The numeric ID of the container agent pool that this host is added to. Defaults to `0`.
+- `agent_platform` (Number) The numeric ID of the container agent pool that this host is added to.
+ - 0: Linux Docker/Native
+- 	4: None
+- 5: Docker Windows
+- 7: EKS Linux
+- 8: ECS Defaults to `0`.
 - `allocated_public_ip` (Boolean) Whether or not to allocate a public IP. Defaults to `false`.
 - `base64_user_data` (String) Base64 encoded EC2 user data to associated with the host.
 - `cloud` (Number) The numeric ID of the cloud provider to launch the host in. Defaults to `0`.

--- a/docs/resources/azure_cosmos_db_account.md
+++ b/docs/resources/azure_cosmos_db_account.md
@@ -84,7 +84,7 @@ resource "duplocloud_azure_cosmos_db_account" "account" {
 			> ⚠️ **Note:**: 
 			> You can only configure backup_interval, backup_retention_interval and backup_storage_redundancy when the type field is set to periodic (see [below for nested schema](#nestedblock--backup_policy))
 - `capabilities` (Block List) Name of the Cosmos DB capability (see [below for nested schema](#nestedblock--capabilities))
-- `consistency_policy` (Block List) Specify the consistency policy for the Cosmos DB account. This is only applicable for GlobalDocumentDB accounts. (see [below for nested schema](#nestedblock--consistency_policy))
+- `consistency_policy` (Block List, Max: 1) Specify the consistency policy for the Cosmos DB account. (see [below for nested schema](#nestedblock--consistency_policy))
 - `disable_key_based_metadata_write_access` (Boolean) Disable write operations on metadata resources (databases, containers, throughput) via account keys Defaults to `false`.
 - `enable_free_tier` (Boolean) Flag to indicate whether Free Tier is enabled. Defaults to `false`.
 - `public_network_access` (String) Flag to indicate whether to enable/disable public network access. Defaults to `Enabled`.

--- a/docs/resources/azure_virtual_machine.md
+++ b/docs/resources/azure_virtual_machine.md
@@ -64,7 +64,10 @@ resource "duplocloud_azure_virtual_machine" "az_vm" {
 
 - `ad_domain_type` (String) Specify domain service provided by Microsoft Azure for managing identities and access in the cloud. Valid values are `aadjoin` or `addsjoin`.
 - `admin_password` (String, Sensitive) The password associated with the local administrator account.
-- `agent_platform` (Number) The numeric ID of the container agent pool that this host is added to. Defaults to `0`.
+- `agent_platform` (Number) The numeric ID of the container agent pool that this host is added to.
+
+ - 0: Linux Docker/Native
+- 5: Docker Windows Defaults to `0`.
 - `allocated_public_ip` (Boolean) Whether or not to allocate a public IP. Defaults to `false`.
 - `availability_set_id` (String) Specify availability set id to which virtual machine should be added to
 - `base64_user_data` (String) Base64 encoded user data to associated with the host.

--- a/docs/resources/ecs_service.md
+++ b/docs/resources/ecs_service.md
@@ -26,6 +26,7 @@ resource "duplocloud_ecs_task_definition" "myservice" {
 # Deploy NGINX using ECS
 resource "duplocloud_ecs_service" "myservice" {
   tenant_id       = duplocloud_tenant.myapp.tenant_id
+  name            = "myecsservice"
   task_definition = duplocloud_ecs_task_definition.myservice.arn
   replicas        = 2
   load_balancer {
@@ -36,6 +37,20 @@ resource "duplocloud_ecs_service" "myservice" {
     enable_access_logs   = false
     drop_invalid_headers = true
     health_check_url     = "https://example.healthcheckurl.com/healthcheck"
+    target_group_count   = 1
+  }
+}
+
+# Example to create ecs service having asg as capacity_provider, for asg created with agent platform ecs
+resource "duplocloud_ecs_service" "myservice" {
+  tenant_id       = duplocloud_tenant.myapp.tenant_id
+  name            = "myservice"
+  task_definition = duplocloud_ecs_task_definition.myservice.arn
+  replicas        = 1
+  capacity_provider_strategy {
+    base              = 0
+    weight            = 1
+    capacity_provider = "<asg-fullname>"
   }
 }
 ```

--- a/docs/resources/ecs_service.md
+++ b/docs/resources/ecs_service.md
@@ -88,6 +88,11 @@ resource "duplocloud_ecs_service" "myservice" {
 Required:
 
 - `capacity_provider` (String) Name of the capacity provider.
+Valid values are:
+
+FARGATE
+FARGATE_SPOT
+ASG fullname: Used when asg created with agent platform ECS
 
 Optional:
 

--- a/docs/resources/gcp_host.md
+++ b/docs/resources/gcp_host.md
@@ -54,7 +54,10 @@ resource "duplocloud_gcp_host" "host" {
 
 - `accelerator_count` (Number) The number of the guest accelerator cards exposed to this instance. Defaults to `0`.
 - `accelerator_type` (String) The accelerator type resource to expose to this instance
-- `agent_platform` (Number) The numeric ID of the container agent pool that this host is added to. Defaults to `0`.
+- `agent_platform` (Number) The numeric ID of the container agent pool that this host is added to.
+ - 0: Linux Docker/Native
+- 	4: None
+- 5: Docker Windows Defaults to `0`.
 - `allocated_public_ip` (Boolean) Whether or not to allocate a public IP. Defaults to `false`.
 - `labels` (Map of String) A set of key/value label pairs assigned to the vm
 - `metadata` (Map of String) Configuration, metadata used when creating the host.<br>*Note: To configure OS disk size OsDiskSize can be specified as Key and its size as value, size value should be atleast 10, Similarly to added start up script one can pass the key as startup_script and startup command as its value*

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -91,7 +91,7 @@ func nativeHostSchema() map[string]*schema.Schema {
 			Default:     true,
 		},
 		"agent_platform": {
-			Description: "The numeric ID of the container agent pool that this host is added to.",
+			Description: "The numeric ID of the container agent pool that this host is added to.\n - 0: Linux Docker/Native\n- 	4: None\n- 5: Docker Windows\n- 7: EKS Linux\n- 8: ECS",
 			Type:        schema.TypeInt,
 			Optional:    true,
 			ForceNew:    true, // relaunch instance

--- a/duplocloud/resource_duplo_azure_virtual_machine.go
+++ b/duplocloud/resource_duplo_azure_virtual_machine.go
@@ -3,11 +3,12 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -89,7 +90,7 @@ func duploAzureVirtualMachineSchema() map[string]*schema.Schema {
 			ForceNew:    true,
 		},
 		"agent_platform": {
-			Description: "The numeric ID of the container agent pool that this host is added to.",
+			Description: "The numeric ID of the container agent pool that this host is added to.\n\n - 0: Linux Docker/Native\n- 5: Docker Windows",
 			Type:        schema.TypeInt,
 			Optional:    true,
 			Default:     0,

--- a/duplocloud/resource_duplo_ecs_service.go
+++ b/duplocloud/resource_duplo_ecs_service.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -273,10 +274,6 @@ func ecsServiceSchema() map[string]*schema.Schema {
 						Description: "Name of the capacity provider.",
 						Type:        schema.TypeString,
 						Required:    true,
-						ValidateFunc: validation.StringInSlice([]string{
-							"FARGATE",
-							"FARGATE_SPOT",
-						}, false),
 					},
 				},
 			},

--- a/duplocloud/resource_duplo_ecs_service.go
+++ b/duplocloud/resource_duplo_ecs_service.go
@@ -271,9 +271,12 @@ func ecsServiceSchema() map[string]*schema.Schema {
 						Computed:    true,
 					},
 					"capacity_provider": {
-						Description: "Name of the capacity provider.",
-						Type:        schema.TypeString,
-						Required:    true,
+						Description: "Name of the capacity provider.\n" +
+							"Valid values are:\n\n" +
+							"FARGATE\nFARGATE_SPOT\n" +
+							"ASG fullname: Used when asg created with agent platform ECS",
+						Type:     schema.TypeString,
+						Required: true,
 					},
 				},
 			},

--- a/duplocloud/resource_duplo_gcp_host.go
+++ b/duplocloud/resource_duplo_gcp_host.go
@@ -3,10 +3,11 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -61,7 +62,7 @@ func nativeGcpHostSchema() map[string]*schema.Schema {
 			Computed: true,
 		},
 		"agent_platform": {
-			Description: "The numeric ID of the container agent pool that this host is added to.",
+			Description: "The numeric ID of the container agent pool that this host is added to.\n - 0: Linux Docker/Native\n- 	4: None\n- 5: Docker Windows",
 			Type:        schema.TypeInt,
 			Optional:    true,
 			ForceNew:    true, // relaunch instance

--- a/examples/resources/duplocloud_ecs_service/resource.tf
+++ b/examples/resources/duplocloud_ecs_service/resource.tf
@@ -11,6 +11,7 @@ resource "duplocloud_ecs_task_definition" "myservice" {
 # Deploy NGINX using ECS
 resource "duplocloud_ecs_service" "myservice" {
   tenant_id       = duplocloud_tenant.myapp.tenant_id
+  name            = "myecsservice"
   task_definition = duplocloud_ecs_task_definition.myservice.arn
   replicas        = 2
   load_balancer {
@@ -21,5 +22,19 @@ resource "duplocloud_ecs_service" "myservice" {
     enable_access_logs   = false
     drop_invalid_headers = true
     health_check_url     = "https://example.healthcheckurl.com/healthcheck"
+    target_group_count   = 1
+  }
+}
+
+# Example to create ecs service having asg as capacity_provider, for asg created with agent platform ecs
+resource "duplocloud_ecs_service" "myservice" {
+  tenant_id       = duplocloud_tenant.myapp.tenant_id
+  name            = "myservice"
+  task_definition = duplocloud_ecs_task_definition.myservice.arn
+  replicas        = 1
+  capacity_provider_strategy {
+    base              = 0
+    weight            = 1
+    capacity_provider = "<asg-fullname>"
   }
 }


### PR DESCRIPTION
## Overview

Cherry Pick and document update
## Summary of changes

This PR does the following:

- Cherry picked DUPLO-30481
- Updated documents

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
