### PR TITLE
DUPLO-36938 TF:  Add resource id in the error message along with uniform error message if resource already exists

### DIFF
--- a/duplocloud/resource_duplo_gcp_k8_node_pool.go
+++ b/duplocloud/resource_duplo_gcp_k8_node_pool.go
@@ -459,21 +459,21 @@ func resourceGCPK8NodePoolCreate(ctx context.Context, d *schema.ResourceData, m 
 	// Create the request object.
 	rq, err := expandGCPNodePool(d)
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", rq.Name, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", rq.Name, err)
 
 	}
 	// Post the object to Duplo
 	shortName := rq.Name
 	fullName, clientErr := c.GetDuploServicesName(tenantID, shortName)
 	if clientErr != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", tenantID, err)
 	}
 
 	_, cerr := c.GCPK8NodePoolCreate(tenantID, rq)
 	id := fmt.Sprintf("%s/%s", tenantID, fullName)
 
 	if cerr != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, cerr)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, cerr)
 	}
 
 	diags := waitForResourceToBePresentAfterCreate(ctx, d, "gcp node pool", id, func() (interface{}, duplosdk.ClientError) {
@@ -484,7 +484,7 @@ func resourceGCPK8NodePoolCreate(ctx context.Context, d *schema.ResourceData, m 
 	}
 	err = gcpNodePoolWaitUntilReady(ctx, c, tenantID, fullName, d.Timeout("create"))
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 	d.SetId(id)
 	d.Set("name", shortName)
@@ -729,9 +729,9 @@ func resourceGCPNodePoolRead(ctx context.Context, d *schema.ResourceData, m inte
 		if err.Status() == 404 {
 			log.Printf("GCP node pool %s not found", fullName)
 			d.SetId("") // object missing or deleted
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 		}
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 	}
 
@@ -918,13 +918,13 @@ func resourceGcpNodePoolDelete(ctx context.Context, d *schema.ResourceData, m in
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 	}
 
 	err = c.GCPK8NodePoolDelete(tenantID, fullName)
 	if err != nil && err.Status() != 404 {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 	if err != nil && err.Status() == 404 {
 		log.Printf("GCP node pool %s not found", fullName)
@@ -932,7 +932,7 @@ func resourceGcpNodePoolDelete(ctx context.Context, d *schema.ResourceData, m in
 	}
 	derr := gcpNodePoolWaitUntilAvailableForDeleted(ctx, c, tenantID, fullName, d.Timeout("delete"))
 	if derr != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 	}
 	// Wait up to 60 seconds for Duplo to delete the node pool.
@@ -958,75 +958,75 @@ func resourceGCPK8NodePoolUpdate(ctx context.Context, d *schema.ResourceData, m 
 	tenantID, fullName := idParts[0], idParts[1]
 	rq, err := expandGCPNodePool(d)
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 	}
 	c := m.(*duplosdk.Client)
 	if d.HasChange("zones") {
 		_, err = gcpNodePoolZoneUpdate(c, tenantID, fullName, rq.Zones)
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 		}
 		err = gcpNodePoolWaitUntilReady(ctx, c, tenantID, fullName, d.Timeout("update"))
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 		}
 	}
 	if d.HasChange("image_type") {
 		_, err = gcpNodePoolImageTypeUpdate(c, tenantID, fullName, rq.ImageType)
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 		}
 		err = gcpNodePoolWaitUntilReady(ctx, c, tenantID, fullName, d.Timeout("update"))
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 		}
 	}
 
 	if d.HasChange("taints") || d.HasChange("labels") || d.HasChange("tags") || d.HasChange("resource_labels") || d.HasChange("allocation_tags") {
 		_, err = gcpNodePoolUpdateTaintAndTags(c, tenantID, fullName, rq)
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 		}
 		err = gcpNodePoolWaitUntilReady(ctx, c, tenantID, fullName, d.Timeout("update"))
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 		}
 	}
 	if d.HasChange("upgrade_settings") {
 		_, err = gcpNodePoolUpdateUpgradeSetting(c, tenantID, fullName, rq.UpgradeSettings)
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 		}
 		err = gcpNodePoolWaitUntilReady(ctx, c, tenantID, fullName, d.Timeout("update"))
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 		}
 	}
 	if d.HasChange("initial_node_count") {
 		_, err = gcpNodePoolUpdateInitialNodeCount(c, tenantID, fullName, rq.InitialNodeCount)
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 		}
 		err = gcpNodePoolWaitUntilReady(ctx, c, tenantID, fullName, d.Timeout("update"))
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 		}
 	}
 
 	err = gcpNodePoolAutoScalingUpdate(c, tenantID, fullName, d, *rq)
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 
 	err = gcpNodePoolWaitUntilReady(ctx, c, tenantID, fullName, d.Timeout("update"))
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 
 	diag := resourceGCPNodePoolRead(ctx, d, m)

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -444,7 +444,7 @@ func resourceInfrastructureUpdate(ctx context.Context, d *schema.ResourceData, m
 			err = c.InfrastructureChangeSetting(infraName, existing, settings)
 		}
 		if err != nil {
-			return diag.Errorf("Duplocloud resource '%s'\n%s", d.Id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", d.Id(), err)
 		}
 	}
 

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -340,12 +340,12 @@ func resourceInfrastructureRead(ctx context.Context, d *schema.ResourceData, m i
 	c := m.(*duplosdk.Client)
 	missing, err := infrastructureRead(c, d, name)
 	if err != nil && err.Status() != 404 {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 	if (err != nil && err.Status() == 404) || missing {
 		d.SetId("") // object missing
 		log.Printf("Infrastructure not found")
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 	}
 
@@ -371,7 +371,7 @@ func resourceInfrastructureCreate(ctx context.Context, d *schema.ResourceData, m
 	c := m.(*duplosdk.Client)
 	err = c.InfrastructureCreate(rq)
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 
 	// Wait up to 60 seconds for Duplo to be able to return the infrastructure details.
@@ -386,7 +386,7 @@ func resourceInfrastructureCreate(ctx context.Context, d *schema.ResourceData, m
 	// Then, wait until the infrastructure is completely ready.
 	err = duploInfrastructureWaitUntilReady(ctx, c, rq.Name, d.Timeout("create"))
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 
 	diags = resourceInfrastructureRead(ctx, d, m)
@@ -419,7 +419,7 @@ func resourceInfrastructureUpdate(ctx context.Context, d *schema.ResourceData, m
 	// Apply any settings changes.
 	config, err := c.InfrastructureGetSetting(infraName)
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", d.Id(), err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", d.Id(), err)
 	}
 	if d.HasChange("setting") {
 		var existing *[]duplosdk.DuploKeyStringValue
@@ -444,7 +444,7 @@ func resourceInfrastructureUpdate(ctx context.Context, d *schema.ResourceData, m
 			err = c.InfrastructureChangeSetting(infraName, existing, settings)
 		}
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", d.Id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", d.Id, err)
 		}
 	}
 
@@ -477,7 +477,7 @@ func resourceInfrastructureDelete(ctx context.Context, d *schema.ResourceData, m
 		if err.Status() == 404 {
 			return nil
 		}
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", d.Id(), err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", d.Id(), err)
 	}
 
 	// Wait for 20 minutes to allow infrastructure deletion.

