### PR TITLE
DUPLO-42415 TF: fix auto_minor_version_upgrade drift for Aurora writer

### DIFF
--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -426,8 +426,10 @@ func resourceDuploRdsInstanceRead(ctx context.Context, d *schema.ResourceData, m
 			return diag.Errorf("%s", err.Error())
 		}
 		duplo.DeletionProtection = clust.DeleteProtection
-		duplo.AutoMinorVersionUpgrade = clust.AutoMinorVersionUpgrade
-
+		// Do not override AutoMinorVersionUpgrade with the cluster-level value:
+		// the instance-level value is what AWS actually applies and what the
+		// user-configured create body sets. Sourcing from the cluster caused
+		// drift when the backend cluster-level value was stale (DUPLO-42415).
 	}
 	d.SetId(fmt.Sprintf("v2/subscriptions/%s/RDSDBInstance/%s", duplo.TenantID, duplo.Name))
 	// Convert the object into Terraform resource data

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -426,10 +426,11 @@ func resourceDuploRdsInstanceRead(ctx context.Context, d *schema.ResourceData, m
 			return diag.Errorf("%s", err.Error())
 		}
 		duplo.DeletionProtection = clust.DeleteProtection
-		// Do not override AutoMinorVersionUpgrade with the cluster-level value:
-		// the instance-level value is what AWS actually applies and what the
-		// user-configured create body sets. Sourcing from the cluster caused
-		// drift when the backend cluster-level value was stale (DUPLO-42415).
+		// Do not override AutoMinorVersionUpgrade with the cluster-level value.
+		// The cluster-level field is a derived aggregate: AWS sets it to false
+		// if any instance in the cluster has it disabled. It does not represent
+		// the writer's own setting, so using it here caused spurious drift
+		// (DUPLO-42415).
 	}
 	d.SetId(fmt.Sprintf("v2/subscriptions/%s/RDSDBInstance/%s", duplo.TenantID, duplo.Name))
 	// Convert the object into Terraform resource data


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-42415

## Overview

Aurora PostgreSQL writer instances showed persistent drift on `auto_minor_version_upgrade` after every apply.

## Summary of changes

- In `resourceDuploRdsInstanceRead`, removed the line that overwrote the instance-level `AutoMinorVersionUpgrade` with the cluster-level value from `DescribeRdsCluster`. The cluster-level value is a derived/aggregate field (false if any instance in the cluster has it disabled), so it did not accurately represent the writer instance's own setting, causing spurious drift.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None