### PR TITLE
DUPLO-36977 TF KMS support for global redis cluster

### DIFF
--- a/docs/resources/ecache_associate_global_secondary_cluster.md
+++ b/docs/resources/ecache_associate_global_secondary_cluster.md
@@ -29,6 +29,9 @@ resource "duplocloud_ecache_instance" "re" {
   enable_cluster_mode        = true
   number_of_shards           = 2
   automatic_failover_enabled = true
+  encryption_in_transit      = true
+  kms_key_id                 = "ebdc0518-e512-4cf8-b09a-5cbf2797a736"
+  auth_token                 = "qasxdqwdqadasdqxqwqwsxqswdsqxqwxqwxwqqw"
 }
 
 resource "duplocloud_ecache_global_datastore" "gds" {
@@ -46,6 +49,9 @@ resource "duplocloud_ecache_associate_global_secondary_cluster" "rg" {
   global_datastore_id    = duplocloud_ecache_global_datastore.gds.fullname
   description            = "secondary cluster"
   secondary_cluster_name = "red11sc"
+  secondary_kms_key      = "9b513a7a-b4d9-4e1d-9606-bba6e2c5a449"
+  auth_token             = "qasxdqwdqadasdqxqwqwsxqswdsqxqwxqwxwqqw"
+
 }
 ```
 
@@ -61,7 +67,11 @@ resource "duplocloud_ecache_associate_global_secondary_cluster" "rg" {
 
 ### Optional
 
+- `auth_token` (String) Set a password for authenticating to the ElastiCache instance.
+
+See AWS documentation for the [required format](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html) of this field.
 - `description` (String) The description for secondary cluster
+- `secondary_kms_key` (String) Specify kms key for secondary cluster
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only

--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -208,7 +208,6 @@ Should be one of:
 - `encryption_in_transit` (Boolean) Enables encryption-in-transit. Defaults to `false`.
 - `engine_version` (String) The engine version of the elastic instance.
 See AWS documentation for the [available Redis and Valkey instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) or the [available Memcached instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions-mc.html).
-- `global_replication_group` (Block List) (see [below for nested schema](#nestedblock--global_replication_group))
 - `kms_key_id` (String) The globally unique identifier for the key.
 - `log_delivery_configuration` (Block Set, Max: 2) (see [below for nested schema](#nestedblock--log_delivery_configuration))
 - `number_of_shards` (Number) The number of shards to create. Applicable only if enable_cluster_mode is set to true
@@ -229,21 +228,8 @@ See AWS documentation for the [available Redis and Valkey instance types](https:
 - `id` (String) The ID of this resource.
 - `identifier` (String) The full name of the elasticache instance.
 - `instance_status` (String) The status of the elasticache instance.
-- `port` (Number) The listening port of the elasticache instance.
-
-<a id="nestedblock--global_replication_group"></a>
-### Nested Schema for `global_replication_group`
-
-Required:
-
-- `description` (String) Specify global replication description
-- `group_id` (String) Specify global replication group id
-- `secondary_tenant_id` (String) Specify secondary tenant id
-
-Read-Only:
-
 - `is_primary` (Boolean) Flag to indicate if this is primary replication group
-
+- `port` (Number) The listening port of the elasticache instance.
 
 <a id="nestedblock--log_delivery_configuration"></a>
 ### Nested Schema for `log_delivery_configuration`

--- a/docs/resources/gcp_node_pool.md
+++ b/docs/resources/gcp_node_pool.md
@@ -203,7 +203,7 @@ locals {
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `total_max_node_count` (Number) Maximum number of nodes for one location in the NodePool. Must be >= minNodeCount.
 - `total_min_node_count` (Number) Minimum number of nodes for one location in the NodePool. Must be >= 1 and <= maxNodeCount.
-- `upgrade_settings` (Block List) Upgrade settings control disruption and speed of the upgrade. (see [below for nested schema](#nestedblock--upgrade_settings))
+- `upgrade_settings` (Block List, Max: 1) Upgrade settings control disruption and speed of the upgrade. (see [below for nested schema](#nestedblock--upgrade_settings))
 
 ### Read-Only
 

--- a/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
+++ b/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	"time"
 
@@ -59,6 +60,17 @@ func ecacheReplicationGroupSchema() map[string]*schema.Schema {
 			Description: "Region of secondary cluster",
 			Type:        schema.TypeString,
 			Computed:    true,
+		},
+		"secondary_kms_key": {
+			Description: "Specify kms key for secondary cluster",
+			Type:        schema.TypeString,
+			Optional:    true,
+		},
+		"auth_token": {
+			Description:  "Region of secondary cluster",
+			Type:         schema.TypeString,
+			Optional:     true,
+			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^.{16,}$`), "must be atleast 16 character "),
 		},
 	}
 }

