### PR TITLE
DUPLO-42144 TF: Cloud task: duplocloud_gcp_cloud_queue resource is not getting created

### DIFF
--- a/docs/resources/gcp_cloud_queue.md
+++ b/docs/resources/gcp_cloud_queue.md
@@ -35,13 +35,13 @@ resource "duplocloud_gcp_cloud_queue" "queue" {
 
 ### Optional
 
+- `location` (String) The GCP location (region) for the cloud tasks queue. If not specified, it is automatically resolved from the tenant's infrastructure region.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `fullname` (String) The full name of the cloud function.
 - `id` (String) The ID of this resource.
-- `location` (String) The name of the cloud tasks queue
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/docs/resources/gcp_cloud_task.md
+++ b/docs/resources/gcp_cloud_task.md
@@ -19,9 +19,9 @@ resource "duplocloud_tenant" "myapp" {
 }
 
 
-resource "duplocloud_gcp_cloud_queue_task" "task" {
+resource "duplocloud_gcp_cloud_task" "task" {
   tenant_id  = duplocloud_tenant.myapp.tenant_id
-  queue_name = duplocloud_gcp_cloud_tasks_queue.queue.name
+  queue_name = duplocloud_gcp_cloud_queue.queue.name
   name       = "task1"
   app_engine {
     relative_uri = "/create"
@@ -34,9 +34,9 @@ resource "duplocloud_gcp_cloud_queue_task" "task" {
 
 }
 
-resource "duplocloud_gcp_cloud_queue_task" "task2" {
+resource "duplocloud_gcp_cloud_task" "task2" {
   tenant_id  = duplocloud_tenant.myapp.tenant_id
-  queue_name = duplocloud_gcp_cloud_tasks_queue.queue.name
+  queue_name = duplocloud_gcp_cloud_queue.queue.name
   name       = "task2"
   http_target {
     url    = "https://catfact.ninja/fact"

--- a/duplocloud/resource_duplo_gcp_cloud_queue.go
+++ b/duplocloud/resource_duplo_gcp_cloud_queue.go
@@ -30,9 +30,11 @@ func gcpCloudTasksQueueSchema() map[string]*schema.Schema {
 			ForceNew:    true,
 		},
 		"location": {
-			Description: "The name of the cloud tasks queue",
+			Description: "The GCP location (region) for the cloud tasks queue. If not specified, it is automatically resolved from the tenant's infrastructure region.",
 			Type:        schema.TypeString,
+			Optional:    true,
 			Computed:    true,
+			ForceNew:    true,
 		},
 		"fullname": {
 			Description: "The full name of the cloud function.",
@@ -70,11 +72,18 @@ func resourceGcpCloudQueueRead(ctx context.Context, d *schema.ResourceData, m in
 	if len(idParts) != 3 {
 		return diag.Errorf("Invalid resource ID: %s", id)
 	}
+	c := m.(*duplosdk.Client)
+
 	tenantID, qName := idParts[0], idParts[2]
 
+	// Resolve location from the tenant's infrastructure region.
+	features, clientErr := c.TenantFeaturesGet(tenantID)
+	if clientErr != nil {
+		return diag.Errorf("Error fetching tenant %s features: %s", tenantID, clientErr)
+	}
+
 	// Get the object from Duplo, detecting a missing object
-	c := m.(*duplosdk.Client)
-	duplo, err := c.GCPCloudTasksQueueGet(tenantID, qName)
+	duplo, err := c.GCPCloudTasksQueueGet(tenantID, qName, features.Region)
 	if duplo == nil || (err != nil && err.Status() == 404) {
 		d.SetId("") // object missing
 		return nil
@@ -83,8 +92,6 @@ func resourceGcpCloudQueueRead(ctx context.Context, d *schema.ResourceData, m in
 		return diag.Errorf("Unable to retrieve tenant %s cloud task's queue '%s' : %s", tenantID, qName, err)
 	}
 
-	// Set simple fields first.
-	d.SetId(fmt.Sprintf("%s/tasks/queue/%s", tenantID, qName))
 	resourceGcpCloudQueueSetData(d, tenantID, qName, duplo)
 	log.Printf("[TRACE] resourceGcpCloudQueueRead ******** end")
 	return nil
@@ -94,11 +101,21 @@ func resourceGcpCloudQueueRead(ctx context.Context, d *schema.ResourceData, m in
 func resourceGcpCloudQueueCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	log.Printf("[TRACE] resourceGcpCloudQueueCreate ******** start")
 
+	c := m.(*duplosdk.Client)
+	tenantID := d.Get("tenant_id").(string)
+
 	// Create the request object.
 	rq := expandGcpCloudTasksQueue(d)
 
-	c := m.(*duplosdk.Client)
-	tenantID := d.Get("tenant_id").(string)
+	// If location is not provided, resolve it from the tenant's infrastructure region.
+	if rq.Location == "" {
+		features, err := c.TenantFeaturesGet(tenantID)
+		if err != nil {
+			return diag.Errorf("Error fetching tenant %s features: %s", tenantID, err)
+		}
+		rq.Location = features.Region
+	}
+
 	// Post the object to Duplo
 	err := c.GcpCloudTasksQueueCreate(tenantID, rq)
 	if err != nil {
@@ -125,8 +142,8 @@ func resourceGcpCloudQueueDelete(ctx context.Context, d *schema.ResourceData, m 
 		return diag.Errorf("Invalid resource ID: %s", id)
 	}
 	tenantID, qName := idParts[0], idParts[2]
-
-	err := c.GCPCloudTasksQueueDelete(tenantID, qName)
+	location := d.Get("location").(string)
+	err := c.GCPCloudTasksQueueDelete(tenantID, qName, location)
 	if err != nil {
 		if err.Status() == 404 {
 			return nil

--- a/duplosdk/gcp_cloud_tasks.go
+++ b/duplosdk/gcp_cloud_tasks.go
@@ -40,11 +40,11 @@ func (c *Client) GcpCloudTasksCreate(tenantID string, queue string, rq *DuploGCP
 	)
 	return err
 }
-func (c *Client) GCPCloudTasksQueueGet(tenantID string, name string) (*DuploGCPCloudTaskQueue, ClientError) {
+func (c *Client) GCPCloudTasksQueueGet(tenantID string, name, location string) (*DuploGCPCloudTaskQueue, ClientError) {
 	rp := DuploGCPCloudTaskQueue{}
 	err := c.getAPI(
 		fmt.Sprintf("GCPCloudTasksQueueGet(%s, %s)", tenantID, name),
-		fmt.Sprintf("v3/subscriptions/%s/google/queues/%s", tenantID, name),
+		fmt.Sprintf("v3/subscriptions/%s/google/queues/%s/%s", tenantID, name, location),
 		&rp,
 	)
 
@@ -70,10 +70,10 @@ func (c *Client) GCPCloudTasksDelete(tenantID, queue, task string) ClientError {
 		&resp)
 }
 
-func (c *Client) GCPCloudTasksQueueDelete(tenantID, queue string) ClientError {
+func (c *Client) GCPCloudTasksQueueDelete(tenantID, queue, location string) ClientError {
 	var resp interface{}
 	return c.deleteAPI(
-		fmt.Sprintf("GCPCloudTasksQueueDelete(%s, %s)", tenantID, queue),
-		fmt.Sprintf("v3/subscriptions/%s/google/queues/%s", tenantID, queue),
+		fmt.Sprintf("GCPCloudTasksQueueDelete(%s, %s,%s)", tenantID, queue, location),
+		fmt.Sprintf("v3/subscriptions/%s/google/queues/%s/%s", tenantID, queue, location),
 		&resp)
 }

--- a/examples/resources/duplocloud_gcp_cloud_task/resource.tf
+++ b/examples/resources/duplocloud_gcp_cloud_task/resource.tf
@@ -4,9 +4,9 @@ resource "duplocloud_tenant" "myapp" {
 }
 
 
-resource "duplocloud_gcp_cloud_queue_task" "task" {
+resource "duplocloud_gcp_cloud_task" "task" {
   tenant_id  = duplocloud_tenant.myapp.tenant_id
-  queue_name = duplocloud_gcp_cloud_tasks_queue.queue.name
+  queue_name = duplocloud_gcp_cloud_queue.queue.name
   name       = "task1"
   app_engine {
     relative_uri = "/create"
@@ -19,9 +19,9 @@ resource "duplocloud_gcp_cloud_queue_task" "task" {
 
 }
 
-resource "duplocloud_gcp_cloud_queue_task" "task2" {
+resource "duplocloud_gcp_cloud_task" "task2" {
   tenant_id  = duplocloud_tenant.myapp.tenant_id
-  queue_name = duplocloud_gcp_cloud_tasks_queue.queue.name
+  queue_name = duplocloud_gcp_cloud_queue.queue.name
   name       = "task2"
   http_target {
     url    = "https://catfact.ninja/fact"


### PR DESCRIPTION
## ClickUp Ticket

**DUPLO-42144 : https://app.clickup.com/t/8655600/DUPLO-42144**
**DUPLO-42145 : https://app.clickup.com/t/8655600/DUPLO-42145**

## Overview

The `duplocloud_gcp_cloud_queue` resource was failing on create with a 400 error: `"An empty string was provided, but is not valid — Parameter name: locationId"`. The backend requires a `locationId` but the resource was not sending it.

## Summary of changes

This PR does the following:

- **Auto-resolve location from tenant infrastructure**: When `location` is not specified by the user, the provider now calls `TenantFeaturesGet` to resolve the GCP region from the tenant's infrastructure and populates it automatically.
- **Update SDK methods to include location parameter**: `GCPCloudTasksQueueGet` and `GCPCloudTasksQueueDelete` now accept a `location` parameter and include it in the API path (`v3/subscriptions/{tenant_id}/google/queues/{name}/{location}`).
- **Fix location schema**: Changed from `Computed`-only to `Optional + Computed + ForceNew` so users can optionally override the location, and it is populated on read.
- **Fix Read overwriting resource ID**: Removed the `d.SetId()` call in Read that was resetting the ID to an inconsistent 4-part format (`{tenantID}/tasks/queue/{name}`), which would have broken subsequent state operations.
- Documentation fix
## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [x] Manually, on a remote test system

## Describe any breaking changes

- None. The `location` field is now `Optional + Computed` (previously `Computed`-only), so existing configs without `location` will continue to work — the value is auto-resolved from the tenant's infrastructure region.
