### PR TITLE
DUPLO-37001 Hitting 400 when deleting keyvault secrets more than 2 at once through TF

### DIFF
--- a/duplocloud/resource_duplo_azure_tenant_key_vault_secret.go
+++ b/duplocloud/resource_duplo_azure_tenant_key_vault_secret.go
@@ -181,7 +181,7 @@ func resourceAzureTenantKeyVaultSecretDelete(ctx context.Context, d *schema.Reso
 		}
 		return diag.Errorf("Unable to delete tenant %s azure tenant key vault secret'%s': %s", tenantID, name, clientErr)
 	}
-
+	time.Sleep(30 * time.Second)
 	diag := waitForResourceToBeMissingAfterDelete(ctx, d, "azure tenant key vault secret", id, func() (interface{}, duplosdk.ClientError) {
 		return c.TenantKeyVaultSecretGet(tenantID, vaultName, name)
 	})

--- a/duplosdk/azure_key_vault.go
+++ b/duplosdk/azure_key_vault.go
@@ -269,11 +269,12 @@ func (c *Client) TenantKeyVaultSecretGet(tenantID, vaultName, secretName string)
 
 func (c *Client) TenantKeyVaultSecretList(tenantID, vaultName string) (*[]DuploAzureTenantKeyVaultSecret, ClientError) {
 	resp := []DuploAzureTenantKeyVaultSecret{}
-	err := c.getAPI(
+	conf := NewRetryConf()
+
+	err := c.getAPIWithRetry(
 		fmt.Sprintf("TenantKeyVaultSecretList(%s, %s)", tenantID, vaultName),
 		fmt.Sprintf("v3/subscriptions/%s/azure/keyvault/%s/secret", tenantID, vaultName),
-		&resp,
-	)
+		&resp, &conf)
 	return &resp, err
 }
 


### PR DESCRIPTION

## Overview

Added retry to get api and sleep to avoid API crash
## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
