### PR TITLE
DUPLO-40601 TF: fix aws batch compute environment min_vcpus/desired_vcpus drift

### DIFF
--- a/duplocloud/resource_duplo_aws_batch_compute_environment.go
+++ b/duplocloud/resource_duplo_aws_batch_compute_environment.go
@@ -284,7 +284,10 @@ func resourceAwsBatchComputeEnvironment() *schema.Resource {
 		UpdateContext: resourceAwsBatchComputeEnvironmentUpdate,
 		DeleteContext: resourceAwsBatchComputeEnvironmentDelete,
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			StateContext: func(ctx context.Context, d *schema.ResourceData, m interface{}) ([]*schema.ResourceData, error) {
+				d.Set("wait_for_deployment", true)
+				return schema.ImportStatePassthroughContext(ctx, d, m)
+			},
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(30 * time.Minute),
@@ -383,16 +386,14 @@ func resourceAwsBatchComputeEnvironmentUpdate(ctx context.Context, d *schema.Res
 
 		if computeEnvironmentType := strings.ToUpper(d.Get("type").(string)); computeEnvironmentType == "MANAGED" {
 			// "At least one compute-resources attribute must be specified"
+			// Always include min_vcpus and desired_vcpus to prevent the API from
+			// resetting them to 0 when only other fields change. MinvCpus in the
+			// SDK struct has no omitempty, so its Go zero value (0) would be sent
+			// as "MinvCpus":0 if not explicitly set from the config.
 			computeResourceUpdate := &duplosdk.DuploAwsBatchComputeResource{
-				MaxvCpus: d.Get("compute_resources.0.max_vcpus").(int),
-			}
-
-			if d.HasChange("compute_resources.0.desired_vcpus") {
-				computeResourceUpdate.DesiredvCpus = d.Get("compute_resources.0.desired_vcpus").(int)
-			}
-
-			if d.HasChange("compute_resources.0.min_vcpus") {
-				computeResourceUpdate.MinvCpus = d.Get("compute_resources.0.min_vcpus").(int)
+				MaxvCpus:     d.Get("compute_resources.0.max_vcpus").(int),
+				MinvCpus:     d.Get("compute_resources.0.min_vcpus").(int),
+				DesiredvCpus: d.Get("compute_resources.0.desired_vcpus").(int),
 			}
 
 			if d.HasChange("compute_resources.0.security_group_ids") {
@@ -425,7 +426,7 @@ func resourceAwsBatchComputeEnvironmentUpdate(ctx context.Context, d *schema.Res
 			}
 		}
 	}
-	return nil
+	return resourceAwsBatchComputeEnvironmentRead(ctx, d, m)
 }
 
 func resourceAwsBatchComputeEnvironmentDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -573,9 +574,7 @@ func flattenComputeResource(apiObject *duplosdk.DuploAwsBatchComputeResource) ma
 		tfMap["bid_percentage"] = v
 	}
 
-	if v := apiObject.DesiredvCpus; v > 0 {
-		tfMap["desired_vcpus"] = v
-	}
+	tfMap["desired_vcpus"] = apiObject.DesiredvCpus
 
 	if v := apiObject.Ec2Configuration; v != nil && len(*v) > 0 {
 		tfMap["ec2_configuration"] = flattenEC2Configurations(v)
@@ -605,9 +604,7 @@ func flattenComputeResource(apiObject *duplosdk.DuploAwsBatchComputeResource) ma
 		tfMap["max_vcpus"] = v
 	}
 
-	if v := apiObject.MinvCpus; v > 0 {
-		tfMap["min_vcpus"] = v
-	}
+	tfMap["min_vcpus"] = apiObject.MinvCpus
 
 	if v := apiObject.SecurityGroupIds; len(v) > 0 {
 		tfMap["security_group_ids"] = v

--- a/duplocloud/resource_duplo_aws_batch_compute_environment.go
+++ b/duplocloud/resource_duplo_aws_batch_compute_environment.go
@@ -219,6 +219,7 @@ func duploAwsBatchComputeEnvironmentSchema() map[string]*schema.Schema {
 						Description: "The minimum number of EC2 vCPUs that an environment should maintain. For `EC2` or `SPOT` compute environments, if the parameter is not explicitly defined, a `0` default value will be set. This parameter isn't applicable to jobs running on Fargate resources, and shouldn't be specified.",
 						Type:        schema.TypeInt,
 						Optional:    true,
+						Computed:    true,
 					},
 					"security_group_ids": {
 						Description: "A list of EC2 security group that are associated with instances launched in the compute environment. This parameter is required for Fargate compute environments.",


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-40601](https://app.clickup.com/t/8655600/DUPLO-40601)

## Overview

Fix persistent drift where `min_vcpus` and `desired_vcpus` reset to 0 after updating an AWS Batch compute environment.

## Summary of changes

This PR does the following:

- Always include `min_vcpus` and `desired_vcpus` in the update payload instead of only when `HasChange` is true, preventing the API from receiving `MinvCpus: 0` (Go zero value) when only other fields change
- Always set `min_vcpus` and `desired_vcpus` in the flatten function regardless of value, since 0 is a valid value
- Call Read at the end of Update to refresh state after the update
- Set `wait_for_deployment` default in the import StateContext to prevent import drift

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None