### PR TITLE
CUST-10420  TF: Duplo Service delete should use new api

### DIFF
--- a/duplosdk/replication_controller.go
+++ b/duplosdk/replication_controller.go
@@ -290,16 +290,9 @@ func (c *Client) ReplicationControllerUpdate(tenantID string, rq *DuploReplicati
 
 // ReplicationControllerDelete deletes a replication controller via the Duplo API.
 func (c *Client) ReplicationControllerDelete(tenantID string, rq *DuploReplicationControllerDeleteRequest) ClientError {
-	rq.TenantId = tenantID
-	rq.State = "delete"
-	if rq.NetworkId == "" {
-		rq.NetworkId = "default"
-	}
-
-	return c.postAPI(
+	return c.deleteAPI(
 		fmt.Sprintf("ReplicationControllerDelete(%s, %s)", tenantID, rq.Name),
-		fmt.Sprintf("subscriptions/%s/ReplicationControllerUpdate", tenantID),
-		&rq,
+		fmt.Sprintf("v3/subscriptions/%s/replicationcontroller/%s", tenantID, rq.Name),
 		nil,
 	)
 }


### PR DESCRIPTION
## Overview
Delete API replace for service resource
## Summary of changes
Changed existing delete api with new one for duplocloud_duplo_service resource
This PR does the following:

- Replaced existing delete api with v3 delete api for duplo service resource
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
