### PR TITLE
DUPLO-42403 TF: fix tenant_secret drift when name_suffix has leading slash

### DIFF
--- a/duplocloud/resource_duplo_tenant_secret.go
+++ b/duplocloud/resource_duplo_tenant_secret.go
@@ -54,6 +54,9 @@ func resourceTenantSecret() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 				ForceNew:    true,
+				DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+					return strings.TrimPrefix(old, "/") == strings.TrimPrefix(new, "/")
+				},
 			},
 			"version_id": {
 				Description: "The version ID of the secret.",


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-42403

## Overview

`duplocloud_tenant_secret` forces a recreate on every plan when `name_suffix` starts with `/`. The Read function strips the leading `/` via `UnprefixName`, causing a perpetual diff against the user's config value.

## Summary of changes

This PR does the following:

- Add `DiffSuppressFunc` on `name_suffix` to treat `/rttys/certs/cas.pem` and `rttys/certs/cas.pem` as equivalent, preventing unnecessary force-replacement

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None