### PR TITLE
DUPLO-42489: Change lbconfig timeout and poll interval.

### DIFF
--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -260,9 +260,9 @@ func resourceDuploServiceLbConfigs() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(15 * time.Minute),
-			Update: schema.DefaultTimeout(15 * time.Minute),
-			Delete: schema.DefaultTimeout(15 * time.Minute),
+			Create: schema.DefaultTimeout(30 * time.Minute),
+			Update: schema.DefaultTimeout(30 * time.Minute),
+			Delete: schema.DefaultTimeout(30 * time.Minute),
 		},
 		Schema:        duploServiceLbConfigsSchema(),
 		CustomizeDiff: validateLBConfigParameters,
@@ -532,9 +532,9 @@ func resourceDuploServiceLbConfigsDelete(ctx context.Context, d *schema.Resource
 		return list, errget
 	})
 
-	// Wait 40 more seconds to deal with consistency issues.
+	// Wait 30 more seconds to deal with consistency issues.
 	if diags == nil {
-		time.Sleep(140 * time.Second)
+		time.Sleep(30 * time.Second)
 	}
 
 	log.Printf("[TRACE] resourceDuploServiceLbConfigsDelete(%s, %s): end", tenantID, name)
@@ -602,8 +602,8 @@ func duploServiceLbConfigsWaitUntilReady(ctx context.Context, c *duplosdk.Client
 			return name, "pending", nil
 		},
 		// MinTimeout will be 10 sec freq, if times-out forces 30 sec anyway
-		PollInterval: 10 * time.Second,
-		Timeout:      10 * time.Minute,
+		PollInterval: 30 * time.Second,
+		Timeout:      20 * time.Minute,
 	}
 	log.Printf("[DEBUG] duploServiceLBConfigsWaitUntilReady(%s, %s)", tenantID, name)
 	_, err := stateConf.WaitForStateContext(ctx)

--- a/duplocloud/resource_duplo_lbconfigs.go
+++ b/duplocloud/resource_duplo_lbconfigs.go
@@ -603,7 +603,7 @@ func duploServiceLbConfigsWaitUntilReady(ctx context.Context, c *duplosdk.Client
 		},
 		// MinTimeout will be 10 sec freq, if times-out forces 30 sec anyway
 		PollInterval: 30 * time.Second,
-		Timeout:      20 * time.Minute,
+		Timeout:      30 * time.Minute,
 	}
 	log.Printf("[DEBUG] duploServiceLBConfigsWaitUntilReady(%s, %s)", tenantID, name)
 	_, err := stateConf.WaitForStateContext(ctx)


### PR DESCRIPTION
## ClickUp Ticket
- DUPLO-42489: Change lbconfig timeout and poll interval.
**ClickUp Ticket ID:**

## Overview

## Summary of changes

This PR does the following:

- Change lbconfig timeout and poll interval.

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- Change lbconfig timeout and poll interval.
