### PR TITLE
DUPLO-40929 TF Doc: fix import example for k8_helm_release

### DIFF
--- a/docs/resources/k8_helm_release.md
+++ b/docs/resources/k8_helm_release.md
@@ -95,5 +95,5 @@ Import is supported using the following syntax:
 #  - *TENANT_ID* is the tenant GUID
 #  - *NAME* is the helm release name
 #
-terraform import duplocloud_k8_helm_repository.release *TENANT_ID*/helm-release/*NAME*
+terraform import duplocloud_k8_helm_release.release *TENANT_ID*/helm-release/*NAME*
 ```

--- a/examples/resources/duplocloud_k8_helm_release/import.sh
+++ b/examples/resources/duplocloud_k8_helm_release/import.sh
@@ -2,4 +2,4 @@
 #  - *TENANT_ID* is the tenant GUID
 #  - *NAME* is the helm release name
 #
-terraform import duplocloud_k8_helm_repository.release *TENANT_ID*/helm-release/*NAME*
+terraform import duplocloud_k8_helm_release.release *TENANT_ID*/helm-release/*NAME*


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-40929

## Overview

The import example for `duplocloud_k8_helm_release` referenced the wrong resource type (`duplocloud_k8_helm_repository`).

## Summary of changes

This PR does the following:

- Fix `examples/resources/duplocloud_k8_helm_release/import.sh` to use `duplocloud_k8_helm_release.release` instead of `duplocloud_k8_helm_repository.release`
- Regenerate `docs/resources/k8_helm_release.md` via `make doc`

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None