### PR TITLE
Duplo 36837: duplocloud_aws_sqs_queue not updating delay_seconds to zero.

### DIFF
--- a/duplosdk/aws_sqs.go
+++ b/duplosdk/aws_sqs.go
@@ -17,7 +17,7 @@ type DuploSQSQueue struct {
 	DeduplicationScope                           int    `json:"DeduplicationScope"`
 	FifoThroughputLimit                          int    `json:"FifoThroughputLimit"`
 	ResourceType                                 int    `json:"ResourceType,omitempty"`
-	DelaySeconds                                 int    `json:"DelaySeconds,omitempty" validate:"required,gte=0,lte=900"`
+	DelaySeconds                                 int    `json:"DelaySeconds" validate:"required,gte=0,lte=900"`
 	DeadLetterTargetQueueName                    string `json:"DeadLetterTargetQueueName,omitempty"`
 	MaxMessageTimesReceivedBeforeDeadLetterQueue int    `json:"MaxMessageTimesReceivedBeforeDeadLetterQueue,omitempty"`
 }


### PR DESCRIPTION
## Overview

Duplo 36837: duplocloud_aws_sqs_queue not updating delay_seconds to zero.

## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
