### PR TITLE
DUPLO-36676 TF: support receive_wait_time_seconds in duplocloud_aws_sqs_queue

### DIFF
--- a/docs/resources/aws_sqs_queue.md
+++ b/docs/resources/aws_sqs_queue.md
@@ -62,6 +62,7 @@ resource "duplocloud_aws_sqs_queue" "sqs_queue_with_dlq" {
 - `fifo_queue` (Boolean) Boolean designating a FIFO queue. If not set, it defaults to `false` making it standard.
 - `fifo_throughput_limit` (String) Specifies whether the FIFO queue throughput quota applies to the entire queue or per message group. Valid values are `perQueue` (default) and `perMessageGroupId`.
 - `message_retention_seconds` (Number) The number of seconds Amazon SQS retains a message. Integer representing seconds, from 60 (1 minute) to 1209600 (14 days).
+- `receive_wait_time_seconds` (Number) The time for which a ReceiveMessage call will wait for a message to arrive. An integer from 0 to 20 (seconds).
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `visibility_timeout_seconds` (Number) The visibility timeout for the queue. An integer from 0 to 43200 (12 hours).
 

--- a/duplocloud/resource_duplo_aws_sqs_queue.go
+++ b/duplocloud/resource_duplo_aws_sqs_queue.go
@@ -121,6 +121,13 @@ func duploAwsSqsQueueSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"receive_wait_time_seconds": {
+			Description:  "The time for which a ReceiveMessage call will wait for a message to arrive. An integer from 0 to 20 (seconds).",
+			Type:         schema.TypeInt,
+			Optional:     true,
+			Computed:     true,
+			ValidateFunc: validation.IntBetween(0, 20),
+		},
 	}
 }
 
@@ -215,6 +222,7 @@ func resourceAwsSqsQueueRead(ctx context.Context, d *schema.ResourceData, m inte
 		name = strings.TrimSuffix(name, ".fifo")
 	}
 	d.Set("name", name)
+	d.Set("receive_wait_time_seconds", queue.ReceiveMessageWaitTimeSeconds)
 	log.Printf("[TRACE] resourceAwsSqsQueueRead(%s, %s): end", tenantID, name)
 	return nil
 }
@@ -260,7 +268,7 @@ func resourceAwsSqsQueueCreate(ctx context.Context, d *schema.ResourceData, m in
 
 func resourceAwsSqsQueueUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
-	if d.HasChanges("message_retention_seconds", "visibility_timeout_seconds", "content_based_deduplication", "deduplication_scope", "fifo_throughput_limit", "delay_seconds", "dead_letter_queue_configuration") {
+	if d.HasChanges("message_retention_seconds", "visibility_timeout_seconds", "content_based_deduplication", "deduplication_scope", "fifo_throughput_limit", "delay_seconds", "dead_letter_queue_configuration", "receive_wait_time_seconds") {
 		var err error
 
 		tenantID := d.Get("tenant_id").(string)
@@ -366,6 +374,9 @@ func expandAwsSqsQueue(d *schema.ResourceData) *duplosdk.DuploSQSQueue {
 		dlqConfig := value.([]interface{})[0].(map[string]interface{})
 		req.DeadLetterTargetQueueName = dlqConfig["target_sqs_dlq_name"].(string)
 		req.MaxMessageTimesReceivedBeforeDeadLetterQueue = dlqConfig["max_message_receive_attempts"].(int)
+	}
+	if v, ok := d.GetOk("receive_wait_time_seconds"); ok && v != nil {
+		req.ReceiveMessageWaitTimeSeconds = d.Get("receive_wait_time_seconds").(int)
 	}
 	return req
 }

--- a/duplosdk/aws_sqs.go
+++ b/duplosdk/aws_sqs.go
@@ -20,6 +20,7 @@ type DuploSQSQueue struct {
 	DelaySeconds                                 int    `json:"DelaySeconds" validate:"required,gte=0,lte=900"`
 	DeadLetterTargetQueueName                    string `json:"DeadLetterTargetQueueName,omitempty"`
 	MaxMessageTimesReceivedBeforeDeadLetterQueue int    `json:"MaxMessageTimesReceivedBeforeDeadLetterQueue,omitempty"`
+	ReceiveMessageWaitTimeSeconds                int    `json:"ReceiveMessageWaitTimeSeconds"`
 }
 
 type DuploSQSQueueResource struct {


### PR DESCRIPTION
## Overview
New field support

## Summary of changes
Added new field receive_wait_time_seconds for resource duplocloud_aws_sqs_queue

This PR does the following:

- CUR operation support for receive_wait_time_seconds field
- Document updated

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
