### PR TITLE
DUPLO-33213 TF: duplocloud_gcp_sql_database_instance  add database_flags support

### DIFF
--- a/docs/resources/gcp_sql_database_instance.md
+++ b/docs/resources/gcp_sql_database_instance.md
@@ -56,6 +56,7 @@ resource "duplocloud_gcp_sql_database_instance" "sql" {
 
 ### Optional
 
+- `database_flag` (Block List) List of database flags to be set on the database instance. Please refer to the [Database Flags Documentation](https://cloud.google.com/sql/docs/mysql/flags) for more details on available flags. (see [below for nested schema](#nestedblock--database_flag))
 - `disk_size` (Number) The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB.
 - `labels` (Map of String) Map of string keys and values that can be used to organize and categorize this resource.
 - `need_backup` (Boolean) Flag to enable backup process on delete of database Defaults to `true`.
@@ -70,6 +71,15 @@ resource "duplocloud_gcp_sql_database_instance" "sql" {
 - `id` (String) The ID of this resource.
 - `ip_address` (List of String) List of IP addresses of the database.
 - `self_link` (String) The SelfLink of the sql database.
+
+<a id="nestedblock--database_flag"></a>
+### Nested Schema for `database_flag`
+
+Required:
+
+- `name` (String) The name of the database flag.
+- `value` (String) The value of the database flag.
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/duplocloud/resource_duplo_gcp_sql_database.go
+++ b/duplocloud/resource_duplo_gcp_sql_database.go
@@ -100,6 +100,26 @@ func gcpSqlDBInstanceSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Default:     true,
 		},
+		"database_flag": {
+			Description: "List of database flags to be set on the database instance. Please refer to the [Database Flags Documentation](https://cloud.google.com/sql/docs/mysql/flags) for more details on available flags.",
+			Type:        schema.TypeList,
+			Optional:    true,
+			Computed:    true,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"name": {
+						Description: "The name of the database flag.",
+						Type:        schema.TypeString,
+						Required:    true,
+					},
+					"value": {
+						Description: "The value of the database flag.",
+						Type:        schema.TypeString,
+						Required:    true,
+					},
+				},
+			},
+		},
 	}
 }
 
@@ -247,7 +267,7 @@ func resourceGcpSqlDBInstanceUpdate(ctx context.Context, d *schema.ResourceData,
 		d.SetId("") // object missing
 		return nil
 	}
-	if d.HasChanges("tier", "disk_size", "labels", "database_version") {
+	if d.HasChanges("tier", "disk_size", "labels", "database_version", "database_flag") {
 		requestedVersion := d.Get("database_version").(string)
 
 		// Validate the database version
@@ -324,6 +344,7 @@ func flattenGcpSqlDBInstance(d *schema.ResourceData, tenantID string, name strin
 	d.Set("connection_name", duplo.ConnectionName)
 	flattenGcpLabels(d, duplo.Labels)
 	flattenIPAddress(d, duplo.IPAddress)
+	flattenDatabasFlags(d, duplo.DatabaseFlags)
 
 }
 
@@ -340,6 +361,20 @@ func expandGcpSqlDBInstance(d *schema.ResourceData) *duplosdk.DuploGCPSqlDBInsta
 		rq.Labels = map[string]string{}
 		for key, value := range v.(map[string]interface{}) {
 			rq.Labels[key] = value.(string)
+		}
+	}
+	if v, ok := d.GetOk("database_flag"); ok && !isInterfaceNil(v) {
+		rq.DatabaseFlags = make([]duplosdk.DuploGCPSqlDBInstanceFlag, 0, len(v.([]interface{})))
+		for _, item := range v.([]interface{}) {
+			if item == nil {
+				continue
+			}
+			m := item.(map[string]interface{})
+			flag := duplosdk.DuploGCPSqlDBInstanceFlag{
+				Name:  m["name"].(string),
+				Value: m["value"].(string),
+			}
+			rq.DatabaseFlags = append(rq.DatabaseFlags, flag)
 		}
 	}
 	return rq
@@ -440,4 +475,16 @@ func gcpSqlDBInstanceWaitUntilUnavailable(ctx context.Context, c *duplosdk.Clien
 	log.Printf("[DEBUG] RdsInstanceWaitUntilUnavailable (%s)", id)
 	_, err := stateConf.WaitForStateContext(ctx)
 	return err
+}
+
+func flattenDatabasFlags(d *schema.ResourceData, flags []duplosdk.DuploGCPSqlDBInstanceFlag) {
+	i := make([]interface{}, 0, len(flags))
+	for _, flag := range flags {
+		mp := map[string]interface{}{}
+		mp["name"] = flag.Name
+		mp["value"] = flag.Value
+		i = append(i, mp)
+	}
+
+	d.Set("database_flag", i)
 }

--- a/duplosdk/gcp_sql_database.go
+++ b/duplosdk/gcp_sql_database.go
@@ -9,17 +9,23 @@ const (
 )
 
 type DuploGCPSqlDBInstance struct {
-	Name            string            `json:"Name"`
-	DatabaseVersion string            `json:"DatabaseVersion"`
-	Tier            string            `json:"Tier"`
-	DataDiskSizeGb  int               `json:"DataDiskSizeGb"`
-	Status          string            `json:"Status,omitempty"`
-	ResourceType    int               `json:"ResourceType,omitempty"`
-	Labels          map[string]string `json:"labels,omitempty"`
-	SelfLink        string            `json:"SelfLink,omitempty"`
-	RootPassword    string            `json:"RootPassword,omitempty"`
-	IPAddress       []string          `json:"IpAddress,omitempty"`
-	ConnectionName  string            `json:"ConnectionName,omitempty"`
+	Name            string                      `json:"Name"`
+	DatabaseVersion string                      `json:"DatabaseVersion"`
+	Tier            string                      `json:"Tier"`
+	DataDiskSizeGb  int                         `json:"DataDiskSizeGb"`
+	Status          string                      `json:"Status,omitempty"`
+	ResourceType    int                         `json:"ResourceType,omitempty"`
+	Labels          map[string]string           `json:"labels,omitempty"`
+	SelfLink        string                      `json:"SelfLink,omitempty"`
+	RootPassword    string                      `json:"RootPassword,omitempty"`
+	IPAddress       []string                    `json:"IpAddress,omitempty"`
+	ConnectionName  string                      `json:"ConnectionName,omitempty"`
+	DatabaseFlags   []DuploGCPSqlDBInstanceFlag `json:"DatabaseFlags,omitempty"`
+}
+
+type DuploGCPSqlDBInstanceFlag struct {
+	Name  string `json:"name"`
+	Value string `json:"value"`
 }
 
 func (c *Client) GCPSqlDBInstanceCreate(tenantID string, rq *DuploGCPSqlDBInstance) (*DuploGCPSqlDBInstance, ClientError) {


### PR DESCRIPTION
## Overview
Database flag suport for cloud sql
## Summary of changes
Added field database_flag in duplocloud_gcp_sql_database_instance resource
This PR does the following:

- Added database_flag list of object field
- Updated doc

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
