### PR TITLE
DUPLO-37126 Redis:Seondary cluster fails with fault-AwsClient: US West (Oregon) (us-west-2) ECache Client: Failed to create a ECache DB Instance When using automatic failover, there must be at least 2 cache clusters in the replication group.

### DIFF
--- a/docs/resources/aws_launch_template.md
+++ b/docs/resources/aws_launch_template.md
@@ -86,7 +86,7 @@ resource "duplocloud_aws_launch_template" "template" {
 
 ### Read-Only
 
-- `default_version` (String) The current default version of the launch template.
+- `default_version` (String) The default version of the launch template at creation time. Use the data source for the current value.
 - `id` (String) The ID of this resource.
 - `latest_version` (String) The latest launch template version
 - `version_metadata` (String)

--- a/docs/resources/aws_tag.md
+++ b/docs/resources/aws_tag.md
@@ -20,7 +20,7 @@ description: |-
 
 ### Required
 
-- `arn` (String) The resource ARN on which a custom tag needs to be created. **Note:** ASG (Auto Scaling Group) ARNs are not supported.
+- `arn` (String) The resource ARN of which custom tag need to be created. **Note:** ASG (Auto Scaling Group) ARNs are not supported.
 - `key` (String) The tag name.
 - `tenant_id` (String) The GUID of the tenant that the custom tag for a resource will be created in.
 - `value` (String) The value of the tag.

--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -202,7 +202,7 @@ Should be one of:
    - `2` : Valkey
 
  Defaults to `0`.
-- `enable_cluster_mode` (Boolean) Flag to enable/disable redis/valkey cluster mode.
+- `enable_cluster_mode` (Boolean) Flag to enable/disable redis/valkey cluster mode. Cluster mode should be enabled if the instance acts as the primary for a global datastore.
 - `encryption_at_rest` (Boolean) Enables encryption-at-rest. Defaults to `false`.
 - `encryption_in_transit` (Boolean) Enables encryption-in-transit. Defaults to `false`.
 - `engine_version` (String) The engine version of the elastic instance.

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -166,7 +166,7 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			Optional:    true,
 		},
 		"enable_cluster_mode": {
-			Description: "Flag to enable/disable redis/valkey cluster mode.",
+			Description: "Flag to enable/disable redis/valkey cluster mode. Cluster mode should be enabled if the instance acts as the primary for a global datastore.",
 			Type:        schema.TypeBool,
 			Optional:    true,
 			ForceNew:    true,


### PR DESCRIPTION
## ClickUp Ticket

<!-- Required: Link to the ClickUp ticket -->
<!-- Example: https://app.clickup.com/t/8655600/DUPLO-12345 -->

**DUPLO-37126:https://app.clickup.com/t/8655600/DUPLO-37126**

## Overview
Document updated
## Summary of changes

This PR does the following:

- Updated document description for enable_cluster_mode field in ecache resource
- ...

## Testing performed

- [ ] Using unit tests
- [✔︎ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
