### PR TITLE
DUPLO-35754

### DIFF
--- a/docs/resources/azure_k8s_cluster.md
+++ b/docs/resources/azure_k8s_cluster.md
@@ -78,7 +78,6 @@ resource "duplocloud_azure_k8s_cluster" "ac" {
 - `pricing_tier` (String) Pricing tier for the AKS cluster. Valid values are: `Free`, `Standard`, and `Premium`. This determines the level of support and features available for the AKS cluster.
 - `private_cluster_enabled` (Boolean) Should this Kubernetes Cluster have its API server only exposed on internal IP addresses? This provides a Private IP Address for the Kubernetes API on the Virtual Network where the Kubernetes Cluster is located. Defaults to `false`.
 - `resource_group_name` (String) The name of the aks resource group.
-- `system_agent_pool_taints` (List of String) Taints to be applied to the system agent pool.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `vm_size` (String) The size of the Virtual Machine.
 

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -435,6 +435,7 @@ See AWS documentation for the [available instance types](https://aws.amazon.com/
 
 - `allocated_storage` (Number) (Required unless a `snapshot_id` is provided) The allocated storage in gigabytes.
 - `auto_minor_version_upgrade` (Boolean) Enable or disable auto minor version upgrade
+- `auto_scaling` (Boolean) Enable or disable storage auto scaling for the RDS instance. Defaults to `false`.
 - `availability_zone` (String) Specify a valid Availability Zone for the RDS primary instance (when Multi-AZ is disabled) or for the Aurora writer instance. e.g. us-west-2a
 - `backup_retention_period` (Number) Specifies backup retention period between 1 and 35 day(s). Default backup retention period is 1 day. Defaults to `1`.
 - `cluster_parameter_group_name` (String) Parameter group associated with this instance's DB Cluster.

--- a/duplocloud/resource_duplo_azure_k8s_cluster.go
+++ b/duplocloud/resource_duplo_azure_k8s_cluster.go
@@ -128,14 +128,15 @@ func duploAzureK8sClusterSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 		},
+		/*Future enhancement
 		"system_agent_pool_taints": {
-			Description:      "Taints to be applied to the system agent pool.",
-			Type:             schema.TypeList,
-			Optional:         true,
-			Computed:         true,
-			DiffSuppressFunc: diffSuppressWhenNotCreating,
-			Elem:             &schema.Schema{Type: schema.TypeString},
-		},
+				Description:      "Taints to be applied to the system agent pool.",
+				Type:             schema.TypeList,
+				Optional:         true,
+				Computed:         true,
+				DiffSuppressFunc: diffSuppressWhenNotCreating,
+				Elem:             &schema.Schema{Type: schema.TypeString},
+			},*/
 		"active_directory_config": {
 			Description: "Azure Active Directory configuration for the AKS cluster.",
 			Type:        schema.TypeList,
@@ -283,11 +284,11 @@ func expandAzureK8sCluster(d *schema.ResourceData) *duplosdk.DuploAksConfig {
 		LinuxAdminUsername:                d.Get("linux_admin_username").(string),
 		LinuxSshPublicKey:                 d.Get("linux_ssh_public_key").(string),
 	}
-	if v, ok := d.GetOk("system_agent_pool_taints"); ok && len(v.([]interface{})) > 0 {
+	/*	if v, ok := d.GetOk("system_agent_pool_taints"); ok && len(v.([]interface{})) > 0 {
 		for _, taint := range v.([]interface{}) {
 			body.SystemAgentPoolTaints = append(body.SystemAgentPoolTaints, taint.(string))
 		}
-	}
+	}*/
 
 	if body.Name == "" {
 		body.Name = d.Get("infra_name").(string)
@@ -324,16 +325,16 @@ func flattenAzureK8sCluster(d *schema.ResourceData, duplo *duplosdk.DuploAksConf
 	d.Set("pricing_tier", duplo.PricingTier)
 	d.Set("linux_admin_username", duplo.LinuxAdminUsername)
 	d.Set("linux_ssh_public_key", duplo.LinuxSshPublicKey)
-
-	if len(duplo.SystemAgentPoolTaints) > 0 {
-		s := []interface{}{}
-		for _, taint := range duplo.SystemAgentPoolTaints {
-			s = append(s, taint)
-		}
-		d.Set("system_agent_pool_taints", s)
-	} else {
-		d.Set("system_agent_pool_taints", make([]interface{}, 0))
-	}
+	/*
+		if len(duplo.SystemAgentPoolTaints) > 0 {
+			s := []interface{}{}
+			for _, taint := range duplo.SystemAgentPoolTaints {
+				s = append(s, taint)
+			}
+			d.Set("system_agent_pool_taints", s)
+		} else {
+			d.Set("system_agent_pool_taints", make([]interface{}, 0))
+		}*/
 	if duplo.AadConfig != nil {
 		m := map[string]interface{}{
 			"ad_tenant_id":           duplo.AadConfig.ADTenantId,

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -349,6 +349,12 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			Optional:    true,
 			Computed:    true,
 		},
+		"auto_scaling": {
+			Description: "Enable or disable storage auto scaling for the RDS instance.",
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+		},
 	}
 }
 
@@ -920,7 +926,7 @@ func rdsInstanceFromState(d *schema.ResourceData) (*duplosdk.DuploRdsInstance, e
 		return nil, errors.New("v2_scaling_configuration: min_capacity and max_capacity must be provided")
 	}
 	if duploObject.MultiAZ && duploObject.AvailabilityZone != "" {
-		return nil, errors.New("multi_az and availability_zone can not be set together.")
+		return nil, errors.New("multi_az and availability_zone can not be set together")
 	}
 	duploObject.DatabaseName = d.Get("db_name").(string)
 	pI := expandPerformanceInsight(d)
@@ -933,7 +939,7 @@ func rdsInstanceFromState(d *schema.ResourceData) (*duplosdk.DuploRdsInstance, e
 		duploObject.PerformanceInsightsKMSKeyId = kmsid
 
 	}
-
+	duploObject.IsAutoScalingEnabled = d.Get("auto_scaling").(bool)
 	return duploObject, nil
 }
 
@@ -1019,6 +1025,7 @@ func rdsInstanceToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Resour
 	jo["enhanced_monitoring"] = duploObject.MonitoringInterval
 	jo["db_name"] = duploObject.DatabaseName
 	jo["auto_minor_version_upgrade"] = duploObject.AutoMinorVersionUpgrade
+	jo["auto_scaling"] = duploObject.IsAutoScalingEnabled
 	pis := []interface{}{}
 	pi := make(map[string]interface{})
 	pi["enabled"] = duploObject.EnablePerformanceInsights

--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -142,25 +142,25 @@ type DuploInfrastructureConfig struct {
 }
 
 type DuploAksConfig struct {
-	Name                              string             `json:"Name"`
-	CreateAndManage                   bool               `json:"CreateAndManage"`
-	PrivateCluster                    bool               `json:"PrivateCluster"`
-	K8sVersion                        string             `json:"K8sVersion,omitempty"`
-	VmSize                            string             `json:"VmSize,omitempty"`
-	NetworkPlugin                     string             `json:"NetworkPlugin,omitempty"`
-	OutboundType                      string             `json:"OutboundType,omitempty"`
-	NodeResourceGroup                 string             `json:"NodeResourceGroup"`
-	EnableWorkloadIdentity            bool               `json:"EnableWorkloadIdentity"`
-	EnableBlobCsiDriver               bool               `json:"EnableBlobCsiDriver"`
-	DisableRunCommand                 bool               `json:"DisableRunCommand"`
-	AddCriticalTaintToSystemAgentPool bool               `json:"AddCriticalTaintToSystemAgentPool"`
-	EnableImageCleaner                bool               `json:"EnableImageCleaner"`
-	ImageCleanerIntervalInDays        int                `json:"ImageCleanerIntervalInDays"`
-	PricingTier                       string             `json:"PricingTier"`
-	LinuxAdminUsername                string             `json:"LinuxAdminUsername"`
-	LinuxSshPublicKey                 string             `json:"LinuxSshPublicKey"`
-	SystemAgentPoolTaints             []string           `json:"SystemAgentPoolTaints"`
-	AadConfig                         *DuploAksAadConfig `json:"AadConfig,omitempty"`
+	Name                              string `json:"Name"`
+	CreateAndManage                   bool   `json:"CreateAndManage"`
+	PrivateCluster                    bool   `json:"PrivateCluster"`
+	K8sVersion                        string `json:"K8sVersion,omitempty"`
+	VmSize                            string `json:"VmSize,omitempty"`
+	NetworkPlugin                     string `json:"NetworkPlugin,omitempty"`
+	OutboundType                      string `json:"OutboundType,omitempty"`
+	NodeResourceGroup                 string `json:"NodeResourceGroup"`
+	EnableWorkloadIdentity            bool   `json:"EnableWorkloadIdentity"`
+	EnableBlobCsiDriver               bool   `json:"EnableBlobCsiDriver"`
+	DisableRunCommand                 bool   `json:"DisableRunCommand"`
+	AddCriticalTaintToSystemAgentPool bool   `json:"AddCriticalTaintToSystemAgentPool"`
+	EnableImageCleaner                bool   `json:"EnableImageCleaner"`
+	ImageCleanerIntervalInDays        int    `json:"ImageCleanerIntervalInDays"`
+	PricingTier                       string `json:"PricingTier"`
+	LinuxAdminUsername                string `json:"LinuxAdminUsername"`
+	LinuxSshPublicKey                 string `json:"LinuxSshPublicKey"`
+	//SystemAgentPoolTaints             []string           `json:"SystemAgentPoolTaints"`
+	AadConfig *DuploAksAadConfig `json:"AadConfig,omitempty"`
 }
 
 type DuploAksAadConfig struct {

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -76,6 +76,7 @@ type DuploRdsInstance struct {
 	PerformanceInsightsKMSKeyId        string                  `json:"PerformanceInsightsKMSKeyId,omitempty"`
 	AutoMinorVersionUpgrade            bool                    `json:"AutoMinorVersionUpgrade"`
 	DeletionProtection                 bool                    `json:"DeletionProtection"`
+	IsAutoScalingEnabled               bool                    `json:"IsAutoScalingEnabled"`
 }
 
 type V2ScalingConfiguration struct {


### PR DESCRIPTION
## Overview

Field removed marked for future enhancement

## Summary of changes

Removed SystemAgentPoolTaints field from duplocloud_azure_k8s_cluster resource

This PR does the following:

- Removed schema field system_agent_pool_taints
- ...

## Testing performed

- [ ] Using unit tests
- [✔︎ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
