### PR TITLE
DUPLO-35618 duplocloud_ecache_instance throws error exceeds allowable ecache name length 40

### DIFF
--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -316,11 +316,7 @@ func resourceDuploEcacheInstanceCreate(ctx context.Context, d *schema.ResourceDa
 	}
 	c := m.(*duplosdk.Client)
 
-	fullName, errname := c.GetResourceName("duplo", tenantID, duplo.Name, false)
-	if errname != nil {
-		return diag.Errorf("resourceDuploEcacheInstanceCreate: Unable to retrieve duplo service name (name: %s, error: %s)", duplo.Name, errname.Error())
-
-	}
+	fullName := "duplo-" + duplo.Name
 	if !validateStringLength(fullName, TOTALECACHENAMELENGTH) {
 		return diag.Errorf("resourceDuploEcacheInstanceCreate: fullname %s exceeds allowable ecache name length %d)", fullName, TOTALECACHENAMELENGTH)
 


### PR DESCRIPTION
## Overview

Fixed name length validation bug
## Summary of changes
Removed GetResourceName function . This was just a logical validation that does not effect with which name resource is created.
Name is always getting created without tenant name. Wont effect any previously created ecache
This PR does the following:

- Added logic to create fullName as "duplo-"+name to validate length
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