--- a/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
+++ b/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
@@ -65,12 +65,18 @@ func ecacheReplicationGroupSchema() map[string]*schema.Schema {
 			Description: "Specify kms key for secondary cluster",
 			Type:        schema.TypeString,
 			Optional:    true,
+			ForceNew:    true,
 		},
 		"auth_token": {
-			Description:  "Region of secondary cluster",
-			Type:         schema.TypeString,
-			Optional:     true,
-			ValidateFunc: validation.StringMatch(regexp.MustCompile(`^.{16,}$`), "must be atleast 16 character "),
+			Description: "Set a password for authenticating to the ElastiCache instance.\n\n" +
+				"See AWS documentation for the [required format](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html) of this field.",
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+			ValidateFunc: validation.All(
+				validation.StringLenBetween(16, 128),
+				validation.StringMatch(regexp.MustCompile(`^[a-zA-Z0-9!&#$<>^-]*$`), "Invalid AWS Elasticache Redis password"),
+			),
 		},
 	}
 }
@@ -105,6 +111,8 @@ func resourceDuploEcacheReplicationGroupCreate(ctx context.Context, d *schema.Re
 		SecondaryTenantId:        d.Get("secondary_tenant_id").(string),
 		GlobalReplicationGroupId: d.Get("global_datastore_id").(string),
 		ReplicationGroupId:       d.Get("secondary_cluster_name").(string),
+		KmsKeyId:                 d.Get("secondary_kms_key").(string),
+		AuthToken:                d.Get("auth_token").(string),
 	}
 	log.Printf("[TRACE] resourceDuploEcacheReplicationGroupCreate(%s): start", tenantID)
 
@@ -184,6 +192,8 @@ func resourceDuploEcacheReplicationGroupRead(ctx context.Context, d *schema.Reso
 	d.Set("identifier", fullName)
 	d.Set("secondary_region", member.ReplicationGroupRegion)
 	d.Set("secondary_tenant_id", secTenantId)
+	d.Set("secondary_kms_key", member.KmsKeyId)
+	d.Set("auth_token", member.AuthToken)
 	log.Printf("[TRACE] resourceDuploEcacheReplicationGroupRead(%s, %s): end", tenantID, name)
 	return nil
 }

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -651,14 +651,8 @@ func flattenEcacheInstance(duplo *duplosdk.DuploEcacheInstance, d *schema.Resour
 	d.Set("snapshot_retention_limit", duplo.SnapshotRetentionLimit)
 	d.Set("snapshot_window", duplo.SnapshotWindow)
 	d.Set("automatic_failover_enabled", duplo.AutomaticFailoverEnabled)
-	if duplo.IsGlobal {
-		m := make(map[string]interface{})
-		m["group_id"] = duplo.GlobalReplicationGroupId
-		m["description"] = duplo.GlobalReplicationGroupDescription
-		m["secondary_tenant_id"] = duplo.SecondaryTenantId
-		m["is_primary"] = duplo.IsPrimary
-		d.Set("global_replication_group", []interface{}{m})
-	}
+	d.Set("is_primary", duplo.IsPrimary)
+
 	return nil
 }
 
@@ -805,10 +799,6 @@ func validateEcacheParameters(ctx context.Context, diff *schema.ResourceDiff, m 
 	if ecm && !failover {
 		return fmt.Errorf("automatic_failover_enabled should be true for cluster mode")
 
-	}
-	grg := diff.Get("global_replication_group").([]interface{})
-	if len(grg) > 0 && eng != 0 {
-		return fmt.Errorf("global_replication_group is only supported for Redis engine")
 	}
 	return nil
 }

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -248,34 +248,11 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 				},
 			},
 		},
