### PR TITLE
DUPLO-37738 keypair_type in aws_host resource is wrong

### DIFF
--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -202,8 +202,8 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 - `keypair_type` (Number) The numeric ID of the keypair type being used.Should be one of:
 
    - `0` : Default
-   - `1` : ED25519
-   - `2` : RSA (deprecated - some operating systems no longer support it)
+   - `1` : RSA (deprecated - some operating systems no longer support it)
+   - `2` : ED25519
 - `max_instance_count` (Number) The maximum size of the Auto Scaling Group.
 - `max_spot_price` (String) Maximum price to pay for a spot instance in dollars per unit hour.
 - `metadata` (Block List) Configuration metadata used when creating the host.<br>*Note: To configure OS disk size OsDiskSize can be specified as Key and its size as value, size value should be atleast 10* (see [below for nested schema](#nestedblock--metadata))

--- a/docs/resources/aws_host.md
+++ b/docs/resources/aws_host.md
@@ -151,8 +151,8 @@ resource "duplocloud_aws_host" "host" {
 - `keypair_type` (Number) The numeric ID of the keypair type being used.Should be one of:
 
    - `0` : Default
-   - `1` : ED25519
-   - `2` : RSA (deprecated - some operating systems no longer support it)
+   - `1` : RSA (deprecated - some operating systems no longer support it)
+   - `2` : ED25519
 - `metadata` (Block List) Configuration metadata used when creating the host.<br>*Note: To configure OS disk size OsDiskSize can be specified as Key and its size as value, size value should be atleast 10* (see [below for nested schema](#nestedblock--metadata))
 - `minion_tags` (Block List) A map of tags to assign to the resource. Example - `AllocationTags` can be passed as tag key with any value. (see [below for nested schema](#nestedblock--minion_tags))
 - `network_interface` (Block List) An optional list of custom network interface configurations to use when creating the host. (see [below for nested schema](#nestedblock--network_interface))

--- a/duplocloud/resource_duplo_aws_host.go
+++ b/duplocloud/resource_duplo_aws_host.go
@@ -121,8 +121,8 @@ func nativeHostSchema() map[string]*schema.Schema {
 			Description: "The numeric ID of the keypair type being used." +
 				"Should be one of:\n\n" +
 				"   - `0` : Default\n" +
-				"   - `1` : ED25519\n" +
-				"   - `2` : RSA (deprecated - some operating systems no longer support it)\n",
+				"   - `1` : RSA (deprecated - some operating systems no longer support it)\n" +
+				"   - `2` : ED25519\n",
 			Type:     schema.TypeInt,
 			Optional: true,
 			Computed: true,


### PR DESCRIPTION
## Overview

Document update
## Summary of changes
Enum representation fix
This PR does the following:

- Updated document for keypair_type for its representation
- ...

## Testing performed

- [ ] Using unit tests
- [✔︎ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
