### PR TITLE
DUPLO-35661 TF Doc: ECS: The duplocloud_ecs_task_definition resource doc should mention the requires_compatibilities values

### DIFF
--- a/docs/data-sources/ecs_task_definition.md
+++ b/docs/data-sources/ecs_task_definition.md
@@ -38,7 +38,7 @@ description: |-
 - `prevent_tf_destroy` (Boolean) Prevent this resource to be deleted from terraform destroy. Default value is `true`.
 - `proxy_configuration` (List of Object) (see [below for nested schema](#nestedatt--proxy_configuration))
 - `requires_attributes` (Set of Object) (see [below for nested schema](#nestedatt--requires_attributes))
-- `requires_compatibilities` (Set of String) Requires compatibilities for running jobs.
+- `requires_compatibilities` (Set of String) Requires compatibilities for running jobs. Such as EC2, FARGATE, EXTERNAL. It varies based on network mode and how AWS maps it. `FARGATE` should be used if network mode is set to `awsvpc`.
 - `revision` (Number) The current revision of the task definition.
 - `runtime_platform` (List of Object) Configuration block for runtime_platform that containers in your task may use. Required on ecs tasks that are hosted on Fargate. (see [below for nested schema](#nestedatt--runtime_platform))
 - `status` (String) The status of the task definition.

--- a/docs/resources/ecs_task_definition.md
+++ b/docs/resources/ecs_task_definition.md
@@ -141,7 +141,7 @@ resource "duplocloud_ecs_task_definition" "myservice" {
 - `prevent_tf_destroy` (Boolean) Prevent this resource to be deleted from terraform destroy. Default value is `true`. Defaults to `true`.
 - `proxy_configuration` (Block List, Max: 1) (see [below for nested schema](#nestedblock--proxy_configuration))
 - `requires_attributes` (Block Set) (see [below for nested schema](#nestedblock--requires_attributes))
-- `requires_compatibilities` (Set of String) Requires compatibilities for running jobs.
+- `requires_compatibilities` (Set of String) Requires compatibilities for running jobs. Such as EC2, FARGATE, EXTERNAL. It varies based on network mode and how AWS maps it. `FARGATE` should be used if network mode is set to `awsvpc`.
 - `runtime_platform` (Block List, Max: 1) Configuration block for runtime_platform that containers in your task may use. Required on ecs tasks that are hosted on Fargate. (see [below for nested schema](#nestedblock--runtime_platform))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `volumes` (String) A JSON-encoded string containing a list of volumes that are used by the ECS task definition. Defaults to `[]`.

--- a/duplocloud/resource_duplo_ecs_task_definition.go
+++ b/duplocloud/resource_duplo_ecs_task_definition.go
@@ -166,7 +166,7 @@ func ecsTaskDefinitionSchema() map[string]*schema.Schema {
 		},
 		"requires_compatibilities": {
 			Type:             schema.TypeSet,
-			Description:      "Requires compatibilities for running jobs.",
+			Description:      "Requires compatibilities for running jobs. Such as EC2, FARGATE, EXTERNAL. It varies based on network mode and how AWS maps it. `FARGATE` should be used if network mode is set to `awsvpc`.",
 			Optional:         true,
 			Computed:         true,
 			DiffSuppressFunc: diffSuppressWhenNotCreating,


### PR DESCRIPTION
## Overview

Document Update for duplocloud_ecs_task_definition
## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
