### PR TITLE
DUPLO-35622

### DIFF
--- a/docs/resources/ecache_associate_global_secondary_cluster.md
+++ b/docs/resources/ecache_associate_global_secondary_cluster.md
@@ -46,7 +46,6 @@ resource "duplocloud_ecache_associate_global_secondary_cluster" "rg" {
   global_datastore_id    = duplocloud_ecache_global_datastore.gds.fullname
   description            = "secondary cluster"
   secondary_cluster_name = "red11sc"
-  port                   = 7688
 }
 ```
 
@@ -56,7 +55,6 @@ resource "duplocloud_ecache_associate_global_secondary_cluster" "rg" {
 ### Required
 
 - `global_datastore_id` (String) Specify the global datastore name with which the secondary regional cluster should be associated.
-- `port` (Number) Specify port for secondary cluster
 - `secondary_cluster_name` (String) The name of the elasticache instance that need to be created as secondary regional cluster.
 - `secondary_tenant_id` (String) The tenant_id where secondary cluster need to be created. **NOTE** The tenant_id must belong to a region different from that of the primary cluster.
 - `tenant_id` (String) The GUID of the tenant that the elasticache instance datastore has been created in.

--- a/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
+++ b/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
@@ -44,12 +44,6 @@ func ecacheReplicationGroupSchema() map[string]*schema.Schema {
 			ForceNew:     true,
 			ValidateFunc: validation.IsUUID,
 		},
-		"port": {
-			Description: "Specify port for secondary cluster",
-			Type:        schema.TypeInt,
-			Required:    true,
-			ForceNew:    true,
-		},
 		"secondary_cluster_name": {
 			Description: "The name of the elasticache instance that need to be created as secondary regional cluster.",
 			Type:        schema.TypeString,
@@ -83,7 +77,7 @@ func resourceDuploEcacheReplicationGroup() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(29 * time.Minute),
+			Create: schema.DefaultTimeout(40 * time.Minute),
 			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
 		Schema: ecacheReplicationGroupSchema(),
@@ -98,7 +92,6 @@ func resourceDuploEcacheReplicationGroupCreate(ctx context.Context, d *schema.Re
 		Description:              d.Get("description").(string),
 		SecondaryTenantId:        d.Get("secondary_tenant_id").(string),
 		GlobalReplicationGroupId: d.Get("global_datastore_id").(string),
-		Port:                     d.Get("port").(int),
 		ReplicationGroupId:       d.Get("secondary_cluster_name").(string),
 	}
 	log.Printf("[TRACE] resourceDuploEcacheReplicationGroupCreate(%s): start", tenantID)
@@ -109,7 +102,7 @@ func resourceDuploEcacheReplicationGroupCreate(ctx context.Context, d *schema.Re
 		return diag.Errorf("DuploEcacheReplicationGroupCreate failed to create global datastore : %s", cerr)
 	}
 	id := fmt.Sprintf("%s/ecacheReplicationGroup/%s/%s/%s", tenantID, rq.SecondaryTenantId, rq.GlobalReplicationGroupId, rq.ReplicationGroupId)
-	err := replicationGroupWaitUntilAvailable(ctx, c, tenantID, rq.GlobalReplicationGroupId, rq.SecondaryTenantId, rp.ReplicationGroup.ReplicationGroupId)
+	err := replicationGroupWaitUntilAvailable(ctx, c, tenantID, rq.GlobalReplicationGroupId, rq.SecondaryTenantId, rp.ReplicationGroupId)
 	if err != nil {
 		return diag.Errorf("replicationGroupWaitUntilAvailable %s", cerr)
 

--- a/duplocloud/resource_duplo_ecache_global_datastore.go
+++ b/duplocloud/resource_duplo_ecache_global_datastore.go
@@ -86,12 +86,12 @@ func resourceDuploEcacheGlobalDatastoreCreate(ctx context.Context, d *schema.Res
 	c := m.(*duplosdk.Client)
 	rp, cerr := c.DuploEcacheGlobalDatastoreCreate(tenantID, &rq)
 	if cerr != nil {
-		return diag.Errorf("%s", cerr)
+		return diag.Errorf("DuploEcacheGlobalDatastoreCreate failed to create global datastore %s", cerr)
 	}
 	id := fmt.Sprintf("%s/ecacheGlobalDatastore/%s", tenantID, rp.GlobalReplicationGroup.GlobalReplicationGroupId)
 	err := globalDatastoreWaitUntilAvailable(ctx, c, tenantID, rp.GlobalReplicationGroup.GlobalReplicationGroupId)
 	if err != nil {
-		return diag.Errorf("%s", cerr)
+		return diag.Errorf("globalDatastoreWaitUntilAvailable Waiting for global datastore to be available failed %s", cerr)
 
 	}
 	d.SetId(id)
@@ -140,7 +140,7 @@ func resourceDuploEcacheGlobalDatastoreRead(ctx context.Context, d *schema.Resou
 		if err.Status() == 404 {
 			log.Printf("Unable to fetch Ecache Global Datastore")
 			d.SetId("")
-			return nil
+			return diag.Errorf("DuploEcacheGlobalDatastoreGet Unable to fetch Ecache Global Datastore %s", err)
 		}
 		return diag.FromErr(err)
 	}

--- a/duplosdk/ecache_instance.go
+++ b/duplosdk/ecache_instance.go
@@ -214,6 +214,7 @@ type DuploEcacheGlobalDatastoreResponse struct {
 	ReplicationGroup                  struct {
 		ReplicationGroupId string `json:"ReplicationGroupId"`
 	} `json:"ReplicationGroup,omitempty"`
+	ReplicationGroupId string `json:"ReplicationGroupId"`
 }
 
 type DuploEcacheReplicationMember struct {
@@ -268,7 +269,6 @@ type DuploEcacheReplicationGroup struct {
 	Description              string `json:"GlobalReplicationGroupDescription"`
 	GlobalReplicationGroupId string `json:"GlobalReplicationGroupId"`
 	SecondaryTenantId        string `json:"TenantId"`
-	Port                     int    `json:"Port"`
 	ReplicationGroupId       string `json:"ReplicationGroupId"`
 }
 

--- a/examples/resources/duplocloud_ecache_associate_global_secondary_cluster/resource.tf
+++ b/examples/resources/duplocloud_ecache_associate_global_secondary_cluster/resource.tf
@@ -31,5 +31,4 @@ resource "duplocloud_ecache_associate_global_secondary_cluster" "rg" {
   global_datastore_id    = duplocloud_ecache_global_datastore.gds.fullname
   description            = "secondary cluster"
   secondary_cluster_name = "red11sc"
-  port                   = 7688
 }


### PR DESCRIPTION
## Overview

REmoved port from duplocloud_ecache_associate_global_secondary_cluster
## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
<img width="979" height="742" alt="Screenshot 2025-08-29 at 18 11 53" src="https://github.com/user-attachments/assets/9a9e167f-0b14-4dbf-811d-b77ff391834e" />
<img width="1066" height="853" alt="Screenshot 2025-08-29 at 18 34 10" src="https://github.com/user-attachments/assets/891db365-92de-4642-8ad7-1d08f50310ea" />
