### PR TITLE
DUPLO-39603 TF: force replacement of MWAA environment on environment_class change

### DIFF
--- a/docs/resources/aws_mwaa_environment.md
+++ b/docs/resources/aws_mwaa_environment.md
@@ -91,7 +91,7 @@ resource "duplocloud_aws_mwaa_environment" "my-mwaa" {
 
 - `airflow_configuration_options` (Map of String, Sensitive) The `airflow_configuration_options` parameter specifies airflow override options
 - `airflow_version` (String) Airflow version of your environment, will be set by default to the latest version that MWAA supports.
-- `environment_class` (String) Environment class for the cluster. Possible options are `mw1.micro`, `mw1.small`, `mw1.medium`, `mw1.large`, `mw1.xlarge`, `mw1.2xlarge`.
+- `environment_class` (String) Environment class for the cluster. Possible options are `mw1.micro`, `mw1.small`, `mw1.medium`, `mw1.large`, `mw1.xlarge`, `mw1.2xlarge`. Changing this forces a new resource to be created.
 - `execution_role_arn` (String) The Execution Role ARN of the Amazon MWAA Environment
 - `kms_key` (String) The Amazon Resource Name (ARN) of your KMS key that you want to use for encryption. Will be set to the ARN of the managed KMS key aws/airflow by default.
 - `logging_configuration` (Block List, Max: 1) (see [below for nested schema](#nestedblock--logging_configuration))

--- a/duplocloud/resource_duplo_aws_mwaa_environment.go
+++ b/duplocloud/resource_duplo_aws_mwaa_environment.go
@@ -90,10 +90,11 @@ func duploMwaaAirflowSchema() map[string]*schema.Schema {
 			}, false),
 		},
 		"environment_class": {
-			Description: "Environment class for the cluster. Possible options are `mw1.micro`, `mw1.small`, `mw1.medium`, `mw1.large`, `mw1.xlarge`, `mw1.2xlarge`.",
+			Description: "Environment class for the cluster. Possible options are `mw1.micro`, `mw1.small`, `mw1.medium`, `mw1.large`, `mw1.xlarge`, `mw1.2xlarge`. Changing this forces a new resource to be created.",
 			Type:        schema.TypeString,
 			Optional:    true,
 			Computed:    true,
+			ForceNew:    true,
 			ValidateFunc: validation.StringInSlice([]string{
 				"mw1.micro", "mw1.small", "mw1.medium", "mw1.large", "mw1.xlarge", "mw1.2xlarge",
 			}, false),
@@ -417,11 +418,6 @@ func resourceMwaaAirflowUpdate(ctx context.Context, d *schema.ResourceData, m in
 	if d.HasChange("dag_s3_path") {
 		updated = true
 		input.DagS3Path = d.Get("dag_s3_path").(string)
-	}
-
-	if d.HasChange("environment_class") {
-		updated = true
-		input.EnvironmentClass = d.Get("environment_class").(string)
 	}
 
 	if d.HasChange("logging_configuration") {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-39603

## Overview

Updating `environment_class` on a `duplocloud_aws_mwaa_environment` resource (e.g. from `mw1.small` to `mw1.micro`) fails with a 400 error because the DuploCloud backend does not support adjusting webserver count constraints during an in-place update. This change makes `environment_class` force a new resource, so the environment is destroyed and recreated with the correct class.

## Summary of changes

This PR does the following:

- Add `ForceNew: true` to the `environment_class` schema attribute so any change triggers resource replacement
- Remove the now-unreachable `HasChange("environment_class")` block from the update function
- Update the attribute description to note the replacement behavior

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None