### PR TITLE
TF handle 404 error and set resource id to empty to avoid terraform termination

### DIFF
--- a/duplocloud/provider_test.go
+++ b/duplocloud/provider_test.go
@@ -2,10 +2,11 @@ package duplocloud
 
 import (
 	"context"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
-	"github.com/duplocloud/terraform-provider-duplocloud/internal/duplosdktest"
 	"log"
 	"strings"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
+	"github.com/duplocloud/terraform-provider-duplocloud/internal/duplosdktest"
 
 	"github.com/barkimedes/go-deepcopy"
 	"github.com/google/uuid"
@@ -85,7 +86,7 @@ func testAccProvider_ConfigureContextFunc(d *schema.Provider) schema.ConfigureCo
 					return
 				},
 			},
-			"/adminproxy/GetInfrastructureConfig/:infraName": {
+			"/v3/admin/infrastructure/:infraName": {
 				Factory: func() interface{} { return &duplosdk.DuploInfrastructureConfig{} },
 				Responder: func(verb string, in interface{}) (id string, out interface{}) {
 					out = deepcopy.MustAnything(in.(*duplosdk.DuploInfrastructureConfig))

--- a/duplocloud/resource_duplo_plan_settings.go
+++ b/duplocloud/resource_duplo_plan_settings.go
@@ -2,9 +2,10 @@ package duplocloud
 
 import (
 	"context"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -103,15 +104,24 @@ func resourcePlanSettingsRead(ctx context.Context, d *schema.ResourceData, m int
 
 	// Get "special" plan settings.
 	settings, err := c.PlanGetSettings(planID)
-	if err != nil {
+	if err != nil && err.Status() != 404 {
 		return diag.Errorf("failed to retrieve plan settings for '%s': %s", planID, err)
 	}
-
+	if (err != nil && err.Status() == 404) || settings == nil {
+		d.SetId("")
+		log.Printf("plan settings not found for plan %s", planID)
+	}
 	// Get plan DNS config.  If the config is "global", that means there is no plan DNS config.
 	dns, err := c.PlanGetDnsConfig(planID)
-	if err != nil {
+	if err != nil && err.Status() != 404 {
 		return diag.Errorf("failed to retrieve plan DNS config for '%s': %s", planID, err)
 	}
+
+	if (err != nil && err.Status() == 404) || settings == nil {
+		d.SetId("")
+		log.Printf("plan settings DNS config not found for plan %s", planID)
+	}
+
 	if dns != nil && dns.IsGlobalDNS {
 		dns = nil
 	}
@@ -198,7 +208,8 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 	}
 
 	// Skip if plan does not exist.
-	if settings == nil {
+	if (err != nil && err.Status() == 404) || settings == nil {
+		log.Printf("plan settings not found for plan %s", planID)
 		return nil
 	}
 

--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -132,6 +132,7 @@ func resourceTenantRead(ctx context.Context, d *schema.ResourceData, m interface
 	duplo, err := c.TenantGetV2(tenantID)
 	if err != nil {
 		if err.Status() == 404 {
+			log.Printf("Tenant %s not found", tenantID)
 			d.SetId("")
 			return nil
 		}
@@ -255,6 +256,7 @@ func resourceTenantDelete(ctx context.Context, d *schema.ResourceData, m interfa
 		duplo, err := c.TenantGetV2(tenantID)
 		if err != nil {
 			if err.Status() == 404 {
+				log.Printf("Tenant %s not found", tenantID)
 				return nil
 			}
 			return diag.Errorf("Unable to retrieve tenant '%s': %s", tenantID, err)
@@ -265,6 +267,7 @@ func resourceTenantDelete(ctx context.Context, d *schema.ResourceData, m interfa
 		err = c.TenantDelete(tenantID)
 		if err != nil {
 			if err.Status() == 404 {
+				log.Printf("Tenant %s not found", tenantID)
 				return nil
 			}
 			return diag.Errorf("Error deleting tenant '%s': %s", tenantID, err)

--- a/duplocloud/resource_duplo_tenant_config.go
+++ b/duplocloud/resource_duplo_tenant_config.go
@@ -81,12 +81,14 @@ func resourceTenantConfigRead(ctx context.Context, d *schema.ResourceData, m int
 	tenant, err := c.TenantGetV2(tenantID)
 	if err != nil {
 		if err.Status() == 404 {
+			log.Printf("Tenant config for tenant %s not found", tenantID)
 			d.SetId("")
 			return nil
 		}
 		return diag.Errorf("Unable to retrieve tenant '%s': %s", tenantID, err)
 	}
 	if tenant == nil {
+		log.Printf("Tenant config for tenant %s not found", tenantID)
 		d.SetId("") // object missing
 		return nil
 	}
@@ -176,6 +178,7 @@ func resourceTenantConfigDelete(ctx context.Context, d *schema.ResourceData, m i
 
 	if cerr != nil {
 		if cerr.Status() == 404 {
+			log.Printf("Tenant config for tenant %s not found", tenantID)
 			d.SetId("")
 			return nil
 		}

--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -261,7 +261,7 @@ func (c *Client) InfrastructureGet(name string) (*DuploInfrastructureConfig, Cli
 // InfrastructureGetConfig retrieves extended infrastructure configuration by name via the Duplo API.
 func (c *Client) InfrastructureGetConfig(name string) (*DuploInfrastructureConfig, ClientError) {
 	rp := DuploInfrastructureConfig{}
-	err := c.getAPI(fmt.Sprintf("InfrastructureGetConfig(%s)", name), fmt.Sprintf("adminproxy/GetInfrastructureConfig/%s", name), &rp)
+	err := c.getAPI(fmt.Sprintf("InfrastructureGetConfig(%s)", name), fmt.Sprintf("v3/admin/infrastructure/%s", name), &rp)
 	if err != nil || rp.Name == "" {
 		return nil, err
 	}

--- a/internal/duplosdktest/emulator.go
+++ b/internal/duplosdktest/emulator.go
@@ -134,7 +134,7 @@ func NewEmulator(config EmuConfig) *httptest.Server {
 	router.NotFound = http.HandlerFunc(emuNotFound)
 
 	// infra API
-	router.GET("/adminproxy/GetInfrastructureConfig/:infraName", emuGet("infra", "infraName"))
+	router.GET("/v3/admin/infrastructure/:infraName", emuGet("infra", "infraName"))
 
 	// tenant APIs
 	router.GET("/admin/GetTenantsForUser", emuList("tenant"))


### PR DESCRIPTION
## Overview

Added 404 handling
## Summary of changes
Exception handling of 404 to reset id
Change of API for infrastructure get api
This PR does the following:

- Changed infrastructure get api to v3
- .404 error handling for read and delete context for 
duplocloud_plan_settings 
duplocloud_infrastructure
duplocloud_tenant
duplocloud_tenant_config
duplocloud_gcp_node_pool resources

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
