### PR TITLE
DUPLO-42422 TF: TF shows forces replacement for resource 'duplocloud_asg_profile' on update of custom_data_tags block

### DIFF
--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -331,7 +331,7 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 - `user_account` (String) The name of the tenant that the host will be created in.
 - `volume` (Block List) Block to specify additional or secondary volume beyond the root device (see [below for nested schema](#nestedblock--volume))
 - `wait_for_capacity` (Boolean) Whether or not to wait until ASG instances to be healthy, after creation. Defaults to `true`.
-- `zone` (String, Deprecated) The availability zone to launch the host in is expressed as a numeric value ranging from 0 to 3.  Defaults to `0`. For environments on the July 2024 release or earlier, use zone. For environments on releases after July 2024, use zones, as zone has been deprecated and non functional on change.
+- `zone` (String, Deprecated) The availability zone to launch the host in is expressed as a numeric value ranging from 0 to 3.  Defaults to `0`. For environments on the July 2024 release or earlier, use zone. For environments on releases after July 2024, use zones, as zone has been deprecated and is non-functional on change.
 - `zones` (List of Number) The multi availability zone to launch the asg in, expressed as a number and starting at 0 - Zone A to 3 - Zone D, based on the infra setup
 
 ### Read-Only

--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -302,7 +302,9 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 - `base64_user_data` (String) Base64 encoded EC2 user data to associated with the host.
 - `can_scale_from_zero` (Boolean) Whether or not ASG should leverage duplocloud's scale from 0 feature
 - `cloud` (Number) The numeric ID of the cloud provider to launch the host in. Defaults to `0`.
-- `custom_data_tags` (Block List) A map of tags to assign to the resource. Example - `AllocationTags` can be passed as tag key with any value. (see [below for nested schema](#nestedblock--custom_data_tags))
+- `custom_data_tags` (Block List) A map of tags to assign to the resource. Example - `AllocationTags` can be passed as tag key with any value.
+
+**Note:** When importing an ASG created using the minion_tags block from v0.12.6 onwards, you need to add a custom_data_tags block by replacing the minion_tags block with the same key and value as the minion_tags block to avoid drift. (see [below for nested schema](#nestedblock--custom_data_tags))
 - `custom_node_labels` (Map of String) Specify the labels to attach to the nodes.
 - `enabled_metrics` (List of String) List of metrics to collect for the ASG Specify one or more of the following metrics.`GroupMinSize`,`GroupMaxSize`,`GroupDesiredCapacity`,`GroupInServiceInstances`,`GroupPendingInstances`,`GroupStandbyInstances`,`GroupTerminatingInstances`,`GroupTotalInstances`,`GroupInServiceCapacity`,`GroupPendingCapacity`,`GroupStandbyCapacity`,`GroupTerminatingCapacity`,`GroupTotalCapacity`,`WarmPoolDesiredCapacity`,`WarmPoolWarmedCapacity`,`WarmPoolPendingCapacity`,`WarmPoolTerminatingCapacity`,`WarmPoolTotalCapacity`,`GroupAndWarmPoolDesiredCapacity`,`GroupAndWarmPoolTotalCapacity`.
 - `encrypt_disk` (Boolean) Defaults to `false`.
@@ -329,7 +331,7 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 - `user_account` (String) The name of the tenant that the host will be created in.
 - `volume` (Block List) Block to specify additional or secondary volume beyond the root device (see [below for nested schema](#nestedblock--volume))
 - `wait_for_capacity` (Boolean) Whether or not to wait until ASG instances to be healthy, after creation. Defaults to `true`.
-- `zone` (String, Deprecated) The availability zone to launch the host in is expressed as a numeric value ranging from 0 to 3.  Defaults to `0`. For environments on the July 2024 release or earlier, use zone. For environments on releases after July 2024, use zones, as zone has been deprecated.
+- `zone` (String, Deprecated) The availability zone to launch the host in is expressed as a numeric value ranging from 0 to 3.  Defaults to `0`. For environments on the July 2024 release or earlier, use zone. For environments on releases after July 2024, use zones, as zone has been deprecated and non functional on change.
 - `zones` (List of Number) The multi availability zone to launch the asg in, expressed as a number and starting at 0 - Zone A to 3 - Zone D, based on the infra setup
 
 ### Read-Only

--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -304,7 +304,7 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 - `cloud` (Number) The numeric ID of the cloud provider to launch the host in. Defaults to `0`.
 - `custom_data_tags` (Block List) A map of tags to assign to the resource. Example - `AllocationTags` can be passed as tag key with any value.
 
-**Note:** When importing an ASG created using the minion_tags block from v0.12.6 onwards, you need to add a custom_data_tags block by replacing the minion_tags block with the same key and value as the minion_tags block to avoid drift. (see [below for nested schema](#nestedblock--custom_data_tags))
+**Note:** When importing an ASG created using the minion_tags block, from v0.12.6 onwards, need to add a custom_data_tags block by replacing the minion_tags block with the same key and value as the minion_tags block to avoid drift. (see [below for nested schema](#nestedblock--custom_data_tags))
 - `custom_node_labels` (Map of String) Specify the labels to attach to the nodes.
 - `enabled_metrics` (List of String) List of metrics to collect for the ASG Specify one or more of the following metrics.`GroupMinSize`,`GroupMaxSize`,`GroupDesiredCapacity`,`GroupInServiceInstances`,`GroupPendingInstances`,`GroupStandbyInstances`,`GroupTerminatingInstances`,`GroupTotalInstances`,`GroupInServiceCapacity`,`GroupPendingCapacity`,`GroupStandbyCapacity`,`GroupTerminatingCapacity`,`GroupTotalCapacity`,`WarmPoolDesiredCapacity`,`WarmPoolWarmedCapacity`,`WarmPoolPendingCapacity`,`WarmPoolTerminatingCapacity`,`WarmPoolTotalCapacity`,`GroupAndWarmPoolDesiredCapacity`,`GroupAndWarmPoolTotalCapacity`.
 - `encrypt_disk` (Boolean) Defaults to `false`.

--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -176,7 +176,7 @@ func autoscalingGroupSchema() map[string]*schema.Schema {
 	awsASGSchema["minion_tags"].DiffSuppressFunc = diffSuppressWhenNotCreating
 
 	awsASGSchema["custom_data_tags"] = &schema.Schema{
-		Description:   "A map of tags to assign to the resource. Example - `AllocationTags` can be passed as tag key with any value.\n\n**Note:** When importing an ASG created using the minion_tags block from v0.12.6 onwards, you need to add a custom_data_tags block by replacing the minion_tags block with the same key and value as the minion_tags block to avoid drift.",
+		Description:   "A map of tags to assign to the resource. Example - `AllocationTags` can be passed as tag key with any value.\n\n**Note:** When importing an ASG created using the minion_tags block, from v0.12.6 onwards, need to add a custom_data_tags block by replacing the minion_tags block with the same key and value as the minion_tags block to avoid drift.",
 		Type:          schema.TypeList,
 		Optional:      true,
 		Elem:          KeyValueSchema(),

--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -125,7 +125,7 @@ func autoscalingGroupSchema() map[string]*schema.Schema {
 		Type:        schema.TypeString,
 		Optional:    true,
 		//ForceNew:         true, // relaunch instance
-		Deprecated:       "For environments on the July 2024 release or earlier, use zone. For environments on releases after July 2024, use zones, as zone has been deprecated and non functional on change.",
+		Deprecated:       "For environments on the July 2024 release or earlier, use zone. For environments on releases after July 2024, use zones, as zone has been deprecated and is non-functional on change.",
 		Default:          0,
 		DiffSuppressFunc: diffSuppressWhenNotCreating,
 	}

--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -124,9 +124,10 @@ func autoscalingGroupSchema() map[string]*schema.Schema {
 		Description: "The availability zone to launch the host in is expressed as a numeric value ranging from 0 to 3. ",
 		Type:        schema.TypeString,
 		Optional:    true,
-		ForceNew:    true, // relaunch instance
-		Deprecated:  "For environments on the July 2024 release or earlier, use zone. For environments on releases after July 2024, use zones, as zone has been deprecated.",
-		Default:     0,
+		//ForceNew:         true, // relaunch instance
+		Deprecated:       "For environments on the July 2024 release or earlier, use zone. For environments on releases after July 2024, use zones, as zone has been deprecated and non functional on change.",
+		Default:          0,
+		DiffSuppressFunc: diffSuppressWhenNotCreating,
 	}
 	awsASGSchema["taints"] = &schema.Schema{
 		Description: "Specify taints to attach to the nodes, to repel other nodes with different toleration",
@@ -175,12 +176,10 @@ func autoscalingGroupSchema() map[string]*schema.Schema {
 	awsASGSchema["minion_tags"].DiffSuppressFunc = diffSuppressWhenNotCreating
 
 	awsASGSchema["custom_data_tags"] = &schema.Schema{
-		Description:   "A map of tags to assign to the resource. Example - `AllocationTags` can be passed as tag key with any value.",
+		Description:   "A map of tags to assign to the resource. Example - `AllocationTags` can be passed as tag key with any value.\n\n**Note:** When importing an ASG created using the minion_tags block from v0.12.6 onwards, you need to add a custom_data_tags block by replacing the minion_tags block with the same key and value as the minion_tags block to avoid drift.",
 		Type:          schema.TypeList,
 		Optional:      true,
-		Computed:      true,
-		ForceNew:      true, // relaunch instance
-		Elem:          KeyValueSchemaAsgCustomDataTag(),
+		Elem:          KeyValueSchema(),
 		ConflictsWith: []string{"minion_tags"},
 	}
 
@@ -310,7 +309,7 @@ func resourceAwsASGCreate(ctx context.Context, d *schema.ResourceData, m interfa
 			return diag.FromErr(err)
 		}
 	}
-
+	ctx = context.WithValue(ctx, flowContextKey, "normal")
 	diags = resourceAwsASGRead(ctx, d, m)
 	log.Printf("[TRACE] resourceAwsASGCreate(%s, %s): end", rq.TenantId, rq.FriendlyName)
 	return diags
@@ -376,6 +375,9 @@ func resourceAwsASGUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 			Key:           "AllocationTags",
 			Value:         newTags,
 		}
+		if newTags == "" {
+			updateRequest.State = "delete"
+		}
 		err := c.TenantUpdateCustomData(rq.TenantId, updateRequest)
 		if err != nil {
 			return diag.Errorf("Error updating ASG profile '%s': %s", rq.FriendlyName, err)
@@ -421,6 +423,7 @@ func resourceAwsASGUpdate(ctx context.Context, d *schema.ResourceData, m interfa
 			return diag.Errorf("Error updating taints from ASG profile '%s': %s", friendlyName, cerr)
 		}
 	}
+	ctx = context.WithValue(ctx, flowContextKey, "normal")
 	diags := resourceAwsASGRead(ctx, d, m)
 	log.Printf("[TRACE] resourceAwsASGUpdate(%s, %s): end", tenantID, friendlyName)
 	return diags
@@ -453,8 +456,16 @@ func resourceAwsASGRead(ctx context.Context, d *schema.ResourceData, m interface
 		return nil
 	}
 
+	flow := "import"
+
+	v := ctx.Value(flowContextKey)
+	if v != nil {
+		if f, ok := v.(string); ok {
+			flow = f
+		}
+	}
 	// Apply the data
-	asgProfileToState(d, profile)
+	asgProfileToState(d, profile, flow)
 	d.Set("tenant_id", tenantID)
 	log.Printf("[TRACE] resourceAwsASGRead(%s): end", id)
 	return nil
@@ -517,7 +528,7 @@ func asgProfileIdParts(id string) (tenantID, name string, err error) {
 	return tenantID, name, err
 }
 
-func asgProfileToState(d *schema.ResourceData, duplo *duplosdk.DuploAsgProfile) {
+func asgProfileToState(d *schema.ResourceData, duplo *duplosdk.DuploAsgProfile, flow string) {
 	d.Set("instance_count", duplo.DesiredCapacity)
 	d.Set("min_instance_count", duplo.MinSize)
 	d.Set("max_instance_count", duplo.MaxSize)
@@ -544,8 +555,13 @@ func asgProfileToState(d *schema.ResourceData, duplo *duplosdk.DuploAsgProfile) 
 	// If a network interface was customized, certain fields are not returned by the backend.
 	if v, ok := d.GetOk("network_interface"); !ok || v == nil || len(v.([]interface{})) == 0 {
 		_, zok := d.GetOk("zones")
-
-		if len(duplo.Zones) > 0 && zok {
+		if len(duplo.Zones) > 0 && flow == "import" {
+			i := []interface{}{}
+			for _, v := range duplo.Zones {
+				i = append(i, v)
+			}
+			d.Set("zones", i)
+		} else if len(duplo.Zones) > 0 && zok {
 			i := []interface{}{}
 			for _, v := range duplo.Zones {
 				i = append(i, v)
@@ -697,7 +713,7 @@ func needsResourceAwsASGUpdate(d *schema.ResourceData) bool {
 }
 
 func checkAllocationTagsDiff(d *schema.ResourceData) (hasChange bool, tags string) {
-	oldRevision, newRevision := d.GetChange("minion_tags")
+	oldRevision, newRevision := d.GetChange("custom_data_tags")
 	oldTags := oldRevision.([]interface{})
 	newTags := newRevision.([]interface{})
 

--- a/duplocloud/utils.go
+++ b/duplocloud/utils.go
@@ -219,23 +219,6 @@ func KeyValueSchema() *schema.Resource {
 	}
 }
 
-func KeyValueSchemaAsgCustomDataTag() *schema.Resource {
-	return &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"key": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-			"value": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-			},
-		},
-	}
-}
-
 func DynamoDbV2TagSchema() *schema.Resource {
 	return &schema.Resource{
 		Schema: map[string]*schema.Schema{


### PR DESCRIPTION
## ClickUp Ticket

**DUPLO-42422 :https://app.clickup.com/t/8655600/DUPLO-42422**

## Overview
Update support for allocation tags and fix of import issue
## Summary of changes

This PR does the following:

- support for allocation tag update, 
- Resolved import issue and added a note in documentation how to handle drift caused by custom_data_tag on import of asg resource created in older resource and imported in current version

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [✔︎ ] Manually, on a remote test system

## Describe any breaking changes

- A drift can occur on  asg created before this version when imported in current version, added note in documentation to handle it
