### PR TITLE
DUPLO-33091 DuploCloud Terraform Provider v0.11.12 Crashing During Apply

### DIFF
--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -2309,8 +2309,7 @@ func flattenCustomOriginConfig(cor *duplosdk.DuploAwsCloudfrontCustomOriginConfi
 	if cor == nil {
 		return nil
 	}
-
-	return map[string]interface{}{
+	m := map[string]interface{}{
 		"http_port":                cor.HTTPPort,
 		"https_port":               cor.HTTPSPort,
 		"origin_keepalive_timeout": cor.OriginKeepaliveTimeout,
@@ -2318,6 +2317,11 @@ func flattenCustomOriginConfig(cor *duplosdk.DuploAwsCloudfrontCustomOriginConfi
 		"origin_protocol_policy":   cor.OriginProtocolPolicy.Value,
 		"origin_ssl_protocols":     castStringSliceToInterface(cor.OriginSslProtocols.Items),
 	}
+	m["origin_ssl_protocols"] = schema.NewSet(
+		schema.HashString,
+		castStringSliceToInterface(cor.OriginSslProtocols.Items),
+	)
+	return m
 }
 func castStringSliceToInterface(in []string) []interface{} {
 	out := make([]interface{}, len(in))

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -901,6 +901,11 @@ func resourceAwsCloudfrontDistributionRead(ctx context.Context, d *schema.Resour
 		}
 		return diag.Errorf("Unable to retrieve tenant %s aws cloudfront distribution%s : %s", tenantID, cfdId, clientErr)
 	}
+	if duplo == nil {
+		log.Printf("[TRACE] resourceAwsCloudfrontDistributionRead(%s, %s): end - distribution response empty", tenantID, cfdId)
+		d.SetId("")
+		return nil
+	}
 	if len(duplo.Distribution.DistributionConfig.CorsAllowedHostNames) == 0 && d.Get("cors_allowed_host_names") != nil {
 		corsAllowedHostNames := []string{}
 


### PR DESCRIPTION
## Overview

Cloudwatch distribution plugin crash
## Summary of changes
duplocloud_aws_cloudfront_distribution resource nested set value of origin field type malformed leading to plugin crash fixed
This PR does the following:

- Fixed converstion of origin.custom_origin_config.origin_ssl_protocols converstion to list instead of set fixed
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
