### PR TITLE
DUPLO-41826 TF: Fix default_version drift on aws_launch_template

### DIFF
--- a/duplocloud/resource_duplo_aws_launch_template.go
+++ b/duplocloud/resource_duplo_aws_launch_template.go
@@ -502,7 +502,9 @@ func flattenLaunchTemplate(d *schema.ResourceData, rp *[]duplosdk.DuploLaunchTem
 		}
 	}
 	d.Set("latest_version", m["latest_version"])
-	d.Set("default_version", m["default_version"])
+	if isDataSource {
+		d.Set("default_version", m["default_version"])
+	}
 	d.Set("ami", m["image_id"])
 	d.Set("block_device_mapping", m["block_device_mapping"])
 	d.Set("instance_requirements", m["instance_requirements"])

--- a/duplocloud/resource_duplo_aws_launch_template.go
+++ b/duplocloud/resource_duplo_aws_launch_template.go
@@ -504,6 +504,8 @@ func flattenLaunchTemplate(d *schema.ResourceData, rp *[]duplosdk.DuploLaunchTem
 	d.Set("latest_version", m["latest_version"])
 	if isDataSource {
 		d.Set("default_version", m["default_version"])
+	} else if v, ok := d.GetOk("default_version"); !ok || v.(string) == "" {
+		d.Set("default_version", m["default_version"])
 	}
 	d.Set("ami", m["image_id"])
 	d.Set("block_device_mapping", m["block_device_mapping"])

--- a/duplocloud/resource_duplo_aws_launch_template.go
+++ b/duplocloud/resource_duplo_aws_launch_template.go
@@ -38,7 +38,7 @@ func awsLaunchTemplateSchema() map[string]*schema.Schema {
 			ForceNew:    true,
 		},
 		"default_version": {
-			Description: "The current default version of the launch template.",
+			Description: "The default version of the launch template at creation time. Use the data source for the current value.",
 			Type:        schema.TypeString,
 			Computed:    true,
 		},


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-41826

## Overview

The `duplocloud_aws_launch_template` resource reports drift on `default_version` when it is changed by the separate `duplocloud_aws_launch_template_default_version` resource between applies.

## Summary of changes

This PR does the following:

- Only set `default_version` from the API response for data sources, not for the resource. This prevents the resource's Read from overwriting the state value when another resource (`duplocloud_aws_launch_template_default_version`) changes the default version between applies.
- Follows the same pattern already used for the `version` attribute on this resource.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None