### PR TITLE
DUPLO-37376 TF:Aurora Global DB- change label identifier to cluster_identifier as input

### DIFF
--- a/docs/resources/aws_rds_global_secondary.md
+++ b/docs/resources/aws_rds_global_secondary.md
@@ -37,7 +37,7 @@ resource "duplocloud_rds_instance" "mydb" {
 
 resource "duplocloud_aws_rds_global_secondary" "gs" {
   tenant_id           = duplocloud_tenant.myapp.tenant_id
-  identifier          = duplocloud_rds_instance.mydb.cluster_identifier
+  cluster_identifier  = duplocloud_rds_instance.mydb.cluster_identifier
   secondary_tenant_id = "a54598b1-0d8f-4a7b-ba7e-4a20f890a57d"
   region              = "us-east-2"
 }

--- a/examples/resources/duplocloud_aws_rds_global_secondary/resource.tf
+++ b/examples/resources/duplocloud_aws_rds_global_secondary/resource.tf
@@ -22,7 +22,7 @@ resource "duplocloud_rds_instance" "mydb" {
 
 resource "duplocloud_aws_rds_global_secondary" "gs" {
   tenant_id           = duplocloud_tenant.myapp.tenant_id
-  identifier          = duplocloud_rds_instance.mydb.cluster_identifier
+  cluster_identifier  = duplocloud_rds_instance.mydb.cluster_identifier
   secondary_tenant_id = "a54598b1-0d8f-4a7b-ba7e-4a20f890a57d"
   region              = "us-east-2"
 }


### PR DESCRIPTION
## Overview

Field name change

## Summary of changes

Field identifier changed to cluster_identifier for duplocloud_aws_rds_global_secondary resource

This PR does the following:

- Document updated
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
