### PR TITLE
DUPLO-33110 Terraform fails on Cloudwatch Event Target Creation

### DIFF
--- a/duplocloud/resource_duplo_aws_cloudwatch_event_target.go
+++ b/duplocloud/resource_duplo_aws_cloudwatch_event_target.go
@@ -3,10 +3,11 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -96,7 +97,10 @@ func resourceAwsCloudWatchEventTargetRead(ctx context.Context, d *schema.Resourc
 		}
 		return diag.Errorf("Unable to retrieve tenant %s cloudwatch event target'%s': %s", tenantID, targetId, clientErr)
 	}
-
+	if duplo == nil {
+		d.SetId("")
+		return nil
+	}
 	d.Set("tenant_id", tenantID)
 	d.Set("arn", duplo.Arn)
 	d.Set("role_arn", duplo.RoleArn)
@@ -114,7 +118,7 @@ func resourceAwsCloudWatchEventTargetCreate(ctx context.Context, d *schema.Resou
 	c := m.(*duplosdk.Client)
 
 	rq := expandCloudWatchEventTarget(d)
-	_, err = c.DuploCloudWatchEventTargetsCreate(tenantID, &duplosdk.DuploCloudWatchEventTargets{
+	err = c.DuploCloudWatchEventTargetsCreate(tenantID, &duplosdk.DuploCloudWatchEventTargets{
 		Rule:         ruleName,
 		EventBusName: d.Get("event_bus_name").(string),
 		Targets:      &[]duplosdk.DuploCloudWatchEventTarget{*rq},
@@ -150,7 +154,7 @@ func resourceAwsCloudWatchEventTargetDelete(ctx context.Context, d *schema.Resou
 	log.Printf("[TRACE] resourceAwsCloudWatchEventTargetDelete(%s, %s, %s): start", tenantID, ruleName, targetId)
 
 	c := m.(*duplosdk.Client)
-	_, clientErr := c.DuploCloudWatchEventTargetsDelete(tenantID, duplosdk.DuploCloudWatchEventTargetsDeleteReq{
+	clientErr := c.DuploCloudWatchEventTargetsDelete(tenantID, duplosdk.DuploCloudWatchEventTargetsDeleteReq{
 		Rule: ruleName,
 		Ids:  []string{targetId},
 	})

--- a/duplosdk/aws_cloudwatch.go
+++ b/duplosdk/aws_cloudwatch.go
@@ -116,26 +116,24 @@ func (c *Client) DuploCloudWatchEventRuleGet(tenantID string, ruleName string) (
 	return nil, err
 }
 
-func (c *Client) DuploCloudWatchEventTargetsCreate(tenantID string, rq *DuploCloudWatchEventTargets) (*map[string]interface{}, ClientError) {
-	rp := map[string]interface{}{}
+func (c *Client) DuploCloudWatchEventTargetsCreate(tenantID string, rq *DuploCloudWatchEventTargets) ClientError {
 	err := c.postAPI(
 		fmt.Sprintf("DuploCloudWatchEventTargetCreate(%s, %s)", tenantID, rq.Rule),
 		fmt.Sprintf("v3/subscriptions/%s/aws/eventTargets", tenantID),
 		&rq,
-		&rp,
+		nil,
 	)
-	return &rp, err
+	return err
 }
 
-func (c *Client) DuploCloudWatchEventTargetsDelete(tenantID string, rq DuploCloudWatchEventTargetsDeleteReq) (*map[string]interface{}, ClientError) {
-	rp := map[string]interface{}{}
+func (c *Client) DuploCloudWatchEventTargetsDelete(tenantID string, rq DuploCloudWatchEventTargetsDeleteReq) ClientError {
 	err := c.postAPI(
 		fmt.Sprintf("DuploCloudWatchEventTargetsDelete(%s, %s)", tenantID, rq.Rule),
 		fmt.Sprintf("v3/subscriptions/%s/aws/deleteEventTargets", tenantID),
 		&rq,
-		&rp,
+		nil,
 	)
-	return &rp, err
+	return err
 }
 
 func (c *Client) DuploCloudWatchEventTargetsList(tenantID string, ruleName string) (*[]DuploCloudWatchEventTarget, ClientError) {


### PR DESCRIPTION
## Overview

Unmarshall issue fix
## Summary of changes
Removed response holding variable
This PR does the following:

- Post api and delete api not returning any response. Leading to unmarshal issue removed those variable
- Added check for empty response in read context to avoid plugin crash

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
