### PR TITLE
DUPLO-37557 TF: duplocloud_aws_cloudwatch_event_target does not send RoleArn if specified for create (but api accepts this)

### DIFF
--- a/duplocloud/resource_duplo_aws_cloudwatch_event_target.go
+++ b/duplocloud/resource_duplo_aws_cloudwatch_event_target.go
@@ -181,9 +181,10 @@ func resourceAwsCloudWatchEventTargetDelete(ctx context.Context, d *schema.Resou
 
 func expandCloudWatchEventTarget(d *schema.ResourceData) *duplosdk.DuploCloudWatchEventTarget {
 	return &duplosdk.DuploCloudWatchEventTarget{
-		Id:    d.Get("target_id").(string),
-		Arn:   d.Get("target_arn").(string),
-		Input: d.Get("input").(string),
+		Id:      d.Get("target_id").(string),
+		Arn:     d.Get("target_arn").(string),
+		Input:   d.Get("input").(string),
+		RoleArn: d.Get("role_arn").(string),
 	}
 }
 


### PR DESCRIPTION
## Overview

Bug fix
## Summary of changes
Fixed value passing issue
This PR does the following:

- RoleArn value initialisation missing fixed.
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
