### PR TITLE
DUPLO-42283 TF: increase ecache update timeout for large instance operations

### DIFF
--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -275,7 +275,7 @@ func resourceDuploEcacheInstance() *schema.Resource {
 		},
 		Timeouts: &schema.ResourceTimeout{
 			Create: schema.DefaultTimeout(29 * time.Minute),
-			Update: schema.DefaultTimeout(15 * time.Minute),
+			Update: schema.DefaultTimeout(60 * time.Minute),
 			Delete: schema.DefaultTimeout(15 * time.Minute),
 		},
 		Schema:        ecacheInstanceSchema(),
@@ -713,7 +713,7 @@ func ecacheInstanceWaitUntilAvailable(ctx context.Context, c *duplosdk.Client, t
 		Target:       []string{"available"},
 		MinTimeout:   10 * time.Second,
 		PollInterval: 30 * time.Second,
-		Timeout:      20 * time.Minute,
+		Timeout:      40 * time.Minute,
 		Refresh: func() (interface{}, string, error) {
 			resp, err := c.EcacheInstanceGet(tenantID, name)
 			if err != nil {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-42283

## Overview

Increases ElastiCache update and wait timeouts to handle large instance scaling (e.g., cross-family node type changes) and engine version upgrades that exceed the previous 20-minute limit.

## Summary of changes

- Increased resource update timeout from 15 minutes to 60 minutes
- Increased `ecacheInstanceWaitUntilAvailable` poll timeout from 20 minutes to 40 minutes

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None