### PR TITLE
DUPLO-35553 TF: duplocloud_k8_secret throws error if state exists but not resource

### DIFF
--- a/duplocloud/resource_duplo_k8_secret.go
+++ b/duplocloud/resource_duplo_k8_secret.go
@@ -104,12 +104,10 @@ func resourceK8SecretRead(ctx context.Context, d *schema.ResourceData, m interfa
 
 	// Get the object from Duplo, detecting a missing object
 	c := m.(*duplosdk.Client)
-	rp, err := c.K8SecretGet(tenantId, name)
-	if err != nil {
-		return diag.FromErr(err)
-	}
-	if rp == nil || rp.SecretName == "" {
+	rp, cerr := c.K8SecretGet(tenantId, name)
+	if cerr != nil {
 		d.SetId("")
+		log.Printf("%s", cerr.Error())
 		return nil
 	}
 

--- a/duplosdk/k8_secret.go
+++ b/duplosdk/k8_secret.go
@@ -43,7 +43,7 @@ func (c *Client) K8SecretGet(tenantID, secretName string) (*DuploK8sSecret, Clie
 		return nil, newClientError(fmt.Sprintf("failed to get secret list: %s", err))
 	}
 
-	if list == nil {
+	if list == nil || len(*list) == 0 {
 		return nil, newClientError("secret list is nil")
 	}
 


### PR DESCRIPTION
## Overview

Allowing recreation of resource if its deleted outside tf
## Summary of changes
Allowing recreation of resource if its deleted outside tf for duplocloud_k8s_secret resource
This PR does the following:

- Error handling and id reset
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
