### PR TITLE
DUPLO-36495 TF: fix apigateway event delete path encoding

### DIFF
--- a/duplosdk/aws_apigateway_events.go
+++ b/duplosdk/aws_apigateway_events.go
@@ -47,7 +47,7 @@ func (c *Client) ApiGatewayEventUpdate(tenantID string, rq *DuploApiGatewayEvent
 func (c *Client) ApiGatewayEventDelete(tenantID, apiGatewayID, method, path string) ClientError {
 	return c.deleteAPI(
 		fmt.Sprintf("ApiGatewayEventDelete(%s, %s)", tenantID, apiGatewayID+"--"+method+"--"+path),
-		fmt.Sprintf("v3/subscriptions/%s/aws/apigateway/events/%s/%s/%s", tenantID, apiGatewayID, method, EncodePathParam(EncodePathParam(path))),
+		fmt.Sprintf("v3/subscriptions/%s/aws/apigateway/events/%s/%s/%s", tenantID, apiGatewayID, method, EncodePathParam(path)),
 		nil)
 }
 


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-36495

## Overview

`ApiGatewayEventDelete` was calling `EncodePathParam(EncodePathParam(path))`, which quadruple-encoded the path (since `EncodePathParam` itself already double-encodes via `url.PathEscape(url.PathEscape(...))`). This caused the DELETE request to hit a wrong URL. The Get and Update methods correctly use a single `EncodePathParam(path)`.

## Summary of changes

This PR does the following:

- Fix `ApiGatewayEventDelete` to use `EncodePathParam(path)` instead of `EncodePathParam(EncodePathParam(path))`, consistent with Get and Update methods

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None