### PR TITLE
DUPLO-41548 TF: fix resource_group_name drift on azure_log_analytics_workspace

### DIFF
--- a/duplocloud/resource_duplo_azure_log_analytics_workspace.go
+++ b/duplocloud/resource_duplo_azure_log_analytics_workspace.go
@@ -115,9 +115,8 @@ func resourceAzureLogAnalyticsWorkspaceRead(ctx context.Context, d *schema.Resou
 		d.SetId("")
 
 	}
-	rgpn := strings.Split(duplo.ID, "/")
 	d.Set("infra_name", infraName)
-	d.Set("resource_group_name", rgpn[len(rgpn)-1])
+	d.Set("resource_group_name", parseResourceGroupFromAzureID(duplo.ID))
 	d.Set("name", name)
 	d.Set("azure_id", duplo.ID)
 	d.Set("sku", duplo.PropertiesSku.Name)
@@ -202,6 +201,19 @@ func parseAzureLogAnalyticsWorkspaceIdParts(id string) (infraName, name string, 
 		err = fmt.Errorf("invalid resource ID: %s", id)
 	}
 	return
+}
+
+// parseResourceGroupFromAzureID extracts the resource group name from a full Azure resource ID
+// of the form: /subscriptions/{sub}/resourceGroups/{rg}/providers/Microsoft.OperationalInsights/workspaces/{name}
+// The match on "resourceGroups" is case-insensitive, since some Azure APIs return it lower-cased.
+func parseResourceGroupFromAzureID(azureID string) string {
+	parts := strings.Split(azureID, "/")
+	for i, p := range parts {
+		if strings.EqualFold(p, "resourceGroups") && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
 }
 
 func logAnalyticsWorkspaceWaitUntilReady(ctx context.Context, c *duplosdk.Client, infraName string, name string, timeout time.Duration) error {

--- a/duplocloud/resource_duplo_azure_log_analytics_workspace.go
+++ b/duplocloud/resource_duplo_azure_log_analytics_workspace.go
@@ -113,7 +113,7 @@ func resourceAzureLogAnalyticsWorkspaceRead(ctx context.Context, d *schema.Resou
 	if duplo.ID == "" {
 		log.Printf("[DEBUG] resourceAzureLogAnalyticsWorkspaceRead: Azure Log Analytics Workspace %s not found for tenantId %s, removing from state", name, infraName)
 		d.SetId("")
-
+		return nil
 	}
 	d.Set("infra_name", infraName)
 	d.Set("resource_group_name", parseResourceGroupFromAzureID(duplo.ID))


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-41548

## Overview

Fixes a false-positive drift on `duplocloud_azure_log_analytics_workspace` where `terraform plan` always reports an in-place update on `resource_group_name` after a successful apply.

The Read handler extracted the RG from the Azure resource ID by taking the last path segment, but the last segment of an Azure ARM ID is the workspace name, not the resource group. As a result the state was populated with the workspace name, producing perpetual drift against the configured value.

## Summary of changes

This PR does the following:

- Replace the last-segment split with a helper that walks the Azure resource ID and returns the segment immediately after ` resourceGroups` (case-insensitive).
- Apply the helper in the Read handler so `resource_group_name` in state reflects the real RG.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None