-		"global_replication_group": {
-			Type:     schema.TypeList,
-			Optional: true,
-			ForceNew: true,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"group_id": {
-						Description: "Specify global replication group id",
-						Type:        schema.TypeString,
-						Required:    true,
-					},
-					"description": {
-						Description: "Specify global replication description",
-						Type:        schema.TypeString,
-						Required:    true,
-					},
-					"secondary_tenant_id": {
-						Description: "Specify secondary tenant id",
-						Type:        schema.TypeString,
-						Required:    true,
-					},
-					"is_primary": {
-						Description: "Flag to indicate if this is primary replication group",
-						Type:        schema.TypeBool,
-						Computed:    true,
-					},
-				},
-			},
+
+		"is_primary": {
+			Description: "Flag to indicate if this is primary replication group",
+			Type:        schema.TypeBool,
+			Computed:    true,
 		},
 	}
 }
@@ -622,13 +599,6 @@ func expandEcacheInstance(d *schema.ResourceData) (*duplosdk.AddDuploEcacheInsta
 		} else {
 			data.DuploEcacheInstance.NumberOfShards = v.(int) //number of shards accepted if cluster mode is enabled
 		}
-	}
-	if v, ok := d.Get("global_replication_group").([]interface{}); ok && len(v) > 0 {
-		m := v[0].(map[string]interface{})
-		data.IsGlobal = true
-		data.SecondaryTenantId = m["secondary_tenant_id"].(string)
-		data.GlobalReplicationGroupDescription = m["description"].(string)
-		data.GlobalReplicationGroupId = m["group_id"].(string)
 	}
 	return data, nil
 }

--- a/duplosdk/ecache_instance.go
+++ b/duplosdk/ecache_instance.go
@@ -223,6 +223,8 @@ type DuploEcacheReplicationMember struct {
 	Status                 string `json:"Status"`
 	TenantId               string `json:"TenantId"`
 	ReplicationGroupRegion string `json:"ReplicationGroupRegion"`
+	KmsKeyId               string `json:"KmsKeyId"`
+	AuthToken              string `json:"AuthToken"`
 }
 
 func (c *Client) DuploEcacheGlobalDatastoreCreate(tenantID string, rq *DuploEcacheGlobalDatastore) (*DuploEcacheGlobalDatastoreResponse, ClientError) {
@@ -270,6 +272,8 @@ type DuploEcacheReplicationGroup struct {
 	GlobalReplicationGroupId string `json:"GlobalReplicationGroupId"`
 	SecondaryTenantId        string `json:"TenantId"`
 	ReplicationGroupId       string `json:"ReplicationGroupId"`
+	KmsKeyId                 string `json:"KmsKeyId,omitempty"`
+	AuthToken                string `json:"AuthToken,omitempty"`
 }
 
 func (c *Client) DuploEcacheReplicationGroupCreate(tenantID string, rq *DuploEcacheReplicationGroup) (*DuploEcacheGlobalDatastoreResponse, ClientError) {

--- a/examples/resources/duplocloud_ecache_associate_global_secondary_cluster/resource.tf
+++ b/examples/resources/duplocloud_ecache_associate_global_secondary_cluster/resource.tf
@@ -14,6 +14,9 @@ resource "duplocloud_ecache_instance" "re" {
   enable_cluster_mode        = true
   number_of_shards           = 2
   automatic_failover_enabled = true
+  encryption_in_transit      = true
+  kms_key_id                 = "ebdc0518-e512-4cf8-b09a-5cbf2797a736"
+  auth_token                 = "qasxdqwdqadasdqxqwqwsxqswdsqxqwxqwxwqqw"
 }
 
 resource "duplocloud_ecache_global_datastore" "gds" {
@@ -31,4 +34,7 @@ resource "duplocloud_ecache_associate_global_secondary_cluster" "rg" {
   global_datastore_id    = duplocloud_ecache_global_datastore.gds.fullname
   description            = "secondary cluster"
   secondary_cluster_name = "red11sc"
+  secondary_kms_key      = "9b513a7a-b4d9-4e1d-9606-bba6e2c5a449"
+  auth_token             = "qasxdqwdqadasdqxqwqwsxqswdsqxqwxqwxwqqw"
+
 }


### PR DESCRIPTION
## Overview

KMS and Auth token support 
## Summary of changes
Added support of kms field and auth token field to duplocloud_ecache_associate_global_secondary_cluster
This PR does the following:

- Schema updated
- Doc and example updated

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
