### PR TITLE
DUPLO-41800 TF: Resource 'duplocloud_aws_cloudfront_distribution_v2' shows diff on 'cors_allowed_host_names' in case of re-plan after import

### DIFF
--- a/duplocloud/resource_duplo_aws_cloudfront_distribution_v2.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution_v2.go
@@ -856,14 +856,6 @@ func resourceAwsCloudfrontDistributionV2Read(ctx context.Context, d *schema.Reso
 		d.SetId("")
 		return nil
 	}
-	if len(duplo.Distribution.DistributionConfig.CorsAllowedHostNames) == 0 && d.Get("cors_allowed_host_names") != nil {
-		corsAllowedHostNames := []string{}
-
-		for _, v := range d.Get("cors_allowed_host_names").([]interface{}) {
-			corsAllowedHostNames = append(corsAllowedHostNames, v.(string))
-		}
-		duplo.Distribution.DistributionConfig.CorsAllowedHostNames = corsAllowedHostNames
-	}
 	flattenAwsCloudfrontDistributionV2(d, duplo.Distribution.DistributionConfig)
 	d.Set("status", duplo.Distribution.Status)
 	d.Set("domain_name", duplo.Distribution.DomainName)
@@ -872,8 +864,53 @@ func resourceAwsCloudfrontDistributionV2Read(ctx context.Context, d *schema.Reso
 	d.Set("tenant_id", tenantID)
 	d.Set("hosted_zone_id", duplosdk.CloudFrontRoute53ZoneID)
 	d.Set("name", name)
+
+	// Infer use_origin_access_control: true when any S3 origin has an OAC configured.
+	// The backend does not return UseOAIIdentity in the GET response; it is stored as
+	// S3 bucket metadata and reflected in the origins' OriginAccessControlId field.
+	useOAC := false
+	if duplo.Distribution.DistributionConfig.Origins != nil && duplo.Distribution.DistributionConfig.Origins.Items != nil {
+		for _, origin := range *duplo.Distribution.DistributionConfig.Origins.Items {
+			if origin.OriginAccessControlId != "" {
+				useOAC = true
+				break
+			}
+		}
+	}
+	d.Set("use_origin_access_control", useOAC)
+
+	// Read cors_allowed_host_names from the S3 origin bucket.
+	// The backend stores CORS settings on the bucket (not in CloudFront) and does not
+	// include them in the CloudFront GET response, so we fetch them directly from S3.
+	if duplo.Distribution.DistributionConfig.Origins != nil && duplo.Distribution.DistributionConfig.Origins.Items != nil {
+		for _, origin := range *duplo.Distribution.DistributionConfig.Origins.Items {
+			bucketFullname := cloudfrontS3BucketFullnameFromDomainName(origin.DomainName)
+			if bucketFullname == "" {
+				continue
+			}
+			bucket, bucketErr := c.TenantGetV3S3Bucket(tenantID, bucketFullname)
+			if bucketErr != nil || bucket == nil {
+				log.Printf("[WARN] resourceAwsCloudfrontDistributionV2Read(%s, %s): could not retrieve S3 bucket %s for CORS: %v", tenantID, cfdId, bucketFullname, bucketErr)
+				continue
+			}
+			if len(bucket.CorsAllowedHostNames) > 0 {
+				d.Set("cors_allowed_host_names", bucket.CorsAllowedHostNames)
+			}
+			break
+		}
+	}
+
 	log.Printf("[TRACE] resourceAwsCloudfrontDistributionRead(%s, %s): end", tenantID, cfdId)
 	return nil
+}
+
+// cloudfrontS3BucketFullnameFromDomainName extracts the S3 bucket full name from a CloudFront
+// origin domain name of the form "{fullname}.s3.{region}.amazonaws.com".
+func cloudfrontS3BucketFullnameFromDomainName(domainName string) string {
+	if idx := strings.Index(domainName, ".s3."); idx > 0 {
+		return domainName[:idx]
+	}
+	return ""
 }
 
 func resourceAwsCloudfrontDistributionV2Create(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -1117,16 +1154,8 @@ func flattenAwsCloudfrontDistributionV2(d *schema.ResourceData, duplo *duplosdk.
 		d.Set("origin_group", flattenOriginGroups(duplo.OriginGroups))
 	}
 
-	if len(duplo.CorsAllowedHostNames) > 0 {
-		corsList := make([]interface{}, len(duplo.CorsAllowedHostNames))
-		for i, v := range duplo.CorsAllowedHostNames {
-			corsList[i] = v
-		}
-
-		d.Set("cors_allowed_host_names", corsList)
-	} else {
-		d.Set("cors_allowed_host_names", nil)
-	}
+	// cors_allowed_host_names is set by resourceAwsCloudfrontDistributionV2Read from the S3 bucket,
+	// not from the CloudFront GET response (the backend does not include it there).
 	d.Set("fullname", duplo.Comment)
 
 }

