### PR TITLE
DUPLO-42294 TF: clarify ecache_instance field constraints in docs

### DIFF
--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -190,10 +190,10 @@ See AWS documentation for the [available instance types](https://docs.aws.amazon
 
 ### Optional
 
-- `auth_token` (String) Set a password for authenticating to the ElastiCache instance.  Only supported if `encryption_in_transit` is to to `true`.
+- `auth_token` (String) Set a password for authenticating to the ElastiCache instance.  Only supported if `encryption_in_transit` is set to `true`.
 
 See AWS documentation for the [required format](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html) of this field.
-- `automatic_failover_enabled` (Boolean) Enables automatic failover.
+- `automatic_failover_enabled` (Boolean) Enables automatic failover. Requires `replicas` to be 2 or more. Must be `true` when `enable_cluster_mode` or `multi_az_enabled` is `true`.
 - `cache_type` (Number) The numerical index of elasticache instance type.
 Should be one of:
 
@@ -206,16 +206,16 @@ Should be one of:
 - `encryption_at_rest` (Boolean) Enables encryption-at-rest. Defaults to `false`.
 - `encryption_in_transit` (Boolean) Enables encryption-in-transit. Defaults to `false`.
 - `engine_version` (String) The engine version of the elastic instance.
-See AWS documentation for the [available Redis and Valkey instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) or the [available Memcached instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions-mc.html).
+See AWS documentation for the [available Redis and Valkey instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) or the [available Memcached instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions-mc.html). Only upgrades are supported; downgrades are rejected on update.
 - `kms_key_id` (String) The globally unique identifier for the key.
 - `log_delivery_configuration` (Block Set, Max: 2) (see [below for nested schema](#nestedblock--log_delivery_configuration))
-- `multi_az_enabled` (Boolean) Enables Multi-AZ support for the ElastiCache instance. Multi-AZ is only applicable for Redis (cache_type=0) and Valkey (cache_type=2). When enabled, automatic_failover_enabled must also be set to true.
+- `multi_az_enabled` (Boolean) Enables Multi-AZ support for the ElastiCache instance. Multi-AZ is only applicable for Redis (cache_type=0) and Valkey (cache_type=2). When enabled, automatic_failover_enabled must also be set to true. Requires `replicas` to be 2 or more.
 - `number_of_shards` (Number) The number of shards to create. Applicable only if enable_cluster_mode is set to true
 - `parameter_group_name` (String) The REDIS/Valkey parameter group to supply.
 - `replicas` (Number) The number of replicas to create. Supported number of replicas is 1 to 6 Defaults to `1`.
 - `snapshot_arns` (List of String) Specify the ARN of a Redis/Valkey RDB snapshot file stored in Amazon S3. User should have the access to export snapshot to s3 bucket. One can find steps to provide access to export snapshot to s3 on following link https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/backups-exporting.html
 - `snapshot_name` (String) Select the snapshot/backup you want to use for creating redis/valkey.
-- `snapshot_retention_limit` (Number) Specify retention limit in days. Accepted values - 1-35.
+- `snapshot_retention_limit` (Number) Specify retention limit in days. Accepted values - 1-35. Not supported for Memcached (`cache_type=1`).
 - `snapshot_window` (String) Specify snapshot window limit The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your node group (shard). Example: 05:00-09:00. If you do not specify this parameter, ElastiCache automatically chooses an appropriate time range.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -87,7 +87,8 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 		"engine_version": {
 			Description: "The engine version of the elastic instance.\n" +
 				"See AWS documentation for the [available Redis and Valkey instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/supported-engine-versions.html) " +
-				"or the [available Memcached instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions-mc.html).",
+				"or the [available Memcached instance types](https://docs.aws.amazon.com/AmazonElastiCache/latest/mem-ug/supported-engine-versions-mc.html). " +
+				"Only upgrades are supported; downgrades are rejected on update.",
 			Type:     schema.TypeString,
 			Optional: true,
 			Computed: true,
@@ -118,13 +119,13 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			Default:     false,
 		},
 		"automatic_failover_enabled": {
-			Description: "Enables automatic failover.",
+			Description: "Enables automatic failover. Requires `replicas` to be 2 or more. Must be `true` when `enable_cluster_mode` or `multi_az_enabled` is `true`.",
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Computed:    true,
 		},
 		"multi_az_enabled": {
-			Description: "Enables Multi-AZ support for the ElastiCache instance. Multi-AZ is only applicable for Redis (cache_type=0) and Valkey (cache_type=2). When enabled, automatic_failover_enabled must also be set to true.",
+			Description: "Enables Multi-AZ support for the ElastiCache instance. Multi-AZ is only applicable for Redis (cache_type=0) and Valkey (cache_type=2). When enabled, automatic_failover_enabled must also be set to true. Requires `replicas` to be 2 or more.",
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Computed:    true,
@@ -137,7 +138,7 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			Default:     false,
 		},
 		"auth_token": {
-			Description: "Set a password for authenticating to the ElastiCache instance.  Only supported if `encryption_in_transit` is to to `true`.\n\n" +
+			Description: "Set a password for authenticating to the ElastiCache instance.  Only supported if `encryption_in_transit` is set to `true`.\n\n" +
 				"See AWS documentation for the [required format](https://docs.aws.amazon.com/AmazonElastiCache/latest/red-ug/auth.html) of this field.",
 			Type:     schema.TypeString,
 			Optional: true,
@@ -197,7 +198,7 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 			DiffSuppressFunc: diffSuppressWhenNotCreating,
 		},
 		"snapshot_retention_limit": {
-			Description:  "Specify retention limit in days. Accepted values - 1-35.",
+			Description:  "Specify retention limit in days. Accepted values - 1-35. Not supported for Memcached (`cache_type=1`).",
 			Type:         schema.TypeInt,
 			Optional:     true,
 			Computed:     true,


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-42294

## Overview

Documentation review of the `duplocloud_ecache_instance` resource. Updates the schema field descriptions to capture constraints that the provider already enforces but were not surfaced in the generated docs, and fixes a typo.

## Summary of changes

This PR does the following:

- `automatic_failover_enabled`: note that it requires `replicas` ≥ 2 and must be `true` when `enable_cluster_mode` or `multi_az_enabled` is `true`
- `multi_az_enabled`: note that it requires `replicas` ≥ 2
- `engine_version`: note that only upgrades are supported (downgrades are rejected on update)
- `snapshot_retention_limit`: note that it is not supported for Memcached (`cache_type=1`)
- `auth_token`: fix typo ("is to to" → "is set to")
- Regenerate `docs/resources/ecache_instance.md` via `make doc`

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None