### PR TITLE
DUPLO-26321 TF: duplocloud_aws_lambda_function_event_config should allow max_retry_attempts to be set to 0

### DIFF
--- a/duplocloud/resource_duplo_aws_lambda_function_event_config.go
+++ b/duplocloud/resource_duplo_aws_lambda_function_event_config.go
@@ -37,6 +37,7 @@ func awsLambdaFunctionEventInvokeConfigSchema() map[string]*schema.Schema {
 			Description:  "Maximum number of attempts a Lambda function may retry in case of error",
 			Type:         schema.TypeInt,
 			Optional:     true,
+			Default:      2,
 			ValidateFunc: validation.IntBetween(0, 2),
 		},
 		"max_event_age_in_seconds": {


### PR DESCRIPTION
## Overview

added default value to max retry attempt
## Summary of changes

This PR does the following:

- ...
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
