### PR TITLE
DUPLO-42023 TF: SQS name validation is incorrect when AWS_SERVICES_TAG_BASED_OWNERSHIP_ENABLED is enabled

### DIFF
--- a/duplocloud/resource_duplo_aws_sqs_queue.go
+++ b/duplocloud/resource_duplo_aws_sqs_queue.go
@@ -409,7 +409,7 @@ func validateSQSName(c *duplosdk.Client, tId, name string, fifo bool) error {
 	} else {
 		rp, cerr := c.TenantGetV2(tId)
 		if cerr != nil {
-			return fmt.Errorf("%s", cerr.Error())
+			return fmt.Errorf("failed to get tenant %s: %w", tId, cerr)
 		}
 		allowedLen = 80 - (15 + len([]rune(rp.AccountName)) - 1)
 		if fifo {

--- a/duplocloud/resource_duplo_aws_sqs_queue.go
+++ b/duplocloud/resource_duplo_aws_sqs_queue.go
@@ -394,14 +394,30 @@ func parseAwsSqsQueueIdParts(id string) (tenantID, url string, err error) {
 }
 
 func validateSQSName(c *duplosdk.Client, tId, name string, fifo bool) error {
-	rp, cerr := c.TenantGetV2(tId)
-	if cerr != nil {
-		return fmt.Errorf("%s", cerr.Error())
-	}
-	allowedLen := 80 - (15 + len([]rune(rp.AccountName)) - 1)
+	var allowedLen int
+	var errMsg string
 
-	if fifo {
-		allowedLen = allowedLen - len([]rune(".fifo"))
+	if c.IsAwsServiceTagBasedOwnershipEnabled("sqs") {
+		// Tag-based ownership: no prefix is added by the system; the user-supplied name is the full SQS queue name.
+		allowedLen = 79 // allows 1 + {0,79} = max 80 chars
+		if fifo {
+			allowedLen = allowedLen - len([]rune(".fifo"))
+			errMsg = fmt.Sprintf("invalid name format. Queue name must start with a letter, contain only letters, numbers, underscores, or hyphens, and be at most %d characters (%d total including the .fifo suffix)", 1+allowedLen, 1+allowedLen+len(".fifo"))
+		} else {
+			errMsg = fmt.Sprintf("invalid name format. Queue name must start with a letter, contain only letters, numbers, underscores, or hyphens, and be at most %d characters", 1+allowedLen)
+		}
+	} else {
+		rp, cerr := c.TenantGetV2(tId)
+		if cerr != nil {
+			return fmt.Errorf("%s", cerr.Error())
+		}
+		allowedLen = 80 - (15 + len([]rune(rp.AccountName)) - 1)
+		if fifo {
+			allowedLen = allowedLen - len([]rune(".fifo"))
+			errMsg = fmt.Sprintf("invalid name format. Queue name must start with a letter, contain only letters, numbers, underscores, or hyphens, and be at most %d characters — total length including the system-added prefix (duploservices-%s-) and .fifo suffix must not exceed 80 characters", 1+allowedLen, rp.AccountName)
+		} else {
+			errMsg = fmt.Sprintf("invalid name format. Queue name must start with a letter, contain only letters, numbers, underscores, or hyphens, and be at most %d characters — total length including the system-added prefix (duploservices-%s-) must not exceed 80 characters", 1+allowedLen, rp.AccountName)
+		}
 	}
 	regString := "^[a-zA-Z][a-zA-Z0-9_-]{0," + strconv.Itoa(allowedLen) + "}$"
 	b, err := regexp.MatchString(regString, name)
@@ -410,7 +426,7 @@ func validateSQSName(c *duplosdk.Client, tId, name string, fifo bool) error {
 	}
 
 	if !b {
-		return fmt.Errorf("invalid name format. Queue names must be made up of only uppercase and lowercase ASCII letters, numbers, underscores, and hyphens, and have up to 80 characters long which is inclusive of duplo prefix (duploservices-{tenant_name}-) added by the system")
+		return fmt.Errorf("%s", errMsg)
 	}
 	return nil
 }

--- a/duplosdk/admin.go
+++ b/duplosdk/admin.go
@@ -40,7 +40,6 @@ type DuploSystemFeatures struct {
 	DefaultInfraCloud                   string                          `json:"DefaultInfraCloud"`
 	TagsBasedManagedResources           []string                        `json:"TagsBasedManagedResources"`
 	ResourceNamePrefix                  string                          `json:"ResourceNamePrefix"`
-	AwsServicesTagBasedOwnershipEnabled []string                        `json:"AwsServicesTagBasedOwnershipEnabled"`
 }
 
 type DuploSystemFeaturesAppConfigs struct {
@@ -107,18 +106,33 @@ func (c *Client) IsAzureCustomPrefixesEnabled() bool {
 	return true
 }
 
+// awsTagBasedOwnershipMap parses the AppConfigs entry AWS_SERVICES_TAG_BASED_OWNERSHIP_ENABLED
+// (semicolon-delimited, e.g. "sqs;secretsmanager") into a lowercase map for O(1) lookup.
+func awsTagBasedOwnershipMap(configs []DuploSystemFeaturesAppConfigs) map[string]struct{} {
+	m := make(map[string]struct{})
+	for _, cfg := range configs {
+		if cfg.Key == "AWS_SERVICES_TAG_BASED_OWNERSHIP_ENABLED" {
+			for _, s := range strings.Split(cfg.Value, ";") {
+				s = strings.TrimSpace(s)
+				if s != "" {
+					m[strings.ToLower(s)] = struct{}{}
+				}
+			}
+			break
+		}
+	}
+	return m
+}
+
 func (c *Client) IsAwsServiceTagBasedOwnershipEnabled(service string) bool {
 	features := DuploSystemFeatures{}
 	err := c.getAPI("AdminGetSystemFeatures()", "v3/features/system", &features)
 	if err != nil {
 		return false
 	}
-	for _, s := range features.AwsServicesTagBasedOwnershipEnabled {
-		if strings.EqualFold(s, service) {
-			return true
-		}
-	}
-	return false
+	enabled := awsTagBasedOwnershipMap(features.AppConfigs)
+	_, ok := enabled[strings.ToLower(service)]
+	return ok
 }
 
 func (c *Client) getPrefixFromResourceType(resourceType string, isInfraResource bool) (string, error) {

--- a/duplosdk/admin.go
+++ b/duplosdk/admin.go
@@ -21,25 +21,25 @@ type DuploSystemFeatures struct {
 		DefaultVersion    string   `json:"DefaultVersion"`
 		SupportedVersions []string `json:"SupportedVersions"`
 	} `json:"EksVersions"`
-	IsOtpNeeded                         bool                            `json:"IsOtpNeeded"`
-	IsAwsAdminJITEnabled                bool                            `json:"IsAwsAdminJITEnabled"`
-	IsDuploOpsEnabled                   bool                            `json:"IsDuploOpsEnabled"`
-	IsTagsBasedResourceMgmtEnabled      bool                            `json:"IsTagsBasedResourceMgmtEnabled"`
-	DevopsManagerHostname               string                          `json:"DevopsManagerHostname"`
-	TenantNameMaxLength                 int                             `json:"TenantNameMaxLength"`
-	AzureResourcePrefix                 *AzureResourcePrefix            `json:"AzureResourcePrefix,omitempty"`
-	S3BucketNamePrefix                  string                          `json:"S3BucketNamePrefix"`
-	GcpDisableTenantPrefix              bool                            `json:"GcpDisableTenantPrefix"`
-	GcpDisableDuploPrefix               bool                            `json:"GcpDisableDuploPrefix"`
-	IsOnPremEnabled                     bool                            `json:"IsOnPremEnabled"`
-	DefaultAwsPartition                 string                          `json:"DefaultAwsPartition"`
-	DuploShellFqdn                      string                          `json:"DuploShellFqdn"`
-	EnabledFlags                        []string                        `json:"EnabledFlags"`
-	AppConfigs                          []DuploSystemFeaturesAppConfigs `json:"AppConfigs"`
-	DisableOobData                      bool                            `json:"DisableOobData"`
-	DefaultInfraCloud                   string                          `json:"DefaultInfraCloud"`
-	TagsBasedManagedResources           []string                        `json:"TagsBasedManagedResources"`
-	ResourceNamePrefix                  string                          `json:"ResourceNamePrefix"`
+	IsOtpNeeded                    bool                            `json:"IsOtpNeeded"`
+	IsAwsAdminJITEnabled           bool                            `json:"IsAwsAdminJITEnabled"`
+	IsDuploOpsEnabled              bool                            `json:"IsDuploOpsEnabled"`
+	IsTagsBasedResourceMgmtEnabled bool                            `json:"IsTagsBasedResourceMgmtEnabled"`
+	DevopsManagerHostname          string                          `json:"DevopsManagerHostname"`
+	TenantNameMaxLength            int                             `json:"TenantNameMaxLength"`
+	AzureResourcePrefix            *AzureResourcePrefix            `json:"AzureResourcePrefix,omitempty"`
+	S3BucketNamePrefix             string                          `json:"S3BucketNamePrefix"`
+	GcpDisableTenantPrefix         bool                            `json:"GcpDisableTenantPrefix"`
+	GcpDisableDuploPrefix          bool                            `json:"GcpDisableDuploPrefix"`
+	IsOnPremEnabled                bool                            `json:"IsOnPremEnabled"`
+	DefaultAwsPartition            string                          `json:"DefaultAwsPartition"`
+	DuploShellFqdn                 string                          `json:"DuploShellFqdn"`
+	EnabledFlags                   []string                        `json:"EnabledFlags"`
+	AppConfigs                     []DuploSystemFeaturesAppConfigs `json:"AppConfigs"`
+	DisableOobData                 bool                            `json:"DisableOobData"`
+	DefaultInfraCloud              string                          `json:"DefaultInfraCloud"`
+	TagsBasedManagedResources      []string                        `json:"TagsBasedManagedResources"`
+	ResourceNamePrefix             string                          `json:"ResourceNamePrefix"`
 }
 
 type DuploSystemFeaturesAppConfigs struct {

--- a/duplosdk/admin.go
+++ b/duplosdk/admin.go
@@ -21,25 +21,26 @@ type DuploSystemFeatures struct {
 		DefaultVersion    string   `json:"DefaultVersion"`
 		SupportedVersions []string `json:"SupportedVersions"`
 	} `json:"EksVersions"`
-	IsOtpNeeded                    bool                            `json:"IsOtpNeeded"`
-	IsAwsAdminJITEnabled           bool                            `json:"IsAwsAdminJITEnabled"`
-	IsDuploOpsEnabled              bool                            `json:"IsDuploOpsEnabled"`
-	IsTagsBasedResourceMgmtEnabled bool                            `json:"IsTagsBasedResourceMgmtEnabled"`
-	DevopsManagerHostname          string                          `json:"DevopsManagerHostname"`
-	TenantNameMaxLength            int                             `json:"TenantNameMaxLength"`
-	AzureResourcePrefix            *AzureResourcePrefix            `json:"AzureResourcePrefix,omitempty"`
-	S3BucketNamePrefix             string                          `json:"S3BucketNamePrefix"`
-	GcpDisableTenantPrefix         bool                            `json:"GcpDisableTenantPrefix"`
-	GcpDisableDuploPrefix          bool                            `json:"GcpDisableDuploPrefix"`
-	IsOnPremEnabled                bool                            `json:"IsOnPremEnabled"`
-	DefaultAwsPartition            string                          `json:"DefaultAwsPartition"`
-	DuploShellFqdn                 string                          `json:"DuploShellFqdn"`
-	EnabledFlags                   []string                        `json:"EnabledFlags"`
-	AppConfigs                     []DuploSystemFeaturesAppConfigs `json:"AppConfigs"`
-	DisableOobData                 bool                            `json:"DisableOobData"`
-	DefaultInfraCloud              string                          `json:"DefaultInfraCloud"`
-	TagsBasedManagedResources      []string                        `json:"TagsBasedManagedResources"`
-	ResourceNamePrefix             string                          `json:"ResourceNamePrefix"`
+	IsOtpNeeded                         bool                            `json:"IsOtpNeeded"`
+	IsAwsAdminJITEnabled                bool                            `json:"IsAwsAdminJITEnabled"`
+	IsDuploOpsEnabled                   bool                            `json:"IsDuploOpsEnabled"`
+	IsTagsBasedResourceMgmtEnabled      bool                            `json:"IsTagsBasedResourceMgmtEnabled"`
+	DevopsManagerHostname               string                          `json:"DevopsManagerHostname"`
+	TenantNameMaxLength                 int                             `json:"TenantNameMaxLength"`
+	AzureResourcePrefix                 *AzureResourcePrefix            `json:"AzureResourcePrefix,omitempty"`
+	S3BucketNamePrefix                  string                          `json:"S3BucketNamePrefix"`
+	GcpDisableTenantPrefix              bool                            `json:"GcpDisableTenantPrefix"`
+	GcpDisableDuploPrefix               bool                            `json:"GcpDisableDuploPrefix"`
+	IsOnPremEnabled                     bool                            `json:"IsOnPremEnabled"`
+	DefaultAwsPartition                 string                          `json:"DefaultAwsPartition"`
+	DuploShellFqdn                      string                          `json:"DuploShellFqdn"`
+	EnabledFlags                        []string                        `json:"EnabledFlags"`
+	AppConfigs                          []DuploSystemFeaturesAppConfigs `json:"AppConfigs"`
+	DisableOobData                      bool                            `json:"DisableOobData"`
+	DefaultInfraCloud                   string                          `json:"DefaultInfraCloud"`
+	TagsBasedManagedResources           []string                        `json:"TagsBasedManagedResources"`
+	ResourceNamePrefix                  string                          `json:"ResourceNamePrefix"`
+	AwsServicesTagBasedOwnershipEnabled []string                        `json:"AwsServicesTagBasedOwnershipEnabled"`
 }
 
 type DuploSystemFeaturesAppConfigs struct {
@@ -104,6 +105,20 @@ func (c *Client) IsAzureCustomPrefixesEnabled() bool {
 		return false
 	}
 	return true
+}
+
+func (c *Client) IsAwsServiceTagBasedOwnershipEnabled(service string) bool {
+	features := DuploSystemFeatures{}
+	err := c.getAPI("AdminGetSystemFeatures()", "v3/features/system", &features)
+	if err != nil {
+		return false
+	}
+	for _, s := range features.AwsServicesTagBasedOwnershipEnabled {
+		if strings.EqualFold(s, service) {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *Client) getPrefixFromResourceType(resourceType string, isInfraResource bool) (string, error) {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-42023](https://app.clickup.com/t/8655600/DUPLO-42023)

## Overview

SQS queue name validation was incorrectly applying the `duploservices-{tenant_name}-` prefix
length deduction even when the system feature `AWS_SERVICES_TAG_BASED_OWNERSHIP_ENABLED`
includes `sqs`. In that mode the backend does not add any prefix, so the full 80-character
AWS limit should be available to the user.

## Summary of changes

- Added `awsTagBasedOwnershipMap` helper in `duplosdk/admin.go` that reads the
  `AWS_SERVICES_TAG_BASED_OWNERSHIP_ENABLED` value from `AppConfigs`
  (semicolon-delimited, e.g. `sqs;secretsmanager`) and builds a lowercase
  `map[string]struct{}` for O(1) service lookup
- Added `IsAwsServiceTagBasedOwnershipEnabled(service string) bool` method on `Client`
  using the above map
- Updated `validateSQSName` in `resource_duplo_aws_sqs_queue.go` to branch on the system feature:
  - **Tag-based enabled:** allows up to 80 characters (no prefix deducted); tenant name is not part of the queue name
  - **Tag-based disabled:** existing behaviour — deducts `duploservices-{tenant_name}-`
    (15 + tenant name length) from the 80-char limit
- Error messages are now context-aware, showing the actual allowed character count,
  the system prefix, and the `.fifo` suffix where applicable

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None. Existing behaviour for environments without tag-based ownership is unchanged.