### PR TITLE
DUPLO-37170 TF: GCP NodePool not changing to new class

### DIFF
--- a/duplocloud/resource_duplo_gcp_k8_node_pool.go
+++ b/duplocloud/resource_duplo_gcp_k8_node_pool.go
@@ -41,6 +41,7 @@ func gcpK8NodePoolFunctionSchema() map[string]*schema.Schema {
 				If unspecified, the default machine type is e2-medium.`,
 			Type:     schema.TypeString,
 			Required: true,
+			ForceNew: true,
 		},
 		"disc_size_gb": {
 			Description: `Size of the disk attached to each node, specified in GB. The smallest allowed disk size is 10GB.


### PR DESCRIPTION

## Overview
Field attribute change

## Summary of changes
Added force new to machine_type field for duplocloud_gcp_node_pool resource
This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
