### PR TITLE
DUPLO-38070 TF: OAC is removed if Cloudfront Resource is updated

### DIFF
--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -2282,7 +2282,7 @@ func updateS3OAI(existingCfd, updatedCfd *duplosdk.DuploAwsCloudfrontDistributio
 	for _, eo := range *existingCfd.Origins.Items {
 		for i, uo := range *updatedCfd.Origins.Items {
 			if eo.Id == uo.Id {
-				if eo.S3OriginConfig != nil {
+				if eo.S3OriginConfig != nil && uo.S3OriginConfig != nil {
 					uo.S3OriginConfig.OriginAccessIdentity = eo.S3OriginConfig.OriginAccessIdentity
 				}
 				// Preserve OAC (Origin Access Control) from the existing config.

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -2280,9 +2280,17 @@ func cloudfrontDistributionWaitUntilDisabled(ctx context.Context, c *duplosdk.Cl
 
 func updateS3OAI(existingCfd, updatedCfd *duplosdk.DuploAwsCloudfrontDistributionConfig) {
 	for _, eo := range *existingCfd.Origins.Items {
-		for _, uo := range *updatedCfd.Origins.Items {
-			if eo.Id == uo.Id && eo.S3OriginConfig != nil {
-				uo.S3OriginConfig.OriginAccessIdentity = eo.S3OriginConfig.OriginAccessIdentity
+		for i, uo := range *updatedCfd.Origins.Items {
+			if eo.Id == uo.Id {
+				if eo.S3OriginConfig != nil {
+					uo.S3OriginConfig.OriginAccessIdentity = eo.S3OriginConfig.OriginAccessIdentity
+				}
+				// Preserve OAC (Origin Access Control) from the existing config.
+				// The expand function doesn't set OriginAccessControlId because it's
+				// managed by the backend, so we must carry it forward on updates.
+				if eo.OriginAccessControlId != "" {
+					(*updatedCfd.Origins.Items)[i].OriginAccessControlId = eo.OriginAccessControlId
+				}
 				break
 			}
 		}

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution_v2.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution_v2.go
@@ -963,8 +963,19 @@ func resourceAwsCloudfrontDistributionV2Update(ctx context.Context, d *schema.Re
 
 	c := m.(*duplosdk.Client)
 
+	duplo, clientErr := c.AwsCloudfrontDistributionGet(tenantID, cfdId)
+	if clientErr != nil {
+		if clientErr.Status() == 404 {
+			d.SetId("")
+			return nil
+		}
+		return diag.Errorf("Unable to retrieve tenant %s aws cloudfront distribution %s : %s", tenantID, cfdId, clientErr)
+	}
+
 	rq := expandAwsCloudfrontDistributionV2Config(d, true)
 	rq.Comment = d.Get("fullname").(string)
+	// Preserve OAI and OAC from existing config, as these are managed by the backend
+	updateS3OAI(duplo.Distribution.DistributionConfig, rq)
 	resp, err := c.AwsCloudfrontDistributionUpdateV2(tenantID, &duplosdk.DuploAwsCloudfrontDistributionCreateV2{
 		Id:                   cfdId,
 		DistributionConfig:   rq,


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-38070

## Overview

When updating a `duplocloud_aws_cloudfront_distribution` (or v2) resource, any Origin Access Control (OAC) that was configured on the distribution is silently removed because the update payload sends `OriginAccessControlId` as empty.

## Summary of changes

This PR does the following:

- Updates `updateS3OAI` to also preserve `OriginAccessControlId` (OAC) from the existing distribution config, not just `OriginAccessIdentity` (OAI)
- Adds a `AwsCloudfrontDistributionGet` call in the v2 update handler so it can read the existing config and preserve OAI/OAC via `updateS3OAI` (the v1 handler already did this)

## Testing performed

- [x] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None