### PR TITLE
DUPLO-35554 Add support for multiple certificate ingresses in terraform

### DIFF
--- a/docs/resources/k8_ingress.md
+++ b/docs/resources/k8_ingress.md
@@ -102,7 +102,7 @@ resource "duplocloud_k8_ingress" "ingress" {
   lbconfig {
     is_internal     = false
     dns_prefix      = "external-echo"
-    certificate_arn = "put your certificate ARN here"
+    certificate_arn = "<cert-arn1>,<cert-arn2>,..."
     https_port      = 443
   }
 
@@ -245,7 +245,7 @@ Required:
 
 Optional:
 
-- `certificate_arn` (String) The ARN of an ACM certificate to associate with this load balancer.  Only applicable for HTTPS.
+- `certificate_arn` (String) The ARN of an ACM certificate to associate with this load balancer.  Only applicable for HTTPS. Multiple ARNs can be attached, separated by commas.
 - `http_port` (Number) HTTP Listener Port.
 - `https_port` (Number) HTTPS Listener Port.
 - `port_override` (String) Port override for the load balancer. Currently supported for Azure

--- a/duplocloud/resource_duplo_k8_ingress.go
+++ b/duplocloud/resource_duplo_k8_ingress.go
@@ -54,7 +54,7 @@ func k8sIngressSchema() map[string]*schema.Schema {
 						Required:    true,
 					},
 					"certificate_arn": {
-						Description: "The ARN of an ACM certificate to associate with this load balancer.  Only applicable for HTTPS.",
+						Description: "The ARN of an ACM certificate to associate with this load balancer.  Only applicable for HTTPS. Multiple ARNs can be attached, separated by commas.",
 						Type:        schema.TypeString,
 						Computed:    true,
 						Optional:    true,

--- a/examples/resources/duplocloud_k8_ingress/resource.tf
+++ b/examples/resources/duplocloud_k8_ingress/resource.tf
@@ -87,7 +87,7 @@ resource "duplocloud_k8_ingress" "ingress" {
   lbconfig {
     is_internal     = false
     dns_prefix      = "external-echo"
-    certificate_arn = "put your certificate ARN here"
+    certificate_arn = "<cert-arn1>,<cert-arn2>,..."
     https_port      = 443
   }
 


### PR DESCRIPTION
## Overview

Document updated
## Summary of changes
Update document and example to add multiple certificate arns to ingress loadbalancer config for duplocloud_k8s_ingress resource
This PR does the following:

- Certificate ARNs can added comma separated, no changes needed at code level 
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
