### PR TITLE
DUPLO-42104 TF: allow in-place update of sasl_iam for kafka clusters

### DIFF
--- a/docs/resources/aws_kafka_cluster.md
+++ b/docs/resources/aws_kafka_cluster.md
@@ -51,7 +51,7 @@ resource "duplocloud_aws_kafka_cluster" "serverless" {
 See the [AWS documentation](https://docs.aws.amazon.com/msk/latest/developerguide/msk-create-cluster.html) for more information.
 - `is_serverless` (Boolean) Enable to make the cluster serverless.  When enabled, the `instance_type`, `storage_size`, `kafka_version`, `configuration_arn`, `configuration_revision`, and `encryption_in_transit` parameters are not applicable. Defaults to `false`.
 - `kafka_version` (String) The version of the Kafka cluster.
-- `sasl_iam` (Boolean) Enable SASL/IAM client authentication. Applies to both provisioned and serverless clusters. **Note:** In-place updates of this property are not currently supported. To change this setting, update it directly in AWS and run `terraform import` to sync the state. For serverless clusters, SASL/IAM is always enabled and cannot be disabled.
+- `sasl_iam` (Boolean) Enable SASL/IAM client authentication. Applies to both provisioned and serverless clusters. For serverless clusters, SASL/IAM is always enabled and cannot be changed after creation.
 - `storage_size` (Number) The size of the Kafka storage, in gigabytes.
 - `subnets` (List of String) The list of subnets that the cluster will be launched in.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/duplocloud/resource_duplo_kafka_cluster.go
+++ b/duplocloud/resource_duplo_kafka_cluster.go
@@ -158,8 +158,7 @@ func kafkaClusterSchema() map[string]*schema.Schema {
 		},
 		"sasl_iam": {
 			Description: "Enable SASL/IAM client authentication. Applies to both provisioned and serverless clusters. " +
-				"**Note:** In-place updates of this property are not currently supported. To change this setting, update it directly in AWS and run `terraform import` to sync the state. " +
-				"For serverless clusters, SASL/IAM is always enabled and cannot be disabled.",
+				"For serverless clusters, SASL/IAM is always enabled and cannot be changed after creation.",
 			Type:     schema.TypeBool,
 			Optional: true,
 			Computed: true,
@@ -491,8 +490,24 @@ func resourceKafkaClusterUpdate(ctx context.Context, d *schema.ResourceData, m i
 		if err != nil {
 			return diag.Errorf("Error updating tenant %s kafka cluster '%s' configuration: %s", tenantID, name, err)
 		}
-		log.Printf("[TRACE] resourceKafkaClusterUpdate ******** end")
+		if err := duploKafkaClusterWaitUntilReady(ctx, c, tenantID, arn, d.Timeout("update")); err != nil {
+			return diag.FromErr(err)
+		}
+	}
 
+	if d.HasChange("sasl_iam") {
+		auth := &duplosdk.DuploKafkaClientAuthentication{
+			Sasl: &duplosdk.DuploKafkaSasl{
+				Iam: &duplosdk.DuploKafkaSaslIam{
+					Enabled: d.Get("sasl_iam").(bool),
+				},
+			},
+		}
+		// Pass an empty CurrentVersion so the backend refetches the latest value, which is necessary in case
+		// a prior update (e.g. configuration) in this same Update has bumped the cluster's CurrentVersion.
+		if err := c.UpdateKafkaClusterClientAuthentication(tenantID, arn, "", auth); err != nil {
+			return diag.Errorf("Error updating tenant %s kafka cluster '%s' client authentication: %s", tenantID, name, err)
+		}
 	}
 
 	err = duploKafkaClusterWaitUntilReady(ctx, c, tenantID, arn, d.Timeout("update"))
@@ -529,6 +544,9 @@ func validateKafkaParameters(ctx context.Context, d *schema.ResourceDiff, m inte
 		if d.NewValueKnown("sasl_iam") && !d.Get("sasl_iam").(bool) {
 			return fmt.Errorf("sasl_iam cannot be set to false for serverless clusters, SASL/IAM is always enabled")
 		}
+		if d.Id() != "" && d.HasChange("sasl_iam") {
+			return fmt.Errorf("sasl_iam cannot be updated after creation for serverless clusters; create a new serverless cluster with the desired sasl_iam setting")
+		}
 	} else {
 		if v := d.Get("instance_type"); v.(string) == "" {
 			return fmt.Errorf("instance_type required for provisioned cluster when is_serverless is false")
@@ -545,11 +563,6 @@ func validateKafkaParameters(ctx context.Context, d *schema.ResourceDiff, m inte
 				return fmt.Errorf("encryption_in_transit must be set to \"TLS\" when sasl_iam is enabled on a provisioned cluster")
 			}
 		}
-	}
-
-	// In-place updates of sasl_iam are not currently supported. Update the setting directly in AWS and import the updated state.
-	if d.Id() != "" && d.HasChange("sasl_iam") {
-		return fmt.Errorf("in-place updates of sasl_iam are not supported; update the setting directly in AWS and run `terraform import` to sync the state")
 	}
 
 	return nil

--- a/duplocloud/resource_duplo_kafka_cluster.go
+++ b/duplocloud/resource_duplo_kafka_cluster.go
@@ -545,7 +545,7 @@ func validateKafkaParameters(ctx context.Context, d *schema.ResourceDiff, m inte
 			return fmt.Errorf("sasl_iam cannot be set to false for serverless clusters, SASL/IAM is always enabled")
 		}
 		if d.Id() != "" && d.HasChange("sasl_iam") {
-			return fmt.Errorf("sasl_iam cannot be updated after creation for serverless clusters; create a new serverless cluster with the desired sasl_iam setting")
+			return fmt.Errorf("sasl_iam cannot be updated after creation for serverless clusters; serverless clusters always have sasl_iam enabled")
 		}
 	} else {
 		if v := d.Get("instance_type"); v.(string) == "" {

--- a/duplosdk/tenant_aws_cloud_resources.go
+++ b/duplosdk/tenant_aws_cloud_resources.go
@@ -865,6 +865,15 @@ func (c *Client) UpdateKafkaClusterConfiguration(tenantID string, encodedArn, ar
 	return rp, nil
 }
 
+// UpdateKafkaClusterClientAuthentication updates the client authentication settings of a provisioned Kafka cluster.
+func (c *Client) UpdateKafkaClusterClientAuthentication(tenantID, arn, cv string, auth *DuploKafkaClientAuthentication) ClientError {
+	rp := make(map[string]interface{})
+	return c.putAPI(fmt.Sprintf("UpdateKafkaClusterClientAuthentication(%s, %s)", tenantID, arn),
+		fmt.Sprintf("v3/subscriptions/%s/aws/kafka/client-authentication", tenantID),
+		map[string]interface{}{"ClusterArn": arn, "CurrentVersion": cv, "ClientAuthentication": auth},
+		&rp)
+}
+
 // TenantGetKafkaClusterBootstrapBrokers gets a non-cached view of the kafka cluster's info via Duplo.
 func (c *Client) TenantGetKafkaClusterBootstrapBrokers(tenantID string, arn string) (*DuploKafkaBootstrapBrokers, ClientError) {
 	rp := DuploKafkaBootstrapBrokers{}


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-42104

## Overview

Allow `sasl_iam` (client authentication) to be updated in place on provisioned AWS Kafka clusters, paired with the new BE endpoint added in DUPLO-42103.

## Summary of changes

This PR does the following:

- Adds SDK method `UpdateKafkaClusterClientAuthentication` that calls the new BE route `PUT v3/subscriptions/{tenantId}/aws/kafka/client-authentication`.
- Wires `resourceKafkaClusterUpdate` to call the new SDK method whenever `sasl_iam` changes, waiting for the cluster to return to `ACTIVE` between chained updates.
- Removes the universal plan-time block that rejected any in-place `sasl_iam` change; replaces it with a serverless-only block (mirrors the BE rejection of serverless updates).
- Updates the `sasl_iam` schema description and regenerates the resource doc.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None