### PR TITLE
DUPLO-36573 TF: Updating requires_compatibilities field does not work, show no changes

### DIFF
--- a/duplocloud/resource_duplo_ecs_task_definition.go
+++ b/duplocloud/resource_duplo_ecs_task_definition.go
@@ -169,11 +169,11 @@ func ecsTaskDefinitionSchema() map[string]*schema.Schema {
 			},
 		},
 		"requires_compatibilities": {
-			Type:             schema.TypeSet,
-			Description:      "Requires compatibilities for running jobs. Such as EC2, FARGATE, EXTERNAL. It varies based on network mode and how AWS maps it. `FARGATE` should be used if network mode is set to `awsvpc`.",
-			Optional:         true,
-			Computed:         true,
-			DiffSuppressFunc: diffSuppressWhenNotCreating,
+			Type:        schema.TypeSet,
+			Description: "Requires compatibilities for running jobs. Such as EC2, FARGATE, EXTERNAL. It varies based on network mode and how AWS maps it. `FARGATE` should be used if network mode is set to `awsvpc`.",
+			Optional:    true,
+			Computed:    true,
+			//	DiffSuppressFunc: diffSuppressWhenNotCreating,
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
 			},
@@ -468,9 +468,16 @@ func flattenEcsTaskDefinition(duplo *duplosdk.DuploEcsTaskDef, d *schema.Resourc
 	d.Set("pid_mode", duplo.PidMode)
 	// stop updating state unitl we have EC2 support
 	if len(duplo.Compatibilities) > 0 {
+		ipRC := d.Get("requires_compatibilities").(*schema.Set)
+		m := map[string]interface{}{}
+		for _, i := range ipRC.List() {
+			m[i.(string)] = struct{}{}
+		}
 		inf := []interface{}{}
 		for _, comp := range duplo.Compatibilities {
-			inf = append(inf, comp)
+			if _, ok := m[comp]; ok {
+				inf = append(inf, comp)
+			}
 		}
 		d.Set("requires_compatibilities", inf)
 	}

--- a/duplocloud/resource_duplo_ecs_task_definition.go
+++ b/duplocloud/resource_duplo_ecs_task_definition.go
@@ -475,7 +475,11 @@ func flattenEcsTaskDefinition(duplo *duplosdk.DuploEcsTaskDef, d *schema.Resourc
 		}
 		inf := []interface{}{}
 		for _, comp := range duplo.Compatibilities {
-			if _, ok := m[comp]; ok {
+			if len(m) > 0 {
+				if _, ok := m[comp]; ok {
+					inf = append(inf, comp)
+				}
+			} else {
 				inf = append(inf, comp)
 			}
 		}


### PR DESCRIPTION
## Overview

Fixed no change issue
## Summary of changes

This PR does the following:

- Filter and setting the field since AWS auto manages the requires_compatibilities
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
