### PR TITLE
DUPLO-35554 Add support for multiple certificate ingresses in terraform

### DIFF
--- a/docs/resources/k8_ingress.md
+++ b/docs/resources/k8_ingress.md
@@ -100,10 +100,10 @@ resource "duplocloud_k8_ingress" "ingress" {
   name               = "external-echo"
   ingress_class_name = "alb"
   lbconfig {
-    is_internal     = false
-    dns_prefix      = "external-echo"
-    certificate_arn = "<cert-arn1>,<cert-arn2>,..."
-    https_port      = 443
+    is_internal      = false
+    dns_prefix       = "external-echo"
+    certificate_arns = ["<cert-arn1>", "<cert-arn2>"]
+    https_port       = 443
   }
 
   rule {
@@ -245,7 +245,8 @@ Required:
 
 Optional:
 
-- `certificate_arn` (String) The ARN of an ACM certificate to associate with this load balancer.  Only applicable for HTTPS. Multiple ARNs can be attached, separated by commas.
+- `certificate_arn` (String, Deprecated) The ARN of an ACM certificate to associate with this load balancer.  Only applicable for HTTPS. This field has been deprecated use certificate_arns
+- `certificate_arns` (List of String) The list of ARN of an ACM certificate to associate with this load balancer.  Only applicable for HTTPS.
 - `http_port` (Number) HTTP Listener Port.
 - `https_port` (Number) HTTPS Listener Port.
 - `port_override` (String) Port override for the load balancer. Currently supported for Azure

--- a/examples/resources/duplocloud_k8_ingress/resource.tf
+++ b/examples/resources/duplocloud_k8_ingress/resource.tf
@@ -85,10 +85,10 @@ resource "duplocloud_k8_ingress" "ingress" {
   name               = "external-echo"
   ingress_class_name = "alb"
   lbconfig {
-    is_internal     = false
-    dns_prefix      = "external-echo"
-    certificate_arn = "<cert-arn1>,<cert-arn2>,..."
-    https_port      = 443
+    is_internal      = false
+    dns_prefix       = "external-echo"
+    certificate_arns = ["<cert-arn1>", "<cert-arn2>"]
+    https_port       = 443
   }
 
   rule {


### PR DESCRIPTION
## Overview

Added new field
## Summary of changes
Added new field arn_certificates to duplo_k8s_ingress resource
This PR does the following:

- Added new field arn_certificates deprecated arn_certificate field
- Document update

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
