### PR TITLE
DUPLO-41523 TF: Fix type field not persisting for duplocloud_azure_key_vault_secret

### DIFF
--- a/duplocloud/resource_duplo_azure_key_vault_secret.go
+++ b/duplocloud/resource_duplo_azure_key_vault_secret.go
@@ -187,7 +187,7 @@ func expandAzureKeyVaultSecret(d *schema.ResourceData) *duplosdk.DuploAzureKeyVa
 	return &duplosdk.DuploAzureKeyVaultRequest{
 		SecretName:  d.Get("name").(string),
 		SecretValue: d.Get("value").(string),
-		SecretType:  d.Get("type").(string),
+		ContentType: d.Get("type").(string),
 	}
 }
 

--- a/duplocloud/resource_duplo_azure_key_vault_secret.go
+++ b/duplocloud/resource_duplo_azure_key_vault_secret.go
@@ -207,4 +207,7 @@ func flattenAzureKeyVaultSecret(d *schema.ResourceData, duplo *duplosdk.DuploAzu
 	d.Set("version", duplo.Identifier.Version)
 	d.Set("recovery_level", duplo.Attributes.RecoveryLevel)
 	d.Set("enabled", duplo.Attributes.Enabled)
+	if duplo.ContentType != "" {
+		d.Set("type", duplo.ContentType)
+	}
 }

--- a/duplosdk/azure_key_vault.go
+++ b/duplosdk/azure_key_vault.go
@@ -29,7 +29,7 @@ type DuploAzureSecretItem struct {
 type DuploAzureKeyVaultRequest struct {
 	SecretName  string `json:"SecretName"`
 	SecretValue string `json:"SecretValue,omitempty"`
-	SecretType  string `json:"SecretType,omitempty"`
+	ContentType string `json:"ContentType,omitempty"`
 }
 
 func (c *Client) KeyVaultSecretCreate(tenantID string, rq *DuploAzureKeyVaultRequest) ClientError {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-41523](https://app.clickup.com/t/86af9r636)

## Overview

When creating an Azure Key Vault secret via `duplocloud_azure_key_vault_secret` with the `type` attribute set, the value was saved in Terraform state but did not appear in the DuploCloud UI's Content Type column or in the resource JSON. Terraform reported no error during apply.

Root cause: the SDK request struct `DuploAzureKeyVaultRequest` serialized the field as `SecretType`, but the backend (and the UI's own create request) expects `ContentType`. Since the POST returned an empty 200 response that the client treats as success (`duplosdk/client.go:275-283`), the mismatch was silent — the backend dropped the unrecognized field.

## Summary of changes

This PR does the following:

- Rename `DuploAzureKeyVaultRequest.SecretType` to `ContentType` with matching `json:"ContentType,omitempty"` tag, aligning with the wire format used by the DuploCloud UI and with the sibling `DuploAzureTenantKeyVaultSecretRequest` struct.
- Update `expandAzureKeyVaultSecret` in `resource_duplo_azure_key_vault_secret.go` to populate the renamed field.
- The Terraform schema attribute `type` is unchanged, so existing `.tf` configs keep working — only the wire format to Duplo changes.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None