### PR TITLE
DUPLO-36803

### DIFF
--- a/duplocloud/resource_duplo_ecs_task_definition.go
+++ b/duplocloud/resource_duplo_ecs_task_definition.go
@@ -18,6 +18,10 @@ import (
 	"github.com/ucarion/jcs"
 )
 
+type flowContextKeyType string
+
+const flowContextKey flowContextKeyType = "flow"
+
 // ecsTaskDefinitionSchema returns a Terraform resource schema for an ECS Task Definition
 func ecsTaskDefinitionSchema() map[string]*schema.Schema {
 	return map[string]*schema.Schema{

--- a/duplocloud/resource_duplo_ecs_task_definition.go
+++ b/duplocloud/resource_duplo_ecs_task_definition.go
@@ -309,6 +309,13 @@ func resourceDuploEcsTaskDefinitionRead(ctx context.Context, d *schema.ResourceD
 	}
 	// Convert the object into Terraform resource data
 	flattenEcsTaskDefinition(rp, d)
+	// this is to check if the flow happened after create context
+	if v := ctx.Value(flowContextKey); v != nil && v.(string) == "normal" {
+		d.Set("prevent_tf_destroy", d.Get("prevent_tf_destroy").(bool))
+	} else { //on import provider doesnot set default value.
+		d.Set("prevent_tf_destroy", true)
+	}
+
 	log.Printf("[TRACE] resourceDuploEcsTaskDefinitionRead(%s, %s): end", tenantID, arn)
 	return nil
 }

--- a/duplocloud/resource_duplo_ecs_task_definition.go
+++ b/duplocloud/resource_duplo_ecs_task_definition.go
@@ -341,6 +341,8 @@ func resourceDuploEcsTaskDefinitionCreate(ctx context.Context, d *schema.Resourc
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	ctx = context.WithValue(ctx, flowContextKey, "normal")
+
 	d.SetId(fmt.Sprintf("subscriptions/%s/EcsTaskDefinition/%s", tenantID, arn))
 
 	diags := resourceDuploEcsTaskDefinitionRead(ctx, d, m)


### PR DESCRIPTION
## Overview

Import doesnt set default value for native TF field
## Summary of changes
fix for default value not getting set for tf_prevent_delete when resource duplocloud_ecs_task_definition is imported
This PR does the following:

- Added context value to know if workflow is normal or import 
- Based on context value set the field

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
