### PR TITLE
DUPLO-38134 Terraform provider times out deleting batch job definitions

### DIFF
--- a/duplocloud/resource_duplo_aws_batch_job_definition.go
+++ b/duplocloud/resource_duplo_aws_batch_job_definition.go
@@ -210,7 +210,7 @@ func resourceAwsBatchJobDefinition() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
-			Delete: schema.DefaultTimeout(80 * time.Minute),
+			Delete: schema.DefaultTimeout(120 * time.Minute), // Increased from 80 to 120 minutes for batch job definitions
 		},
 		Schema: duploAwsBatchJobDefinitionSchema(),
 	}
@@ -300,7 +300,15 @@ func resourceAwsBatchJobDefinitionDelete(ctx context.Context, d *schema.Resource
 		return diag.Errorf("Unable to delete tenant %s aws batch Job Definition '%s': %s", tenantID, name, clientErr)
 	}
 
-	diag := waitForResourceToBeMissingAfterDelete(ctx, d, "aws batch Job Definition", id, func() (interface{}, duplosdk.ClientError) {
+	// AWS Batch job definitions may take time to fully propagate deletion across revisions.
+	// Initial wait ensures the deletion API has time to process all revisions and settle.
+	log.Printf("[TRACE] resourceAwsBatchJobDefinitionDelete(%s, %s): waiting 30 seconds for deletion API to process and backend to settle", tenantID, name)
+	time.Sleep(30 * time.Second)
+
+	// Poll for deletion with enhanced retry configuration to handle slow propagation.
+	// This uses exponential backoff with a maximum of 120 minutes timeout as configured in the schema.
+	// Minimal polling interval ensures backend has time to process state changes between API calls.
+	diag := waitForResourceToBeMissingAfterDeleteWithMinInterval(ctx, d, "aws batch Job Definition", id, 15*time.Second, func() (interface{}, duplosdk.ClientError) {
 		return c.AwsBatchJobDefinitionGet(tenantID, fullName)
 	})
 	if diag != nil {

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -585,6 +585,54 @@ func waitForResourceToBeMissingAfterDelete(ctx context.Context, d *schema.Resour
 	return nil
 }
 
+// waitForResourceToBeMissingAfterDeleteWithMinInterval polls for resource deletion with exponential backoff delays.
+// This allows the backend API time to settle and process state changes between consecutive GET calls.
+// The minInterval parameter specifies the minimum time to wait between initial polling attempts.
+// Delay strategy: Keep minInterval for first 2 attempts, then increase by 5 seconds each subsequent attempt
+// to handle slow backend processing (15s → 15s → 20s → 25s → 30s → ...).
+func waitForResourceToBeMissingAfterDeleteWithMinInterval(ctx context.Context, d *schema.ResourceData, kind string, id string, minInterval time.Duration, get func() (interface{}, duplosdk.ClientError)) diag.Diagnostics {
+	var attempt int
+	err := retry.RetryContext(ctx, d.Timeout("delete"), func() *retry.RetryError {
+		attempt++
+
+		// Calculate delay with exponential backoff after first 2 attempts
+		var delay time.Duration
+		if attempt <= 2 {
+			delay = minInterval
+		} else {
+			// Increase by 5 seconds for each attempt after the first 2
+			additionalDelay := time.Duration((attempt-2)*5) * time.Second
+			delay = minInterval + additionalDelay
+		}
+
+		log.Printf("[TRACE] waitForResourceToBeMissingAfterDeleteWithMinInterval: attempt %d, using delay of %d seconds", attempt, int(delay.Seconds()))
+		time.Sleep(delay)
+
+		resp, errget := get()
+
+		if errget != nil {
+			if errget.Status() == 404 || errget.Status() == 400 {
+				return nil
+			}
+
+			return retry.NonRetryableError(fmt.Errorf("error getting %s '%s': %s", kind, id, errget))
+		}
+		if isStructEmpty(resp) {
+			return nil
+		}
+
+		if !isInterfaceNil(resp) {
+			return retry.RetryableError(fmt.Errorf("expected %s '%s' to be missing, but it still exists", kind, id))
+		}
+
+		return nil
+	})
+	if err != nil {
+		return diag.Errorf("error deleting %s '%s': %s", kind, id, err)
+	}
+	return nil
+}
+
 func waitForResourceToBePresentAfterCreate(ctx context.Context, d *schema.ResourceData, kind string, id string, get func() (interface{}, duplosdk.ClientError)) diag.Diagnostics {
 	err := retry.RetryContext(ctx, d.Timeout("create"), func() *retry.RetryError {
 		resp, errget := get()

--- a/duplosdk/aws_batch.go
+++ b/duplosdk/aws_batch.go
@@ -429,10 +429,14 @@ func (c *Client) AwsBatchJobDefinitionDelete(tenantID string, name string) Clien
 
 func (c *Client) AwsBatchJobDefinitionBulkDelete(tenantID string, name string) ClientError {
 	conf := NewRetryConf()
-	conf.MinDelay = 10
-	conf.MaxDelay = 30
-	conf.MinStartingDelay = 3
-	conf.MaxStartingDelay = 10
+	// Enhanced retry configuration for AWS Batch Job Definition deletion
+	// These are slower operations that may take longer to complete
+	conf.RateExceededMaxRetries = 15 // Increased from 9 to 15 for more retry attempts
+	conf.MinDelay = 15               // Increased from 10 to 15 seconds
+	conf.MaxDelay = 60               // Increased from 30 to 60 seconds for longer backoff
+	conf.MinStartingDelay = 5        // Increased from 3 to 5 seconds
+	conf.MaxStartingDelay = 15       // Increased from 10 to 15 seconds
+	conf.MinJitterDelay = 10         // Added jitter for better distribution
 	return c.deleteAPIWithRetry(
 		fmt.Sprintf("AwsBatchJobDefinitionBulkDelete(%s, %s)", tenantID, name),
 		fmt.Sprintf("v3/subscriptions/%s/aws/batchJobDefinition/%s/revisions", tenantID, name),


### PR DESCRIPTION
## ClickUp Ticket

**DUPLO-38134: https://app.clickup.com/t/8655600/DUPLO-38134** 

## Overview

Fix `API_RETRIES: Max retry attempts exceeded` errors during AWS Batch Job Definition deletion by implementing enhanced retry configuration with intelligent backend settling delays and exponential backoff polling strategy.

## Summary of changes

This PR does the following:

- **Enhanced SDK Retry Configuration** (`duplosdk/aws_batch.go`):
  - Increased `RateExceededMaxRetries` from 9 to 15 
  
  ## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None