### PR TITLE
DUPLO-41753 [Master/Release_nov_2025]:TF: ASG: Unable to add tags to ASG with resource 'duplocloud_aws_tag'  and getting - "Message":"Could not find Tags for resource with ARN

### DIFF
--- a/docs/resources/aws_tag.md
+++ b/docs/resources/aws_tag.md
@@ -20,7 +20,7 @@ description: |-
 
 ### Required
 
-- `arn` (String) The resource ARN of which custom tag need to be created. **Note:** ASG (Auto Scaling Group) ARNs are not supported.
+- `arn` (String) The resource ARN on which a custom tag needs to be created. **Note:** ASG (Auto Scaling Group) ARNs are not supported.
 - `key` (String) The tag name.
 - `tenant_id` (String) The GUID of the tenant that the custom tag for a resource will be created in.
 - `value` (String) The value of the tag.

--- a/docs/resources/aws_tag.md
+++ b/docs/resources/aws_tag.md
@@ -4,11 +4,14 @@ page_title: "duplocloud_aws_tag Resource - terraform-provider-duplocloud"
 subcategory: ""
 description: |-
   duplocloud_aws_tag manages an AWS custom tag for resources in Duplo.
+  ~> Note: AWS Auto Scaling Group (ASG) resources are not supported by this resource. The underlying bulk tagging API does not support ASG ARNs. To tag ASG resources, use the minion_tags attribute in duplocloud_asg_profile instead.
 ---
 
 # duplocloud_aws_tag (Resource)
 
 `duplocloud_aws_tag` manages an AWS custom tag for resources in Duplo.
+
+~> **Note:** AWS Auto Scaling Group (ASG) resources are **not supported** by this resource. The underlying bulk tagging API does not support ASG ARNs. To tag ASG resources, use the `minion_tags` attribute in `duplocloud_asg_profile` instead.
 
 
 
@@ -17,7 +20,7 @@ description: |-
 
 ### Required
 
-- `arn` (String) The resource arn of which custom tag need to be created.
+- `arn` (String) The resource ARN of which custom tag need to be created. **Note:** ASG (Auto Scaling Group) ARNs are not supported.
 - `key` (String) The tag name.
 - `tenant_id` (String) The GUID of the tenant that the custom tag for a resource will be created in.
 - `value` (String) The value of the tag.

--- a/duplocloud/resource_duplo_aws_tag.go
+++ b/duplocloud/resource_duplo_aws_tag.go
@@ -25,7 +25,7 @@ func duploAwsTagSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.IsUUID,
 		},
 		"arn": {
-			Description: "The resource arn of which custom tag need to be created.",
+			Description: "The resource ARN of which custom tag need to be created. **Note:** ASG (Auto Scaling Group) ARNs are not supported.",
 			Type:        schema.TypeString,
 			ForceNew:    true,
 			Required:    true,
@@ -46,7 +46,7 @@ func duploAwsTagSchema() map[string]*schema.Schema {
 
 func resourceAwsCustomTag() *schema.Resource {
 	return &schema.Resource{
-		Description: "`duplocloud_aws_tag` manages an AWS custom tag for resources in Duplo.",
+		Description: "`duplocloud_aws_tag` manages an AWS custom tag for resources in Duplo.\n\n~> **Note:** AWS Auto Scaling Group (ASG) resources are **not supported** by this resource. The underlying bulk tagging API does not support ASG ARNs. To tag ASG resources, use the `minion_tags` attribute in `duplocloud_asg_profile` instead.",
 
 		ReadContext:   resourceAwsTagRead,
 		CreateContext: resourceAwsTagCreate,


### PR DESCRIPTION
## ClickUp Ticket


**DUPLO-41753: https://app.clickup.com/t/8655600/DUPLO-41753**

## Overview
AWS tag resource does not support tags for asg
## Summary of changes

This PR does the following:

- Document update
- ...

## Testing performed

- [ ] Using unit tests
- [ ✔︎] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
