### PR TITLE
DUPLO-36797 [TF] : After doing terraform import cluster_ip_cidr and some settings went missing from terraform state

### DIFF
--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -617,7 +617,9 @@ func infrastructureRead(c *duplosdk.Client, d *schema.ResourceData, name string)
 	d.Set("status", infra.ProvisioningStatus)
 
 	d.Set("all_settings", keyValueToState("all_settings", config.CustomData))
-
+	if config.ClusterIpv4Cidr != "" {
+		d.Set("cluster_ip_cidr", config.ClusterIpv4Cidr)
+	}
 	// Build a list of current state, to replace the user-supplied settings.
 	if v, ok := getAsStringArray(d, "specified_settings"); ok && v != nil {
 		d.Set("setting", keyValueToState("setting", selectKeyValues(config.CustomData, *v)))


### PR DESCRIPTION
## Overview
Fixed cluster_ip_cidr not getting set for duplocloud_infrastructure resource

## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
