### PR TITLE
DUPLO-41572 TF: fix inconsistent apply result on Azure infrastructure subnet create

### DIFF
--- a/duplosdk/infrastructure.go
+++ b/duplosdk/infrastructure.go
@@ -365,8 +365,12 @@ func (c *Client) InfrastructureGetSubnet(infraName string, subnetName string, su
 	}
 
 	// Return the subnet, if it exists.
+	// Use a case-insensitive name compare: Azure normalizes subnet names to lowercase
+	// server-side (e.g. user-supplied "mySubnet1" is stored as "custom-mysubnet1"),
+	// while the name we search with is derived from the ID which preserves the
+	// user's original case.
 	for _, subnet := range *config.Vnet.Subnets {
-		if subnet.Name == subnetName && subnet.AddressPrefix == subnetCidr {
+		if strings.EqualFold(subnet.Name, subnetName) && subnet.AddressPrefix == subnetCidr {
 
 			// Interpret the subnet type (FIXME - the backend needs to return this)
 			if subnet.SubnetType == "" {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-41572

## Overview

Creating a `duplocloud_infrastructure_subnet` on an Azure infra fails with `Provider produced inconsistent result after apply. Root object was present, but now absent.`, even though the subnet is successfully created in Duplo. The post-create Read fails to locate the just-created subnet because Azure normalizes the stored name to lowercase (`custom-mysubnet1`) while the provider looks it up using the user-supplied case preserved in the resource ID (`custom-mySubnet1`). The case-sensitive name compare in `InfrastructureGetSubnet` then returns no match, Read clears the ID, and Terraform surfaces the inconsistent-result error.

## Summary of changes

This PR does the following:

- Use `strings.EqualFold` instead of `==` when matching the subnet name inside `InfrastructureGetSubnet` (`duplosdk/infrastructure.go`) so the Read lookup succeeds regardless of the case the backend stored.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None