### PR TITLE
DUPLO-37160 TF: default actions field not getting set on import for duplocloud_aws_load_balancer_listener resource

### DIFF
--- a/duplocloud/resource_duplo_tenant_aws_lb_listeners.go
+++ b/duplocloud/resource_duplo_tenant_aws_lb_listeners.go
@@ -434,50 +434,45 @@ func flattenAwsLoadBalancerListener(d *schema.ResourceData, tenantID string, lbN
 	d.Set("certificates", certs)
 	tga := d.Get("target_group_arn").(string)
 	// Ensure the target_group_arn is set to nil if not present
-	actions := make([]map[string]interface{}, 0, len(duplo.DefaultActions))
 	for _, defaultAction := range duplo.DefaultActions {
 		if defaultAction.Type.Value == "forward" && tga == "" {
-			actions = append(actions, map[string]interface{}{
-				"type": "forward",
-				"forward": []map[string]interface{}{
-					{
-						"target_group_arn": defaultAction.TargetGroupArn,
-					},
-				},
-			})
+			m := map[string]interface{}{
+				"target_group_arn": defaultAction.TargetGroupArn,
+			}
+			mf := map[string]interface{}{
+				"forward": []interface{}{m},
+			}
+			d.Set("default_actions", []interface{}{mf})
 		} else {
 			d.Set("target_group_arn", defaultAction.TargetGroupArn)
 		}
 		if defaultAction.Type.Value == "fixed-response" {
-			actions = append(actions, map[string]interface{}{
-				"type": "fixed-response",
-				"fixed_response": []map[string]interface{}{
-					{
-						"content_type": defaultAction.FixedResponseConfig.ContentType,
-						"message_body": defaultAction.FixedResponseConfig.MessageBody,
-						"status_code":  defaultAction.FixedResponseConfig.StatusCode,
-					},
-				},
-			})
+			m := map[string]interface{}{
+				"content_type": defaultAction.FixedResponseConfig.ContentType,
+				"message_body": defaultAction.FixedResponseConfig.MessageBody,
+				"status_code":  defaultAction.FixedResponseConfig.StatusCode,
+			}
+			fr := map[string]interface{}{
+				"fixed_response": []interface{}{m},
+			}
+			d.Set("default_actions", []interface{}{fr})
 		}
 		if defaultAction.Type.Value == "redirect" {
-			actions = append(actions, map[string]interface{}{
-				"type": "redirect",
-				"redirect": []map[string]interface{}{
-					{
-						"status_code": defaultAction.RedirectConfig.StatusCode.Value,
-						"port":        defaultAction.RedirectConfig.Port,
-						"protocol":    defaultAction.RedirectConfig.Protocol,
-						"host":        defaultAction.RedirectConfig.Host,
-						"path":        defaultAction.RedirectConfig.Path,
-						"query":       defaultAction.RedirectConfig.Query,
-					},
-				},
-			})
+			m := map[string]interface{}{
+				"status_code": defaultAction.RedirectConfig.StatusCode.Value,
+				"port":        defaultAction.RedirectConfig.Port,
+				"protocol":    defaultAction.RedirectConfig.Protocol,
+				"host":        defaultAction.RedirectConfig.Host,
+				"path":        defaultAction.RedirectConfig.Path,
+				"query":       defaultAction.RedirectConfig.Query,
+			}
+			r := map[string]interface{}{
+				"redirect": []interface{}{m},
+			}
+			d.Set("default_actions", []interface{}{r})
 		}
 	}
 
-	d.Set("default_actions", actions)
 	d.Set("load_balancer_arn", duplo.LoadBalancerArn)
 	d.Set("ssl_policy", duplo.SSLPolicy)
 }


### PR DESCRIPTION
## Overview

Bug fix
## Summary of changes
Field not getting set on import for duplocloud_aws_load_balancer_listener
This PR does the following:

- fix for default actions field not getting set while importing loadbalancer listener resource
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