--- a/duplosdk/aws_cloudfront_distribution.go
+++ b/duplosdk/aws_cloudfront_distribution.go
@@ -113,15 +113,16 @@ type DuploAwsCloudfrontOriginShield struct {
 }
 
 type DuploAwsCloudfrontOrigin struct {
-	ConnectionAttempts int                                    `json:"ConnectionAttempts,omitempty"`
-	ConnectionTimeout  int                                    `json:"ConnectionTimeout,omitempty"`
-	CustomHeaders      *DuploAwsCloudfrontOriginCustomHeaders `json:"CustomHeaders,omitempty"`
-	DomainName         string                                 `json:"DomainName,omitempty"`
-	Id                 string                                 `json:"Id,omitempty"`
-	OriginPath         string                                 `json:"OriginPath"`
-	S3OriginConfig     *DuploAwsCloudfrontOriginS3Config      `json:"S3OriginConfig,omitempty"`
-	CustomOriginConfig *DuploAwsCloudfrontCustomOriginConfig  `json:"CustomOriginConfig,omitempty"`
-	OriginShield       *DuploAwsCloudfrontOriginShield        `json:"OriginShield,omitempty"`
+	ConnectionAttempts    int                                    `json:"ConnectionAttempts,omitempty"`
+	ConnectionTimeout     int                                    `json:"ConnectionTimeout,omitempty"`
+	CustomHeaders         *DuploAwsCloudfrontOriginCustomHeaders `json:"CustomHeaders,omitempty"`
+	DomainName            string                                 `json:"DomainName,omitempty"`
+	Id                    string                                 `json:"Id,omitempty"`
+	OriginPath            string                                 `json:"OriginPath"`
+	S3OriginConfig        *DuploAwsCloudfrontOriginS3Config      `json:"S3OriginConfig,omitempty"`
+	CustomOriginConfig    *DuploAwsCloudfrontCustomOriginConfig  `json:"CustomOriginConfig,omitempty"`
+	OriginShield          *DuploAwsCloudfrontOriginShield        `json:"OriginShield,omitempty"`
+	OriginAccessControlId string                                 `json:"OriginAccessControlId,omitempty"`
 }
 
 type DuploAwsCloudfrontOriginCustomHeaders struct {

--- a/duplosdk/tenant_aws_cloud_resources.go
+++ b/duplosdk/tenant_aws_cloud_resources.go
@@ -79,18 +79,19 @@ type DuploS3Bucket struct {
 	// NOTE: The TenantID field does not come from the backend - we synthesize it
 	TenantID string `json:"-"`
 
-	Name              string                 `json:"Name,omitempty"`
-	DomainName        string                 `json:"DomainName,omitempty"`
-	Region            string                 `json:"Region,omitempty"`
-	Location          string                 `json:"Location,omitempty"`
-	Arn               string                 `json:"Arn,omitempty"`
-	MetaData          string                 `json:"MetaData,omitempty"`
-	EnableVersioning  bool                   `json:"EnableVersioning,omitempty"`
-	EnableAccessLogs  bool                   `json:"EnableAccessLogs,omitempty"`
-	AllowPublicAccess bool                   `json:"AllowPublicAccess,omitempty"`
-	DefaultEncryption string                 `json:"DefaultEncryption,omitempty"`
-	Policies          []string               `json:"Policies,omitempty"`
-	Tags              *[]DuploKeyStringValue `json:"Tags,omitempty"`
+	Name                 string                 `json:"Name,omitempty"`
+	DomainName           string                 `json:"DomainName,omitempty"`
+	Region               string                 `json:"Region,omitempty"`
+	Location             string                 `json:"Location,omitempty"`
+	Arn                  string                 `json:"Arn,omitempty"`
+	MetaData             string                 `json:"MetaData,omitempty"`
+	EnableVersioning     bool                   `json:"EnableVersioning,omitempty"`
+	EnableAccessLogs     bool                   `json:"EnableAccessLogs,omitempty"`
+	AllowPublicAccess    bool                   `json:"AllowPublicAccess,omitempty"`
+	DefaultEncryption    string                 `json:"DefaultEncryption,omitempty"`
+	Policies             []string               `json:"Policies,omitempty"`
+	Tags                 *[]DuploKeyStringValue `json:"Tags,omitempty"`
+	CorsAllowedHostNames []string               `json:"CorsAllowedHostNames,omitempty"`
 }
 
 type DuploGCPBucket struct {


### PR DESCRIPTION
## ClickUp Ticket


**ClickUp Ticket ID: [DUPLO-41800](https://app.clickup.com/t/86afq1nw1)**

## Overview
duplocloud_aws_cloudfront_distribution_v2 shows a perpetual diff on cors_allowed_host_names and use_origin_access_control after a terraform import followed by a re-plan. The backend does not return either of these values in the CloudFront GET response — they are stored as S3 bucket metadata and origin-level OAC configuration respectively.

## Summary of changes

This PR does the following:

- Removed incorrect state hack in resourceAwsCloudfrontDistributionV2Read that attempted to preserve cors_allowed_host_names by copying prior state back into the distribution config — this masked the root cause and caused drift on import.
- Added OriginAccessControlId to DuploAwsCloudfrontOrigin SDK struct so the field is deserialized from the CloudFront GET response. use_origin_access_control is now correctly inferred by checking whether any S3 origin has a non-empty OriginAccessControlId.
- Added CorsAllowedHostNames to DuploS3Bucket SDK struct and added a direct S3 bucket lookup in the Read function to retrieve CORS hosts from the origin bucket. This is the authoritative source for this field since the backend stores it on the bucket, not in the CloudFront config.
- Removed the else { d.Set("cors_allowed_host_names", nil) } branch from flattenAwsCloudfrontDistributionV2 — CORS is now set exclusively from the S3 bucket lookup in the Read function.
- Added cloudfrontS3BucketFullnameFromDomainName helper to extract the bucket name from a CloudFront origin domain name.
## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ✔︎] Manually, on a remote test system

## Describe any breaking changes

- ...
