### PR TITLE
DUPLO-30548 resource duplocloud_ecache_instance : cannot set snapshot_retention_limit for already existing instance

### DIFF
--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -179,19 +179,21 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			ValidateFunc:     validation.IntBetween(1, 500),
 		},
 		"snapshot_arns": {
-			Description:   "Specify the ARN of a Redis/Valkey RDB snapshot file stored in Amazon S3. User should have the access to export snapshot to s3 bucket. One can find steps to provide access to export snapshot to s3 on following link https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-exporting.html",
-			Type:          schema.TypeList,
-			Optional:      true,
-			Computed:      true,
-			ConflictsWith: []string{"snapshot_name"},
-			Elem:          &schema.Schema{Type: schema.TypeString},
+			Description:      "Specify the ARN of a Redis/Valkey RDB snapshot file stored in Amazon S3. User should have the access to export snapshot to s3 bucket. One can find steps to provide access to export snapshot to s3 on following link https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-exporting.html",
+			Type:             schema.TypeList,
+			Optional:         true,
+			Computed:         true,
+			ConflictsWith:    []string{"snapshot_name"},
+			Elem:             &schema.Schema{Type: schema.TypeString},
+			DiffSuppressFunc: diffSuppressWhenNotCreating,
 		},
 		"snapshot_name": {
-			Description:   "Select the snapshot/backup you want to use for creating redis/valkey.",
-			Type:          schema.TypeString,
-			Optional:      true,
-			Computed:      true,
-			ConflictsWith: []string{"snapshot_arns"},
+			Description:      "Select the snapshot/backup you want to use for creating redis/valkey.",
+			Type:             schema.TypeString,
+			Optional:         true,
+			Computed:         true,
+			ConflictsWith:    []string{"snapshot_arns"},
+			DiffSuppressFunc: diffSuppressWhenNotCreating,
 		},
 		"snapshot_retention_limit": {
 			Description:  "Specify retention limit in days. Accepted values - 1-35.",
@@ -206,6 +208,7 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			Optional:         true,
 			Computed:         true,
 			ValidateDiagFunc: isValidSnapshotWindow(),
+			DiffSuppressFunc: diffSuppressWhenNotCreating,
 		},
 		"log_delivery_configuration": {
 			Type:     schema.TypeSet,
@@ -261,6 +264,7 @@ func resourceDuploEcacheInstance() *schema.Resource {
 		ReadContext:   resourceDuploEcacheInstanceRead,
 		CreateContext: resourceDuploEcacheInstanceCreate,
 		DeleteContext: resourceDuploEcacheInstanceDelete,
+		UpdateContext: resourceDuploEcacheInstanceUpdate,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -794,6 +798,9 @@ func validateEcacheParameters(ctx context.Context, diff *schema.ResourceDiff, m 
 	failover := diff.Get("automatic_failover_enabled").(bool)
 	if ecm && !failover {
 		return fmt.Errorf("automatic_failover_enabled should be true for cluster mode")
+	}
+	if diff.Get("snapshot_retention_limit").(int) > 0 && diff.Get("cache_type") == 1 {
+		return fmt.Errorf("cannot set snapshot_retention_limit for memcache")
 
 	}
 	return nil
@@ -952,5 +959,36 @@ func validValkeyVersionString(v interface{}, p cty.Path) diag.Diagnostics {
 		)
 	}
 
+	return diags
+}
+
+func resourceDuploEcacheInstanceUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+
+	// Parse the identifying attributes
+	id := d.Id()
+	tenantID, name, err := parseECacheInstanceIdParts(id)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+	log.Printf("[TRACE] resourceDuploEcacheInstanceUpdate(%s, %s): start", tenantID, name)
+	c := m.(*duplosdk.Client)
+	identifier := d.Get("identifier").(string)
+	if d.HasChange("snapshot_retention_limit") {
+		rq := duplosdk.DuplocloudEcacheSnapshotRetentionLimitUpdateRequest{
+			Identifier:             identifier,
+			SnapshotRetentionLimit: strconv.Itoa(d.Get("snapshot_retention_limit").(int)),
+		}
+		err = c.EcacheInstanceUpdateSnapshotRetentionLimit(tenantID, name, rq)
+		if err != nil {
+			return diag.FromErr(err)
+		}
+		err = ecacheInstanceWaitUntilAvailable(ctx, c, tenantID, name)
+		if err != nil {
+			return diag.Errorf("Error waiting for ECache instance '%s' to be available: %s", id, err)
+		}
+		time.Sleep(time.Duration(90) * time.Second)
+	}
+	diags := resourceDuploEcacheInstanceRead(ctx, d, m)
+	log.Printf("[TRACE] resourceDuploEcacheInstanceCreate(%s, %s): end", tenantID, name)
 	return diags
 }

--- a/duplosdk/ecache_instance.go
+++ b/duplosdk/ecache_instance.go
@@ -130,7 +130,18 @@ func (c *Client) EcacheInstanceDelete(tenantID, name string) ClientError {
 		nil)
 }
 
-// EcacheInstanceGet retrieves an ECache instance via the Duplo API.
+type DuplocloudEcacheSnapshotRetentionLimitUpdateRequest struct {
+	Identifier             string `json:"Identifier"`
+	SnapshotRetentionLimit string `json:"SnapshotRetentionLimit"`
+}
+
+func (c *Client) EcacheInstanceUpdateSnapshotRetentionLimit(tenantID, name string, rq DuplocloudEcacheSnapshotRetentionLimitUpdateRequest) ClientError {
+	return c.postAPI(
+		fmt.Sprintf("EcacheInstanceUpdateSnapshotRetentionLimit(%s, duplo-%s)", tenantID, name),
+		fmt.Sprintf("subscriptions/%s/ECacheInstanceUpdateRetentionLimit", tenantID),
+		&rq, nil)
+}
+
 func (c *Client) EcacheInstanceGet(tenantID, name string) (*DuploEcacheInstance, ClientError) {
 
 	// Call the API.


### PR DESCRIPTION
## Overview

Support to update snapshot retention limit
## Summary of changes
Added update context to update snapshot_retention_limit for duplocloud_ecache_instance resource
This PR does the following:

- Added update context to update snapshot_retention_limit for redis and valkey
- Added custom validation to not set snapshot_retention_limit for memcache cache type

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
