### PR TITLE
DUPLO-42688 TF: add aws_tags attribute to duplocloud_asg_profile

### DIFF
--- a/docs/data-sources/asg_profiles.md
+++ b/docs/data-sources/asg_profiles.md
@@ -32,7 +32,7 @@ Read-Only:
 - `agent_platform` (Number)
 - `allocated_public_ip` (Boolean)
 - `arn` (String)
-- `aws_tags` (Map of String)
+- `asg_tags` (Map of String)
 - `base64_user_data` (String)
 - `can_scale_from_zero` (Boolean)
 - `capacity` (String)

--- a/docs/data-sources/asg_profiles.md
+++ b/docs/data-sources/asg_profiles.md
@@ -32,6 +32,7 @@ Read-Only:
 - `agent_platform` (Number)
 - `allocated_public_ip` (Boolean)
 - `arn` (String)
+- `aws_tags` (Map of String)
 - `base64_user_data` (String)
 - `can_scale_from_zero` (Boolean)
 - `capacity` (String)

--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -280,12 +280,12 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 }
 
 // Example applying arbitrary AWS tags to the ASG and its EC2 instances via
-// `aws_tags`. Use `custom_data_tags` for `AllocationTags` and `aws_tags` for
-// everything else. Changes to `aws_tags` force replacement.
+// `asg_tags`. Use `custom_data_tags` for `AllocationTags` and `asg_tags` for
+// everything else. Changes to `asg_tags` force replacement.
 resource "duplocloud_asg_profile" "duplo-test-asg-with-aws-tags" {
   tenant_id = duplocloud_tenant.duplo-app.tenant_id
 
-  friendly_name      = "my-asg-aws-tags"
+  friendly_name      = "my-asg-with-tags"
   instance_count     = 1
   min_instance_count = 1
   max_instance_count = 1
@@ -300,9 +300,9 @@ resource "duplocloud_asg_profile" "duplo-test-asg-with-aws-tags" {
     value = "allocation-tg"
   }
 
-  aws_tags = {
-    "com.radiantlogic.cicd/node-type" = "worker"
-    "Environment"                     = "production"
+  asg_tags = {
+    "com.duplo.cicd/node-type" = "worker"
+    "Environment"              = "production"
   }
 }
 
@@ -362,7 +362,7 @@ resource "duplocloud_asg_profile" "mixed-instances-asg" {
 - 7: EKS Linux
 - 8: ECS Defaults to `0`.
 - `allocated_public_ip` (Boolean) Whether or not to allocate a public IP. Defaults to `false`.
-- `aws_tags` (Map of String) A map of arbitrary AWS tags applied to the ASG and its launched EC2 instances (routed via the backend's `TagsCsv` field). Use this for tags that aren't `AllocationTags` — those belong in `custom_data_tags`. Changes force replacement because the backend applies these tags only at create time.
+- `asg_tags` (Map of String) A map of arbitrary AWS tags applied to the ASG and its launched EC2 instances (routed via the backend's `TagsCsv` field). Use this for tags that aren't `AllocationTags` — those belong in `custom_data_tags`. Changes force replacement because the backend applies these tags only at create time.
 - `base64_user_data` (String) Base64 encoded EC2 user data to associated with the host.
 - `can_scale_from_zero` (Boolean) Whether or not ASG should leverage duplocloud's scale from 0 feature
 - `capacity` (String) The AWS EC2 instance type.

--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -279,6 +279,33 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
   }
 }
 
+// Example applying arbitrary AWS tags to the ASG and its EC2 instances via
+// `aws_tags`. Use `custom_data_tags` for `AllocationTags` and `aws_tags` for
+// everything else. Changes to `aws_tags` force replacement.
+resource "duplocloud_asg_profile" "duplo-test-asg-with-aws-tags" {
+  tenant_id = duplocloud_tenant.duplo-app.tenant_id
+
+  friendly_name      = "my-asg-aws-tags"
+  instance_count     = 1
+  min_instance_count = 1
+  max_instance_count = 1
+  image_id           = "ami-0cfd96d646e5535a8"
+  capacity           = "t3a.medium"
+  agent_platform     = 7
+  zones              = [0]
+  user_account       = "sep8"
+
+  custom_data_tags {
+    key   = "AllocationTags"
+    value = "allocation-tg"
+  }
+
+  aws_tags = {
+    "com.radiantlogic.cicd/node-type" = "worker"
+    "Environment"                     = "production"
+  }
+}
+
 # Example with mixed instances policy for spot/on-demand distribution
 resource "duplocloud_asg_profile" "mixed-instances-asg" {
   tenant_id          = duplocloud_tenant.duplo-app.tenant_id
@@ -335,6 +362,7 @@ resource "duplocloud_asg_profile" "mixed-instances-asg" {
 - 7: EKS Linux
 - 8: ECS Defaults to `0`.
 - `allocated_public_ip` (Boolean) Whether or not to allocate a public IP. Defaults to `false`.
+- `aws_tags` (Map of String) A map of arbitrary AWS tags applied to the ASG and its launched EC2 instances (routed via the backend's `TagsCsv` field). Use this for tags that aren't `AllocationTags` — those belong in `custom_data_tags`. Changes force replacement because the backend applies these tags only at create time.
 - `base64_user_data` (String) Base64 encoded EC2 user data to associated with the host.
 - `can_scale_from_zero` (Boolean) Whether or not ASG should leverage duplocloud's scale from 0 feature
 - `capacity` (String) The AWS EC2 instance type.

--- a/duplocloud/data_source_duplo_asg_profile.go
+++ b/duplocloud/data_source_duplo_asg_profile.go
@@ -2,6 +2,7 @@ package duplocloud
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 
 	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
@@ -105,6 +106,7 @@ func flattenAsgProfile(duplo *duplosdk.DuploAsgProfile) map[string]interface{} {
 		"tags":                keyValueToState("tags", duplo.Tags),
 		"minion_tags":         keyValueToState("minion_tags", duplo.CustomDataTags),
 		"custom_data_tags":    keyValueToState("custom_data_tags", duplo.CustomDataTags),
+		"asg_tags":            parseAsgTagsCsv(duplo.TagsCsv),
 		"volume":              flattenNativeHostVolumes(duplo.Volumes),
 		"network_interface":   flattenNativeHostNetworkInterfaces(duplo.NetworkInterfaces),
 		"arn":                 duplo.Arn,
@@ -122,4 +124,16 @@ func flattenAsgProfile(duplo *duplosdk.DuploAsgProfile) map[string]interface{} {
 		mp["zones"] = []interface{}{}
 	}
 	return mp
+}
+
+func parseAsgTagsCsv(tagsCsv string) map[string]string {
+	parsed := map[string]string{}
+	if tagsCsv == "" {
+		return parsed
+	}
+	if err := json.Unmarshal([]byte(tagsCsv), &parsed); err != nil {
+		log.Printf("[WARN] Failed to unmarshal TagsCsv for asg_tags in ASG profile data source: %v", err)
+		return map[string]string{}
+	}
+	return parsed
 }

--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -2,6 +2,7 @@ package duplocloud
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"regexp"
@@ -351,6 +352,14 @@ func autoscalingGroupSchema() map[string]*schema.Schema {
 		Computed:      true,
 		Elem:          KeyValueSchema(),
 		ConflictsWith: []string{"minion_tags"},
+	}
+
+	awsASGSchema["aws_tags"] = &schema.Schema{
+		Description: "A map of arbitrary AWS tags applied to the ASG and its launched EC2 instances (routed via the backend's `TagsCsv` field). Use this for tags that aren't `AllocationTags` — those belong in `custom_data_tags`. Changes force replacement because the backend applies these tags only at create time.",
+		Type:        schema.TypeMap,
+		Optional:    true,
+		ForceNew:    true,
+		Elem:        &schema.Schema{Type: schema.TypeString},
 	}
 
 	return awsASGSchema
@@ -731,6 +740,12 @@ func asgProfileToState(d *schema.ResourceData, duplo *duplosdk.DuploAsgProfile, 
 	d.Set("tags", keyValueToState("tags", duplo.Tags))
 	d.Set("minion_tags", keyValueToState("minion_tags", duplo.MinionTags))
 	d.Set("custom_data_tags", keyValueToState("custom_data_tags", duplo.CustomDataTags))
+	if duplo.TagsCsv != "" {
+		var parsed map[string]string
+		if err := json.Unmarshal([]byte(duplo.TagsCsv), &parsed); err == nil {
+			d.Set("aws_tags", parsed)
+		}
+	}
 	d.Set("enabled_metrics", duplo.EnabledMetrics)
 	d.Set("arn", duplo.Arn)
 	// If a network interface was customized, certain fields are not returned by the backend.
@@ -832,6 +847,22 @@ func expandAsgProfile(d *schema.ResourceData) *duplosdk.DuploAsgProfile {
 	}
 
 	asgProfile.MixedInstancesPolicy = expandAsgMixedInstancesPolicy(d)
+
+	// aws_tags is routed through the backend's TagsCsv field (JSON-encoded),
+	// which is the only path that produces real AWS tags on the ASG and
+	// launched EC2 instances.
+	if v, ok := d.GetOk("aws_tags"); ok {
+		raw := v.(map[string]interface{})
+		if len(raw) > 0 {
+			stringMap := make(map[string]string, len(raw))
+			for k, val := range raw {
+				stringMap[k] = val.(string)
+			}
+			if jsonBytes, err := json.Marshal(stringMap); err == nil {
+				asgProfile.TagsCsv = string(jsonBytes)
+			}
+		}
+	}
 
 	return asgProfile
 }

--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -354,10 +354,11 @@ func autoscalingGroupSchema() map[string]*schema.Schema {
 		ConflictsWith: []string{"minion_tags"},
 	}
 
-	awsASGSchema["aws_tags"] = &schema.Schema{
+	awsASGSchema["asg_tags"] = &schema.Schema{
 		Description: "A map of arbitrary AWS tags applied to the ASG and its launched EC2 instances (routed via the backend's `TagsCsv` field). Use this for tags that aren't `AllocationTags` — those belong in `custom_data_tags`. Changes force replacement because the backend applies these tags only at create time.",
 		Type:        schema.TypeMap,
 		Optional:    true,
+		Computed:    true,
 		ForceNew:    true,
 		Elem:        &schema.Schema{Type: schema.TypeString},
 	}
@@ -740,12 +741,14 @@ func asgProfileToState(d *schema.ResourceData, duplo *duplosdk.DuploAsgProfile, 
 	d.Set("tags", keyValueToState("tags", duplo.Tags))
 	d.Set("minion_tags", keyValueToState("minion_tags", duplo.MinionTags))
 	d.Set("custom_data_tags", keyValueToState("custom_data_tags", duplo.CustomDataTags))
+	parsedAsgTags := map[string]string{}
 	if duplo.TagsCsv != "" {
-		var parsed map[string]string
-		if err := json.Unmarshal([]byte(duplo.TagsCsv), &parsed); err == nil {
-			d.Set("aws_tags", parsed)
+		if err := json.Unmarshal([]byte(duplo.TagsCsv), &parsedAsgTags); err != nil {
+			log.Printf("[WARN] Failed to unmarshal TagsCsv for asg_tags in ASG profile state: %v", err)
+			parsedAsgTags = map[string]string{}
 		}
 	}
+	d.Set("asg_tags", parsedAsgTags)
 	d.Set("enabled_metrics", duplo.EnabledMetrics)
 	d.Set("arn", duplo.Arn)
 	// If a network interface was customized, certain fields are not returned by the backend.
@@ -848,10 +851,10 @@ func expandAsgProfile(d *schema.ResourceData) *duplosdk.DuploAsgProfile {
 
 	asgProfile.MixedInstancesPolicy = expandAsgMixedInstancesPolicy(d)
 
-	// aws_tags is routed through the backend's TagsCsv field (JSON-encoded),
+	// asg_tags is routed through the backend's TagsCsv field (JSON-encoded),
 	// which is the only path that produces real AWS tags on the ASG and
 	// launched EC2 instances.
-	if v, ok := d.GetOk("aws_tags"); ok {
+	if v, ok := d.GetOk("asg_tags"); ok {
 		raw := v.(map[string]interface{})
 		if len(raw) > 0 {
 			stringMap := make(map[string]string, len(raw))

--- a/duplosdk/asg.go
+++ b/duplosdk/asg.go
@@ -31,6 +31,7 @@ type DuploAsgProfile struct {
 	NetworkInterfaces    *[]DuploNativeHostNetworkInterface `json:"NetworkInterfaces,omitempty"`
 	Status               string                             `json:"Status,omitempty"`
 	Tags                 *[]DuploKeyStringValue             `json:"Tags,omitempty"`
+	TagsCsv              string                             `json:"TagsCsv,omitempty"`
 	TenantId             string                             `json:"TenantId,omitempty"`
 	UseSpotInstances     bool                               `json:"UseSpotInstances,omitempty"`
 	Volumes              *[]DuploNativeHostVolume           `json:"Volumes,omitempty"`

--- a/examples/resources/duplocloud_asg_profile/resource.tf
+++ b/examples/resources/duplocloud_asg_profile/resource.tf
@@ -260,12 +260,12 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
 }
 
 // Example applying arbitrary AWS tags to the ASG and its EC2 instances via
-// `aws_tags`. Use `custom_data_tags` for `AllocationTags` and `aws_tags` for
-// everything else. Changes to `aws_tags` force replacement.
+// `asg_tags`. Use `custom_data_tags` for `AllocationTags` and `asg_tags` for
+// everything else. Changes to `asg_tags` force replacement.
 resource "duplocloud_asg_profile" "duplo-test-asg-with-aws-tags" {
   tenant_id = duplocloud_tenant.duplo-app.tenant_id
 
-  friendly_name      = "my-asg-aws-tags"
+  friendly_name      = "my-asg-with-tags"
   instance_count     = 1
   min_instance_count = 1
   max_instance_count = 1
@@ -280,9 +280,9 @@ resource "duplocloud_asg_profile" "duplo-test-asg-with-aws-tags" {
     value = "allocation-tg"
   }
 
-  aws_tags = {
-    "com.radiantlogic.cicd/node-type" = "worker"
-    "Environment"                     = "production"
+  asg_tags = {
+    "com.duplo.cicd/node-type" = "worker"
+    "Environment"              = "production"
   }
 }
 

--- a/examples/resources/duplocloud_asg_profile/resource.tf
+++ b/examples/resources/duplocloud_asg_profile/resource.tf
@@ -259,6 +259,33 @@ resource "duplocloud_asg_profile" "duplo-test-asg" {
   }
 }
 
+// Example applying arbitrary AWS tags to the ASG and its EC2 instances via
+// `aws_tags`. Use `custom_data_tags` for `AllocationTags` and `aws_tags` for
+// everything else. Changes to `aws_tags` force replacement.
+resource "duplocloud_asg_profile" "duplo-test-asg-with-aws-tags" {
+  tenant_id = duplocloud_tenant.duplo-app.tenant_id
+
+  friendly_name      = "my-asg-aws-tags"
+  instance_count     = 1
+  min_instance_count = 1
+  max_instance_count = 1
+  image_id           = "ami-0cfd96d646e5535a8"
+  capacity           = "t3a.medium"
+  agent_platform     = 7
+  zones              = [0]
+  user_account       = "sep8"
+
+  custom_data_tags {
+    key   = "AllocationTags"
+    value = "allocation-tg"
+  }
+
+  aws_tags = {
+    "com.radiantlogic.cicd/node-type" = "worker"
+    "Environment"                     = "production"
+  }
+}
+
 # Example with mixed instances policy for spot/on-demand distribution
 resource "duplocloud_asg_profile" "mixed-instances-asg" {
   tenant_id          = duplocloud_tenant.duplo-app.tenant_id


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-42688](https://app.clickup.com/t/86ah2daj1)

## Overview

Adds a new `aws_tags` attribute to `duplocloud_asg_profile` that routes arbitrary key/value pairs into the backend's `TagsCsv` field, producing real AWS tags on the ASG and its launched EC2 instances. `custom_data_tags` continues to handle `AllocationTags` exclusively.

## Summary of changes

This PR does the following:

- Adds `TagsCsv` field to `DuploAsgProfile` SDK struct.
- Adds `aws_tags` (TypeMap, ForceNew) schema attribute on `duplocloud_asg_profile`; expanded by JSON-encoding into `TagsCsv` and flattened by parsing `TagsCsv` on read.
- `ForceNew` because the backend only applies `TagsCsv` at ASG creation time.
- Updates the example resource config and regenerates docs.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None