### PR TITLE
DUPLO-32904 TF: Add field app_name

### DIFF
--- a/docs/resources/azure_cosmos_db_account.md
+++ b/docs/resources/azure_cosmos_db_account.md
@@ -38,6 +38,11 @@ resource "duplocloud_azure_cosmos_db_account" "account" {
     backup_storage_redundancy = "Geo"
     type                      = "Periodic"
   }
+  geo_location {
+    location_name     = "centralus"
+    failover_priority = 0
+  }
+
   enable_free_tier = true #applicable only for provisioned type databases
 }
 
@@ -64,6 +69,11 @@ resource "duplocloud_azure_cosmos_db_account" "account" {
     backup_storage_redundancy = "Geo"
     type                      = "Periodic"
   }
+  geo_location {
+    location_name     = "centralus"
+    failover_priority = 0
+  }
+
 }
 
 

--- a/docs/resources/duplo_service.md
+++ b/docs/resources/duplo_service.md
@@ -337,6 +337,7 @@ Should be one of:
  Defaults to `0`.
 - `allocation_tags` (String)
 - `any_host_allowed` (Boolean) Whether or not the service can run on hosts in other tenants (within the the same plan as the current tenant). Defaults to `false`.
+- `app_name` (String) The name of the app where service will be a part
 - `cloud` (Number) The numeric ID of the cloud provider to launch the service in.
 Should be one of:
 

--- a/duplocloud/data_source_duplo_service.go
+++ b/duplocloud/data_source_duplo_service.go
@@ -217,7 +217,7 @@ func flattenDuploService(d *schema.ResourceData, duplo *duplosdk.DuploReplicatio
 			d.Set("init_container_docker_image", initContainerImages)
 		}
 	}
-
+	d.Set("app_name", duplo.AppName)
 }
 
 func flattenHPASpecs(field string, from interface{}, to *schema.ResourceData) {

--- a/duplocloud/resource_duplo_service.go
+++ b/duplocloud/resource_duplo_service.go
@@ -239,6 +239,12 @@ func duploServiceSchema() map[string]*schema.Schema {
 			Type:        schema.TypeString,
 			Computed:    true,
 		},
+		"app_name": {
+			Description: "The name of the app where service will be a part",
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+		},
 	}
 }
 
@@ -321,6 +327,7 @@ func resourceDuploServiceCreate(ctx context.Context, d *schema.ResourceData, m i
 		ShouldSpreadAcrossZones:           d.Get("should_spread_across_zones").(bool),
 		ForceStatefulSet:                  d.Get("force_stateful_set").(bool),
 		IsCloudCredsFromK8sServiceAccount: d.Get("cloud_creds_from_k8s_service_account").(bool),
+		AppName:                           d.Get("app_name").(string),
 	}
 	if v, ok := d.GetOk("init_container_docker_image"); ok && v != nil && len(v.([]interface{})) > 0 {
 		updatedOtherDockerConfig, err := updateInitContainerImages(d.Get("other_docker_config").(string), v.([]interface{}))
@@ -377,6 +384,7 @@ func resourceDuploServiceUpdate(ctx context.Context, d *schema.ResourceData, m i
 		ShouldSpreadAcrossZones:           d.Get("should_spread_across_zones").(bool),
 		ForceStatefulSet:                  d.Get("force_stateful_set").(bool),
 		IsCloudCredsFromK8sServiceAccount: d.Get("cloud_creds_from_k8s_service_account").(bool),
+		AppName:                           d.Get("app_name").(string),
 	}
 	if v, ok := d.GetOk("init_container_docker_image"); ok && v != nil && len(v.([]interface{})) > 0 {
 		updatedOtherDockerConfig, err := updateInitContainerImages(d.Get("other_docker_config").(string), d.Get("init_container_docker_image").([]interface{}))

--- a/duplosdk/replication_controller.go
+++ b/duplosdk/replication_controller.go
@@ -31,6 +31,7 @@ type DuploReplicationController struct {
 	Tags                              *[]DuploKeyStringValue `json:"Tags,omitempty"`
 	HPASpecs                          map[string]interface{} `json:"HPASpecs,omitempty"`
 	Index                             int                    `json:"Index"`
+	AppName                           string                 `json:"AppName,omitempty"`
 }
 
 // DuploPodTemplate represents a pod template in the Duplo SDK
@@ -160,6 +161,7 @@ type DuploReplicationControllerCreateRequest struct {
 	Commands string `json:"Commands,omitempty"`
 
 	// TODO: DeviceIds
+	AppName string `json:"AppName,omitempty"`
 }
 
 type DuploReplicationControllerUpdateRequest struct {
@@ -182,6 +184,7 @@ type DuploReplicationControllerUpdateRequest struct {
 	OtherDockerConfig                 string                 `json:"OtherDockerConfig,omitempty"`
 	OtherDockerHostConfig             string                 `json:"OtherDockerHostConfig,omitempty"`
 	HPASpecs                          map[string]interface{} `json:"HPASpecs,omitempty"`
+	AppName                           string                 `json:"AppName,omitempty"`
 }
 
 type DuploReplicationControllerDeleteRequest struct {

--- a/examples/resources/duplocloud_azure_cosmos_db_account/resource.tf
+++ b/examples/resources/duplocloud_azure_cosmos_db_account/resource.tf
@@ -23,6 +23,11 @@ resource "duplocloud_azure_cosmos_db_account" "account" {
     backup_storage_redundancy = "Geo"
     type                      = "Periodic"
   }
+  geo_location {
+    location_name     = "centralus"
+    failover_priority = 0
+  }
+
   enable_free_tier = true #applicable only for provisioned type databases
 }
 
@@ -49,6 +54,11 @@ resource "duplocloud_azure_cosmos_db_account" "account" {
     backup_storage_redundancy = "Geo"
     type                      = "Periodic"
   }
+  geo_location {
+    location_name     = "centralus"
+    failover_priority = 0
+  }
+
 }
 
 

--- a/examples/resources/duplocloud_duplo_service/resource.tf
+++ b/examples/resources/duplocloud_duplo_service/resource.tf
@@ -85,3 +85,14 @@ resource "duplocloud_duplo_service" "myservice" {
     ]
   )
 }
+
+# Simple Example 6:  App Name example
+resource "duplocloud_duplo_service" "myservice" {
+  tenant_id = duplocloud_tenant.myapp.tenant_id
+
+  name           = "myservice"
+  agent_platform = 7 # Duplo native container agent
+  docker_image   = "nginx:latest"
+  replicas       = 1
+  app_name       = "appname"
+}


### PR DESCRIPTION
## Overview

Support for app name for service resource
## Summary of changes
Added new field app_name in duplocloud_duplo_service
This PR does the following:

- duplocloud_duplo_service resource schema change added new field app_name
- .updated example and doc

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
