### PR TITLE
DUPLO-42471 Create subnets with different CIDR prefix using terraform

### DIFF
--- a/docs/resources/infrastructure.md
+++ b/docs/resources/infrastructure.md
@@ -408,6 +408,8 @@ Should be one of:
  Defaults to `0`.
 - `cluster_ip_cidr` (String) cluster IP CIDR defines a private IP address range used for internal Kubernetes services.
 - `custom_data` (Block List, Deprecated) A list of configuration settings to apply on creation, expressed as key / value pairs. The custom_data argument is only applied on creation, and is deprecated in favor of the settings argument. (see [below for nested schema](#nestedblock--custom_data))
+- `custom_private_subnet_cidrs` (Set of String) Custom CIDR blocks for private subnets. When specified, overrides the automatic subnet sizing from subnet_cidr.
+- `custom_public_subnet_cidrs` (Set of String) Custom CIDR blocks for public subnets. When specified, overrides the automatic subnet sizing from subnet_cidr.
 - `delete_unspecified_settings` (Boolean) Whether or not this resource should delete any settings not specified by this resource. **WARNING:**  It is not recommended to change the default value of `false`. Defaults to `false`.
 - `enable_container_insights` (Boolean) Whether or not to enable container insights for an ECS cluster.
 - `enable_ecs_cluster` (Boolean) Whether or not to provision an ECS cluster.

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -639,8 +639,6 @@ func infrastructureRead(ctx context.Context, c *duplosdk.Client, d *schema.Resou
 	d.Set("enable_container_insights", infra.EnableContainerInsights)
 	d.Set("address_prefix", infra.Vnet.AddressPrefix)
 	d.Set("subnet_cidr", infra.Vnet.SubnetCidr)
-	d.Set("custom_private_subnet_cidrs", config.Vnet.CustomPrivateSubnetCidrs)
-	d.Set("custom_public_subnet_cidrs", config.Vnet.CustomPublicSubnetCidrs)
 	d.Set("status", infra.ProvisioningStatus)
 
 	d.Set("all_settings", keyValueToState("all_settings", config.CustomData))
@@ -735,6 +733,9 @@ func infrastructureRead(ctx context.Context, c *duplosdk.Client, d *schema.Resou
 
 			d.Set("private_subnets", privateSubnets)
 			d.Set("public_subnets", publicSubnets)
+			d.Set("custom_private_subnet_cidrs", config.Vnet.CustomPrivateSubnetCidrs)
+			d.Set("custom_public_subnet_cidrs", config.Vnet.CustomPublicSubnetCidrs)
+
 		}
 
 		if config.Vnet.SecurityGroups != nil {

--- a/duplocloud/resource_duplo_infrastructure.go
+++ b/duplocloud/resource_duplo_infrastructure.go
@@ -249,6 +249,20 @@ func resourceInfrastructure() *schema.Resource {
 				ForceNew:    true,
 				Optional:    true,
 			},
+			"custom_private_subnet_cidrs": {
+				Description: "Custom CIDR blocks for private subnets. When specified, overrides the automatic subnet sizing from subnet_cidr.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"custom_public_subnet_cidrs": {
+				Description: "Custom CIDR blocks for public subnets. When specified, overrides the automatic subnet sizing from subnet_cidr.",
+				Type:        schema.TypeSet,
+				Optional:    true,
+				ForceNew:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 			"subnet_name": {
 				Description: "The name of the subnet. This is applicable only for Azure.",
 				Type:        schema.TypeString,
@@ -533,6 +547,13 @@ func duploInfrastructureConfigFromState(d *schema.ResourceData) duplosdk.DuploIn
 		},
 	}
 
+	for _, v := range d.Get("custom_private_subnet_cidrs").(*schema.Set).List() {
+		config.Vnet.CustomPrivateSubnetCidrs = append(config.Vnet.CustomPrivateSubnetCidrs, v.(string))
+	}
+	for _, v := range d.Get("custom_public_subnet_cidrs").(*schema.Set).List() {
+		config.Vnet.CustomPublicSubnetCidrs = append(config.Vnet.CustomPublicSubnetCidrs, v.(string))
+	}
+
 	//Azure -> if needed only there, this subnet should be added only in Azure
 	if config.Cloud == 2 {
 		subnet := duplosdk.DuploInfrastructureVnetSubnet{}
@@ -618,6 +639,8 @@ func infrastructureRead(ctx context.Context, c *duplosdk.Client, d *schema.Resou
 	d.Set("enable_container_insights", infra.EnableContainerInsights)
 	d.Set("address_prefix", infra.Vnet.AddressPrefix)
 	d.Set("subnet_cidr", infra.Vnet.SubnetCidr)
+	d.Set("custom_private_subnet_cidrs", config.Vnet.CustomPrivateSubnetCidrs)
+	d.Set("custom_public_subnet_cidrs", config.Vnet.CustomPublicSubnetCidrs)
 	d.Set("status", infra.ProvisioningStatus)
 
 	d.Set("all_settings", keyValueToState("all_settings", config.CustomData))

--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -113,13 +113,15 @@ type DuploInfrastructureVnetSGRule struct {
 
 // DuploInfrastructureVnet represents a Duplo infrastructure VNET
 type DuploInfrastructureVnet struct {
-	ID                 string                                   `json:"Id,omitempty"`
-	Name               string                                   `json:"Name,omitempty"`
-	AddressPrefix      string                                   `json:"AddressPrefix"`
-	SubnetCidr         int                                      `json:"SubnetCidr"`
-	Subnets            *[]DuploInfrastructureVnetSubnet         `json:"Subnets,omitempty"`
-	ProvisioningStatus string                                   `json:"ProvisioningStatus,omitempty"`
-	SecurityGroups     *[]DuploInfrastructureVnetSecurityGroups `json:"SecurityGroups,omitempty"`
+	ID                       string                                   `json:"Id,omitempty"`
+	Name                     string                                   `json:"Name,omitempty"`
+	AddressPrefix            string                                   `json:"AddressPrefix"`
+	SubnetCidr               int                                      `json:"SubnetCidr"`
+	CustomPrivateSubnetCidrs []string                                 `json:"CustomPrivateSubnetCidrs,omitempty"`
+	CustomPublicSubnetCidrs  []string                                 `json:"CustomPublicSubnetCidrs,omitempty"`
+	Subnets                  *[]DuploInfrastructureVnetSubnet         `json:"Subnets,omitempty"`
+	ProvisioningStatus       string                                   `json:"ProvisioningStatus,omitempty"`
+	SecurityGroups           *[]DuploInfrastructureVnetSecurityGroups `json:"SecurityGroups,omitempty"`
 }
 
 // DuploInfrastructureConfig represents extended information about a Duplo infrastructure

--- a/examples/resources/duplocloud_infrastructure/resource.tf
+++ b/examples/resources/duplocloud_infrastructure/resource.tf
@@ -267,3 +267,25 @@ resource "duplocloud_infrastructure" "infra" {
   address_prefix     = var.infra_config["address_prefix"]
   subnet_cidr        = var.infra_config["subnet_cidr"]
 }
+
+resource "duplocloud_infrastructure" "custom_cidr_infra" {
+  infra_name        = var.infra_config["name"]
+  cloud             = var.infra_config["cloud"]
+  region            = var.infra_config["region"]
+  azcount           = var.infra_config["azcount"]
+  enable_k8_cluster = false
+  address_prefix    = "11.1.0.0/16"
+  subnet_cidr       = 20
+
+  custom_private_subnet_cidrs = [
+    "11.1.0.0/18",
+    "11.1.64.0/18",
+    "11.1.128.0/18"
+  ]
+
+  custom_public_subnet_cidrs = [
+    "11.1.192.0/20",
+    "11.1.208.0/20",
+    "11.1.224.0/20"
+  ]
+}


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-42471](https://app.clickup.com/t/8655600/DUPLO-42471)

## Overview

Adds support for creating AWS VPC subnets with custom, mixed CIDR prefix lengths when provisioning infrastructure. Previously, DuploCloud would auto-generate subnets from a single `subnet_cidr` prefix size. This change allows users to explicitly specify per-subnet CIDR blocks for both private and public subnets.

## Summary of changes

- Added `CustomPrivateSubnetCidrs` and `CustomPublicSubnetCidrs` fields to the `DuploInfrastructureVnet` SDK struct in `duplosdk/infrastructure.go`
- Added `custom_private_subnet_cidrs` and `custom_public_subnet_cidrs` schema attributes (`TypeSet`, `ForceNew`) to the `duplocloud_infrastructure` resource
- Wired the new fields into the infrastructure create request and read response

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None. Both new attributes are optional. Existing configurations without these fields are unaffected.
