### PR TITLE
DUPLO-33191 TF: Update the duplocloud_infrastructure terraform resource to output the NAT IP

### DIFF
--- a/docs/data-sources/infrastructure.md
+++ b/docs/data-sources/infrastructure.md
@@ -55,6 +55,7 @@ Will be one of:
    - `2` : Azure
 - `enable_k8_cluster` (Boolean) Whether or not a kubernetes cluster is provisioned.
 - `id` (String) The ID of this resource.
+- `nat_ips` (List of String) The NAT IPs for the subnet.
 - `private_subnets` (Set of Object) The private subnets for the VPC or VNet. (see [below for nested schema](#nestedatt--private_subnets))
 - `public_subnets` (Set of Object) The public subnets for the VPC or VNet. (see [below for nested schema](#nestedatt--public_subnets))
 - `region` (String) The cloud provider region.  The Duplo portal must have already been configured to support this region.

--- a/docs/data-sources/infrastructures.md
+++ b/docs/data-sources/infrastructures.md
@@ -36,6 +36,7 @@ Read-Only:
 - `cloud` (Number)
 - `enable_k8_cluster` (Boolean)
 - `infra_name` (String)
+- `nat_ips` (List of String)
 - `region` (String)
 - `status` (String)
 - `subnet_cidr` (Number)

--- a/docs/resources/infrastructure.md
+++ b/docs/resources/infrastructure.md
@@ -290,6 +290,7 @@ Should be one of:
 
 - `all_settings` (List of Object) A complete list of configuration settings for this infrastructure, even ones not being managed by this resource. (see [below for nested schema](#nestedatt--all_settings))
 - `id` (String) The ID of this resource.
+- `nat_ips` (List of String) The NAT IPs for the subnet.
 - `private_subnets` (Set of Object) The private subnets for the VPC or VNet. (see [below for nested schema](#nestedatt--private_subnets))
 - `public_subnets` (Set of Object) The public subnets for the VPC or VNet. (see [below for nested schema](#nestedatt--public_subnets))
 - `security_groups` (Set of Object) The security groups for the VPC or VNet. (see [below for nested schema](#nestedatt--security_groups))

--- a/duplocloud/data_source_duplo_infrastructure.go
+++ b/duplocloud/data_source_duplo_infrastructure.go
@@ -2,10 +2,11 @@ package duplocloud
 
 import (
 	"context"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"strconv"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -55,6 +56,12 @@ func infrastructureSchemaComputed(single bool) map[string]*schema.Schema {
 			Description: "The status of the infrastructure.",
 			Type:        schema.TypeString,
 			Computed:    true,
+		},
+		"nat_ips": {
+			Description: "The NAT IPs for the subnet.",
+			Type:        schema.TypeList,
+			Computed:    true,
+			Elem:        &schema.Schema{Type: schema.TypeString},
 		},
 	}
 

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -315,6 +315,12 @@ func resourceInfrastructure() *schema.Resource {
 				Optional:    true,
 				Computed:    true,
 			},
+			"nat_ips": {
+				Description: "The NAT IPs for the subnet.",
+				Type:        schema.TypeList,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -726,7 +732,19 @@ func infrastructureRead(c *duplosdk.Client, d *schema.ResourceData, name string)
 			d.Set("security_groups", securityGroups)
 		}
 	}
-
+	if config.Cloud == 3 {
+		natIPs, err := c.GetGCPInfraNATIPs(name)
+		if err != nil {
+			return false, fmt.Errorf("error retrieving GCP NAT IPs for infrastructure '%s': %s", name, err)
+		}
+		if natIPs != nil {
+			natIPsList := make([]interface{}, len(natIPs))
+			for i, ip := range natIPs {
+				natIPsList[i] = ip
+			}
+			d.Set("nat_ips", natIPsList)
+		}
+	}
 	return false, nil
 }
 

--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -506,3 +506,13 @@ func (c *Client) AzureK8sClusterCreate(infraName string, rq *AksConfig) ClientEr
 		&rq,
 		nil)
 }
+
+func (c *Client) GetGCPInfraNATIPs(infraName string) ([]string, ClientError) {
+	rp := []string{}
+	err := c.getAPI(
+		fmt.Sprintf("GetGCPInfraNATIPs(%s)", infraName),
+		fmt.Sprintf("v3/admin/infrastructure/%s/gcp/nat-ip", infraName),
+		&rp)
+
+	return rp, err
+}


### PR DESCRIPTION
## Overview

Support For NAT IPs for GCP infra
## Summary of changes
Added compute field nat_ips in duplocloud_infrastructure resource and datasource respectively
This PR does the following:

- Added compute field nat_ips in duplocloud_infrastructure resource and datasource respectively

- Document updated

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
<img width="966" height="773" alt="Screenshot 2025-07-16 at 17 09 28" src="https://github.com/user-attachments/assets/57b36a8d-41bd-4e5a-9772-e398e508e2ed" />
