### PR TITLE
DUPLO-35523 DOC:Azure:MSSQL Server: For resource duplocloud_azure_mssql_server the values for administrator_type  field are not mentioned

### DIFF
--- a/docs/resources/azure_mssql_server.md
+++ b/docs/resources/azure_mssql_server.md
@@ -81,7 +81,7 @@ Required:
 Optional:
 
 - `ad_authentication_only` (Boolean) Specifies whether only AD Users and administrators can be used to login (`true`) or also local database users (`false`).
-- `administrator_type` (String) Specifies this field only if this admin is from Azure AD. Valid value ActiveDirectory
+- `administrator_type` (String) Implicitly inferred. Valid value ActiveDirectory
 - `principal_type` (String) Specify the type of the principal: `User`, `Group`, or `Application`
 
 

--- a/docs/resources/azure_mssql_server.md
+++ b/docs/resources/azure_mssql_server.md
@@ -81,7 +81,7 @@ Required:
 Optional:
 
 - `ad_authentication_only` (Boolean) Specifies whether only AD Users and administrators can be used to login (`true`) or also local database users (`false`).
-- `administrator_type` (String)
+- `administrator_type` (String) Specifies this field only if this admin is from Azure AD. Valid value ActiveDirectory
 - `principal_type` (String) Specify the type of the principal: `User`, `Group`, or `Application`
 
 

--- a/duplocloud/resource_duplo_azure_mssql_server.go
+++ b/duplocloud/resource_duplo_azure_mssql_server.go
@@ -126,6 +126,7 @@ func duploAzureMssqlServerSchema() map[string]*schema.Schema {
 						ValidateFunc: validation.StringInSlice([]string{"User", "Group", "Application"}, false),
 					},
 					"administrator_type": {
+						Description:  "Specifies this field only if this admin is from Azure AD. Valid value ActiveDirectory",
 						Type:         schema.TypeString,
 						Optional:     true,
 						ValidateFunc: validation.StringInSlice([]string{"ActiveDirectory"}, false),

--- a/duplocloud/resource_duplo_azure_mssql_server.go
+++ b/duplocloud/resource_duplo_azure_mssql_server.go
@@ -126,7 +126,7 @@ func duploAzureMssqlServerSchema() map[string]*schema.Schema {
 						ValidateFunc: validation.StringInSlice([]string{"User", "Group", "Application"}, false),
 					},
 					"administrator_type": {
-						Description:  "Specifies this field only if this admin is from Azure AD. Valid value ActiveDirectory",
+						Description:  "Implicitly inferred. Valid value ActiveDirectory",
 						Type:         schema.TypeString,
 						Optional:     true,
 						ValidateFunc: validation.StringInSlice([]string{"ActiveDirectory"}, false),


### PR DESCRIPTION
## Overview

Document update
## Summary of changes
Document update for duplocloud_azure_mssql_server resource
This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