--- a/duplocloud/resource_duplo_plan_settings.go
+++ b/duplocloud/resource_duplo_plan_settings.go
@@ -101,27 +101,26 @@ func resourcePlanSettingsRead(ctx context.Context, d *schema.ResourceData, m int
 	log.Printf("[TRACE] resourcePlanSettingsRead(%s): start", planID)
 
 	c := m.(*duplosdk.Client)
-
 	// Get "special" plan settings.
 	settings, err := c.PlanGetSettings(planID)
 	if err != nil && err.Status() != 404 {
-		return diag.Errorf("failed to retrieve plan settings for '%s': %s", planID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 	}
 	if (err != nil && err.Status() == 404) || settings == nil {
 		d.SetId("")
-		log.Printf("plan settings not found for plan %s", planID)
-		return nil
+		log.Printf("plan settings resource id %s : \n [Error] %s", planID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 	}
 	// Get plan DNS config.  If the config is "global", that means there is no plan DNS config.
 	dns, err := c.PlanGetDnsConfig(planID)
 	if err != nil && err.Status() != 404 {
-		return diag.Errorf("failed to retrieve plan DNS config for '%s': %s", planID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 	}
 
 	if (err != nil && err.Status() == 404) || settings == nil {
 		d.SetId("")
 		log.Printf("plan settings DNS config not found for plan %s", planID)
-		return nil
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 	}
 
 	if dns != nil && dns.IsGlobalDNS {
@@ -131,12 +130,12 @@ func resourcePlanSettingsRead(ctx context.Context, d *schema.ResourceData, m int
 	// Get plan metadata.
 	allMetadata, err := c.PlanMetadataGetList(planID)
 	if err != nil && err.Status() != 404 {
-		return diag.Errorf("failed to retrieve plan settings for '%s': %s", planID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 	}
 	if (err != nil && err.Status() == 404) || settings == nil {
 		d.SetId("")
 		log.Printf("plan settings not found for plan %s", planID)
-		return nil
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 	}
 
 	// Set the simple fields first.
@@ -169,7 +168,7 @@ func resourcePlanSettingsCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 		}
 		_, err := c.PlanUpdateSettings(planID, &settings)
 		if err != nil {
-			return diag.Errorf("failed to apply plan settings for '%s': %s", planID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 		}
 	}
 
@@ -178,7 +177,7 @@ func resourcePlanSettingsCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 		dns := expandDnsSetting(v.([]interface{})[0].(map[string]interface{}))
 		_, err := c.PlanUpdateDnsConfig(planID, dns)
 		if err != nil {
-			return diag.Errorf("failed to apply plan DNS config for '%s': %s", planID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 		}
 	}
 
@@ -186,13 +185,13 @@ func resourcePlanSettingsCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 	if _, ok := d.GetOk("metadata"); ok || d.HasChange("metadata") {
 		allMetadata, err := c.PlanMetadataGetList(planID)
 		if err != nil {
-			return diag.Errorf("failed to retrieve plan metadata for '%s': %s", planID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 		}
 
 		previous, desired := getPlanMetadataChange(allMetadata, d)
 		err = c.PlanChangeMetadata(planID, previous, desired)
 		if err != nil {
-			return diag.Errorf("Error updating plan configs for '%s': %s", planID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 		}
 	}
 
@@ -211,7 +210,7 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 	// Get "special" plan settings.
 	settings, err := c.PlanGetSettings(planID)
 	if err != nil && err.Status() != 404 {
-		return diag.Errorf("failed to retrieve plan settings for '%s': %s", planID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 	}
 
 	// Skip if plan does not exist.
@@ -225,7 +224,7 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 		settings.UnrestrictedExtLB = false
 		_, err := c.PlanUpdateSettings(planID, settings)
 		if err != nil && err.Status() != 404 {
-			return diag.Errorf("failed to update plan settings for '%s': %s", planID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 		}
 		if (err != nil && err.Status() == 404) || settings == nil {
 			log.Printf("plan settings not found for plan %s", planID)
@@ -238,7 +237,7 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 	if _, ok := d.GetOk("dns_setting"); ok {
 		err := c.PlanDeleteDnsConfig(planID)
 		if err != nil && err.Status() != 404 {
-			return diag.Errorf("failed to remove plan DNS config for '%s': %s", planID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 		}
 		if (err != nil && err.Status() == 404) || settings == nil {
 			log.Printf("plan settings dns config not found for plan %s", planID)
@@ -252,7 +251,7 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 		allMetadata, err := c.PlanMetadataGetList(planID)
 
 		if err != nil && err.Status() != 404 {
-			return diag.Errorf("failed to retrieve plan metadata for '%s': %s", planID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 		}
 		if (err != nil && err.Status() == 404) || settings == nil {
 			log.Printf("plan settings metadata not found for plan %s", planID)
@@ -266,10 +265,10 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 		// Apply the changes via Duplo
 		err = c.PlanChangeMetadata(planID, previous, desired)
 		if err != nil {
-			return diag.Errorf("failed to remove plan metadata for '%s': %s", planID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 		}
 		if err != nil && err.Status() != 404 {
-			return diag.Errorf("failed to remove plan metadata for '%s': %s", planID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
 		}
 		if (err != nil && err.Status() == 404) || settings == nil {
 			log.Printf("plan settings metadata not found for plan %s", planID)

--- a/duplocloud/resource_duplo_plan_settings.go
+++ b/duplocloud/resource_duplo_plan_settings.go
@@ -104,23 +104,23 @@ func resourcePlanSettingsRead(ctx context.Context, d *schema.ResourceData, m int
 	// Get "special" plan settings.
 	settings, err := c.PlanGetSettings(planID)
 	if err != nil && err.Status() != 404 {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 	}
 	if (err != nil && err.Status() == 404) || settings == nil {
 		d.SetId("")
 		log.Printf("plan settings resource id %s : \n [Error] %s", planID, err)
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 	}
 	// Get plan DNS config.  If the config is "global", that means there is no plan DNS config.
 	dns, err := c.PlanGetDnsConfig(planID)
 	if err != nil && err.Status() != 404 {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 	}
 
 	if (err != nil && err.Status() == 404) || settings == nil {
 		d.SetId("")
 		log.Printf("plan settings DNS config not found for plan %s", planID)
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 	}
 
 	if dns != nil && dns.IsGlobalDNS {
@@ -130,12 +130,12 @@ func resourcePlanSettingsRead(ctx context.Context, d *schema.ResourceData, m int
 	// Get plan metadata.
 	allMetadata, err := c.PlanMetadataGetList(planID)
 	if err != nil && err.Status() != 404 {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 	}
 	if (err != nil && err.Status() == 404) || settings == nil {
 		d.SetId("")
 		log.Printf("plan settings not found for plan %s", planID)
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 	}
 
 	// Set the simple fields first.
@@ -168,7 +168,7 @@ func resourcePlanSettingsCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 		}
 		_, err := c.PlanUpdateSettings(planID, &settings)
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 		}
 	}
 
@@ -177,7 +177,7 @@ func resourcePlanSettingsCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 		dns := expandDnsSetting(v.([]interface{})[0].(map[string]interface{}))
 		_, err := c.PlanUpdateDnsConfig(planID, dns)
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 		}
 	}
 
@@ -185,13 +185,13 @@ func resourcePlanSettingsCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 	if _, ok := d.GetOk("metadata"); ok || d.HasChange("metadata") {
 		allMetadata, err := c.PlanMetadataGetList(planID)
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 		}
 
 		previous, desired := getPlanMetadataChange(allMetadata, d)
 		err = c.PlanChangeMetadata(planID, previous, desired)
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 		}
 	}
 
@@ -210,7 +210,7 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 	// Get "special" plan settings.
 	settings, err := c.PlanGetSettings(planID)
 	if err != nil && err.Status() != 404 {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 	}
 
 	// Skip if plan does not exist.
@@ -224,7 +224,7 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 		settings.UnrestrictedExtLB = false
 		_, err := c.PlanUpdateSettings(planID, settings)
 		if err != nil && err.Status() != 404 {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 		}
 		if (err != nil && err.Status() == 404) || settings == nil {
 			log.Printf("plan settings not found for plan %s", planID)
@@ -237,7 +237,7 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 	if _, ok := d.GetOk("dns_setting"); ok {
 		err := c.PlanDeleteDnsConfig(planID)
 		if err != nil && err.Status() != 404 {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 		}
 		if (err != nil && err.Status() == 404) || settings == nil {
 			log.Printf("plan settings dns config not found for plan %s", planID)
@@ -251,7 +251,7 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 		allMetadata, err := c.PlanMetadataGetList(planID)
 
 		if err != nil && err.Status() != 404 {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 		}
 		if (err != nil && err.Status() == 404) || settings == nil {
 			log.Printf("plan settings metadata not found for plan %s", planID)
@@ -265,10 +265,10 @@ func resourcePlanSettingsDelete(ctx context.Context, d *schema.ResourceData, m i
 		// Apply the changes via Duplo
 		err = c.PlanChangeMetadata(planID, previous, desired)
 		if err != nil {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 		}
 		if err != nil && err.Status() != 404 {
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", planID, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", planID, err)
 		}
 		if (err != nil && err.Status() == 404) || settings == nil {
 			log.Printf("plan settings metadata not found for plan %s", planID)

--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -136,7 +136,7 @@ func resourceTenantRead(ctx context.Context, d *schema.ResourceData, m interface
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("Unable to retrieve tenant '%s': %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
 	}
 	if duplo == nil {
 		d.SetId("") // object missing
@@ -200,7 +200,8 @@ func resourceTenantCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	if err != nil {
-		return diag.Errorf("Unable to create tenant '%s': %s", rq.AccountName, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", accountName, err)
+
 	}
 
 	// Wait up to 60 seconds for Duplo to be able to return the tenant.
@@ -259,7 +260,7 @@ func resourceTenantDelete(ctx context.Context, d *schema.ResourceData, m interfa
 				log.Printf("Tenant %s not found", tenantID)
 				return nil
 			}
-			return diag.Errorf("Unable to retrieve tenant '%s': %s", tenantID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
 		}
 		if duplo == nil {
 			return nil
@@ -270,7 +271,8 @@ func resourceTenantDelete(ctx context.Context, d *schema.ResourceData, m interfa
 				log.Printf("Tenant %s not found", tenantID)
 				return nil
 			}
-			return diag.Errorf("Error deleting tenant '%s': %s", tenantID, err)
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+
 		}
 
 		// Wait for 1 minute to allow tenant deletion.

--- a/duplocloud/resource_duplo_tenant.go
+++ b/duplocloud/resource_duplo_tenant.go
@@ -136,7 +136,7 @@ func resourceTenantRead(ctx context.Context, d *schema.ResourceData, m interface
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 	if duplo == nil {
 		d.SetId("") // object missing
@@ -200,7 +200,7 @@ func resourceTenantCreate(ctx context.Context, d *schema.ResourceData, m interfa
 	}
 
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", accountName, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", accountName, err)
 
 	}
 
@@ -260,7 +260,7 @@ func resourceTenantDelete(ctx context.Context, d *schema.ResourceData, m interfa
 				log.Printf("Tenant %s not found", tenantID)
 				return nil
 			}
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 		}
 		if duplo == nil {
 			return nil
@@ -271,7 +271,7 @@ func resourceTenantDelete(ctx context.Context, d *schema.ResourceData, m interfa
 				log.Printf("Tenant %s not found", tenantID)
 				return nil
 			}
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 
 		}
 

--- a/duplocloud/resource_duplo_tenant_config.go
+++ b/duplocloud/resource_duplo_tenant_config.go
@@ -83,14 +83,15 @@ func resourceTenantConfigRead(ctx context.Context, d *schema.ResourceData, m int
 		if err.Status() == 404 {
 			log.Printf("Tenant config for tenant %s not found", tenantID)
 			d.SetId("")
-			return nil
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
 		}
-		return diag.Errorf("Unable to retrieve tenant '%s': %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
 	}
 	if tenant == nil {
 		log.Printf("Tenant config for tenant %s not found", tenantID)
 		d.SetId("") // object missing
-		return nil
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, "object missing")
+
 	}
 	duplo, err := c.TenantGetConfig(tenantID)
 	if err != nil {
@@ -98,7 +99,7 @@ func resourceTenantConfigRead(ctx context.Context, d *schema.ResourceData, m int
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("Unable to retrieve tenant config for '%s': %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
 	}
 	if duplo == nil {
 		d.SetId("") // object missing
@@ -133,7 +134,8 @@ func resourceTenantConfigCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 	c := m.(*duplosdk.Client)
 	config, err := c.TenantGetConfig(tenantID)
 	if err != nil {
-		return diag.Errorf("Error retrieving tenant config for '%s': %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
+
 	}
 	var existing *[]duplosdk.DuploKeyStringValue
 	if v, ok := getAsStringArray(d, "specified_settings"); ok && v != nil {
@@ -157,7 +159,7 @@ func resourceTenantConfigCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 		err = c.TenantChangeConfig(tenantID, existing, settings)
 	}
 	if err != nil {
-		return diag.Errorf("Error updating tenant config for '%s': %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
 	}
 	d.SetId(tenantID)
 
@@ -195,7 +197,7 @@ func resourceTenantConfigDelete(ctx context.Context, d *schema.ResourceData, m i
 		err = c.TenantChangeConfig(tenantID, previous, desired)
 	}
 	if err != nil {
-		return diag.Errorf("Error deleting tenant config for '%s': %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
 	}
 
 	log.Printf("[TRACE] resourceTenantConfigDelete(%s): end", tenantID)

--- a/duplocloud/resource_duplo_tenant_config.go
+++ b/duplocloud/resource_duplo_tenant_config.go
@@ -83,14 +83,14 @@ func resourceTenantConfigRead(ctx context.Context, d *schema.ResourceData, m int
 		if err.Status() == 404 {
 			log.Printf("Tenant config for tenant %s not found", tenantID)
 			d.SetId("")
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", tenantID, err)
 		}
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", tenantID, err)
 	}
 	if tenant == nil {
 		log.Printf("Tenant config for tenant %s not found", tenantID)
 		d.SetId("") // object missing
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, "object missing")
+		return diag.Errorf("Duplocloud resource '%s'\n%s", tenantID, "object missing")
 
 	}
 	duplo, err := c.TenantGetConfig(tenantID)
@@ -99,7 +99,7 @@ func resourceTenantConfigRead(ctx context.Context, d *schema.ResourceData, m int
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", tenantID, err)
 	}
 	if duplo == nil {
 		d.SetId("") // object missing
@@ -134,7 +134,7 @@ func resourceTenantConfigCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 	c := m.(*duplosdk.Client)
 	config, err := c.TenantGetConfig(tenantID)
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", tenantID, err)
 
 	}
 	var existing *[]duplosdk.DuploKeyStringValue
@@ -159,7 +159,7 @@ func resourceTenantConfigCreateOrUpdate(ctx context.Context, d *schema.ResourceD
 		err = c.TenantChangeConfig(tenantID, existing, settings)
 	}
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", tenantID, err)
 	}
 	d.SetId(tenantID)
 
@@ -197,7 +197,7 @@ func resourceTenantConfigDelete(ctx context.Context, d *schema.ResourceData, m i
 		err = c.TenantChangeConfig(tenantID, previous, desired)
 	}
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", tenantID, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", tenantID, err)
 	}
 
 	log.Printf("[TRACE] resourceTenantConfigDelete(%s): end", tenantID)

--- a/duplocloud/resource_duplo_user_tenant_access.go
+++ b/duplocloud/resource_duplo_user_tenant_access.go
@@ -3,10 +3,11 @@ package duplocloud
 import (
 	"context"
 	"fmt"
-	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 	"log"
 	"strings"
 	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -68,7 +69,7 @@ func resourceUserTenantAccessRead(ctx context.Context, d *schema.ResourceData, m
 	c := m.(*duplosdk.Client)
 	duplo, err := c.GetUserTenantAccessInfo(idParts[0], idParts[1])
 	if err != nil {
-		return diag.Errorf("Unable to retrieve User '%s': %s", id, err)
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
 	}
 	if duplo == nil {
 		d.SetId("") // object missing
@@ -97,9 +98,17 @@ func resourceUserTenantAccessCreate(ctx context.Context, d *schema.ResourceData,
 
 	// Post the object to Duplo
 	c := m.(*duplosdk.Client)
+	id := fmt.Sprintf("%s/%s", rq.Username, rq.TenantId)
+	d.SetId(id)
+
 	err := c.GrantUserTenantAccess(&rq)
 	if err != nil {
-		return diag.Errorf("Unable to grant tenant %s access to User '%s' : %s", rq.TenantId, rq.Username, err)
+		if err.Status() == 404 {
+			log.Printf("Tenant config for tenant %s not found", id)
+			d.SetId("")
+			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		}
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
 	}
 
 	var rp *duplosdk.DuploUser
@@ -111,7 +120,6 @@ func resourceUserTenantAccessCreate(ctx context.Context, d *schema.ResourceData,
 		return diags
 	}
 
-	d.SetId(fmt.Sprintf("%s/%s", rq.Username, rq.TenantId))
 	diags = resourceUserTenantAccessRead(ctx, d, m)
 	log.Printf("[TRACE] resourceUserTenantAccessCreate(%s): end", userName)
 	return diags
@@ -145,8 +153,12 @@ func resourceUserTenantAccessDelete(ctx context.Context, d *schema.ResourceData,
 	c := m.(*duplosdk.Client)
 	err := c.GrantUserTenantAccess(&rq)
 	if err != nil {
-		return diag.Errorf("Unable to remove tenant %s access from User '%s' : %s", rq.TenantId, rq.Username, err)
+		if err.Status() == 404 {
+			return nil
+		}
+		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
 	}
+
 	diag := waitForResourceToBeMissingAfterDelete(ctx, d, "User", id, func() (interface{}, duplosdk.ClientError) {
 		if rp, err := c.GetUserTenantAccessInfo(rq.Username, rq.TenantId); rp != nil || err != nil {
 			return rp, err

--- a/duplocloud/resource_duplo_user_tenant_access.go
+++ b/duplocloud/resource_duplo_user_tenant_access.go
@@ -69,7 +69,7 @@ func resourceUserTenantAccessRead(ctx context.Context, d *schema.ResourceData, m
 	c := m.(*duplosdk.Client)
 	duplo, err := c.GetUserTenantAccessInfo(idParts[0], idParts[1])
 	if err != nil {
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 	if duplo == nil {
 		d.SetId("") // object missing
@@ -106,9 +106,9 @@ func resourceUserTenantAccessCreate(ctx context.Context, d *schema.ResourceData,
 		if err.Status() == 404 {
 			log.Printf("Tenant config for tenant %s not found", id)
 			d.SetId("")
-			return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+			return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 		}
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 
 	var rp *duplosdk.DuploUser
@@ -156,7 +156,7 @@ func resourceUserTenantAccessDelete(ctx context.Context, d *schema.ResourceData,
 		if err.Status() == 404 {
 			return nil
 		}
-		return diag.Errorf("Duplocloud resource id '%s' \n[Error]: %s", id, err)
+		return diag.Errorf("Duplocloud resource '%s'\n%s", id, err)
 	}
 
 	diag := waitForResourceToBeMissingAfterDelete(ctx, d, "User", id, func() (interface{}, duplosdk.ClientError) {


### PR DESCRIPTION
## Overview

Error format updated
## Summary of changes
Updated error format for 
duplocloud_infrastructure 
duplocloud_plan_settings 
duplocloud_tenant 
duplocloud_tenant_config 
duplocloud_user_tenant_access
 duplocloud_gcp_node_pool

This PR does the following:

- Error: Duplocloud resource <resource-id>
<API error>
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
