### PR TITLE
DUPLO-34448 TF:Cloudfront Functions: For publish set to false, resource throws error DUPLO-34449  TF:Cloudfront Function: Updating cloudfront name shows update in place instead of forces replacement

### DIFF
--- a/docs/resources/aws_kafka_cluster.md
+++ b/docs/resources/aws_kafka_cluster.md
@@ -70,6 +70,7 @@ Optional:
 
 - `create` (String)
 - `delete` (String)
+- `update` (String)
 
 ## Import
 

--- a/docs/resources/azure_cosmos_db_account.md
+++ b/docs/resources/azure_cosmos_db_account.md
@@ -200,6 +200,7 @@ Optional:
 
 - `create` (String)
 - `delete` (String)
+- `update` (String)
 
 
 <a id="nestedblock--virtual_network_rule"></a>

--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -201,8 +201,6 @@ Should be one of:
    - `1` : Memcache
    - `2` : Valkey
 
-   - `2` : Valkey
-
  Defaults to `0`.
 - `enable_cluster_mode` (Boolean) Flag to enable/disable redis/valkey cluster mode.
 - `encryption_at_rest` (Boolean) Enables encryption-at-rest. Defaults to `false`.

--- a/duplocloud/resource_duplo_aws_cloudfront_function.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_function.go
@@ -30,6 +30,7 @@ func resourceAwsCloudfrontFunction() *schema.Resource {
 				Description: "The name of the CloudFront function.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ForceNew:    true,
 			},
 			"code": {
 				Description: "The JavaScript code for the CloudFront function.",
@@ -108,6 +109,11 @@ func resourceCloudfrontFunctionRead(ctx context.Context, d *schema.ResourceData,
 			return nil
 		}
 		return diag.Errorf("failed to read CloudFront function: %s", err)
+	}
+	if rp == nil {
+		d.SetId("")
+		return nil
+
 	}
 	d.Set("name", name)
 	flattenCloudFrontFunction(d, rp)

--- a/duplosdk/aws_cloudfront_function.go
+++ b/duplosdk/aws_cloudfront_function.go
@@ -31,8 +31,9 @@ func (c *Client) GetCloudFrontFunction(tenantID, name string) (*DuploCloudFrontF
 	if err != nil {
 		return nil, err
 	}
+
 	err = c.getAPI(fmt.Sprintf("GetCloudFrontFunction(%s,%s)", tenantID, name),
-		fmt.Sprintf("v3/subscriptions/%s/aws/cloudfront/function/%s/code?stage=LIVE", tenantID, name),
+		fmt.Sprintf("v3/subscriptions/%s/aws/cloudfront/function/%s/code?stage=%s", tenantID, name, rp.FunctionSummary.FunctionMetadata.Stage.Value),
 		&code)
 
 	if err != nil {


### PR DESCRIPTION
## Overview
Fix for
TF:Cloudfront Functions: For publish set to false, resource throws error
TF:Cloudfront Function: Updating cloudfront name shows update in place instead of forces replacement

## Summary of changes
Bug fix 
This PR does the following:

- Made name force new
- API fix for non publish cloudfront function

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
