### PR TITLE
support for edition field

### DIFF
--- a/docs/resources/gcp_sql_database_instance.md
+++ b/docs/resources/gcp_sql_database_instance.md
@@ -58,6 +58,7 @@ resource "duplocloud_gcp_sql_database_instance" "sql" {
 
 - `database_flag` (Block List) List of database flags to be set on the database instance. Please refer to the [Database Flags Documentation](https://cloud.google.com/sql/docs/mysql/flags) for more details on available flags. (see [below for nested schema](#nestedblock--database_flag))
 - `disk_size` (Number) The size of data disk, in GB. Size of a running instance cannot be reduced but can be increased. The minimum value is 10GB.
+- `edition` (String) Edition for the database. Valid value ENTERPRISE, ENTERPRISE_PLUS Defaults to `ENTERPRISE`.
 - `labels` (Map of String) Map of string keys and values that can be used to organize and categorize this resource.
 - `need_backup` (Boolean) Flag to enable backup process on delete of database Defaults to `true`.
 - `root_password` (String) Provide root password for specific database versions.

--- a/duplocloud/resource_duplo_gcp_sql_database.go
+++ b/duplocloud/resource_duplo_gcp_sql_database.go
@@ -119,6 +119,14 @@ func gcpSqlDBInstanceSchema() map[string]*schema.Schema {
 				},
 			},
 		},
+		"edition": {
+			Description:  "Edition for the database. Valid value ENTERPRISE, ENTERPRISE_PLUS",
+			Type:         schema.TypeString,
+			Optional:     true,
+			Default:      "ENTERPRISE",
+			ValidateFunc: validation.StringInSlice([]string{"ENTERPRISE", "ENTERPRISE_PLUS"}, false),
+			ForceNew:     true,
+		},
 	}
 }
 
@@ -344,6 +352,7 @@ func flattenGcpSqlDBInstance(d *schema.ResourceData, tenantID string, name strin
 	flattenGcpLabels(d, duplo.Labels)
 	flattenIPAddress(d, duplo.IPAddress)
 	flattenDatabasFlags(d, duplo.DatabaseFlags)
+	d.Set("edition", duplo.Edition)
 
 }
 
@@ -355,6 +364,7 @@ func expandGcpSqlDBInstance(d *schema.ResourceData) *duplosdk.DuploGCPSqlDBInsta
 		DataDiskSizeGb:  d.Get("disk_size").(int),
 		ResourceType:    duplosdk.DuploGCPDatabaseInstanceResourceType,
 		RootPassword:    d.Get("root_password").(string),
+		Edition:         d.Get("edition").(string),
 	}
 	if v, ok := d.GetOk("labels"); ok && !isInterfaceNil(v) {
 		rq.Labels = map[string]string{}

--- a/duplosdk/gcp_sql_database.go
+++ b/duplosdk/gcp_sql_database.go
@@ -21,6 +21,7 @@ type DuploGCPSqlDBInstance struct {
 	IPAddress       []string                    `json:"IpAddress,omitempty"`
 	ConnectionName  string                      `json:"ConnectionName,omitempty"`
 	DatabaseFlags   []DuploGCPSqlDBInstanceFlag `json:"DatabaseFlags"`
+	Edition         string                      `json:"Edition"`
 }
 
 type DuploGCPSqlDBInstanceFlag struct {


### PR DESCRIPTION
## Overview

Field support
## Summary of changes
A new field edition added to duplocloud_gcp_sql_database_instance resource
This PR does the following:

- Added optional forcenew field edition with default value ENTERPRISE
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- ...
