### PR TITLE
DUPLO-41523 TF: Validate azure_key_vault_secret name starts with tenant prefix

### DIFF
--- a/docs/resources/azure_key_vault_secret.md
+++ b/docs/resources/azure_key_vault_secret.md
@@ -31,7 +31,7 @@ resource "duplocloud_azure_key_vault_secret" "myapp" {
 
 ### Required
 
-- `name` (String) Specifies the name of the Key Vault Secret. Changing this forces a new resource to be created.
+- `name` (String) Specifies the name of the Key Vault Secret. Must start with the tenant's account name (case-insensitive); the Duplo backend filters list results by this prefix, so secrets without it cannot be retrieved after creation. Changing this forces a new resource to be created.
 - `tenant_id` (String) The GUID of the tenant that the key vault secret will be created in.
 - `value` (String, Sensitive) Specifies the value of the Key vault secret.
 

--- a/docs/resources/azure_key_vault_secret.md
+++ b/docs/resources/azure_key_vault_secret.md
@@ -20,7 +20,7 @@ resource "duplocloud_tenant" "myapp" {
 
 resource "duplocloud_azure_key_vault_secret" "myapp" {
   tenant_id = duplocloud_tenant.myapp.tenant_id
-  name      = "myapp-base01-test"
+  name      = "${duplocloud_tenant.myapp.account_name}-test"
   value     = "tst"
   type      = "duplo_container_env"
 }

--- a/docs/resources/azure_key_vault_secret.md
+++ b/docs/resources/azure_key_vault_secret.md
@@ -20,7 +20,7 @@ resource "duplocloud_tenant" "myapp" {
 
 resource "duplocloud_azure_key_vault_secret" "myapp" {
   tenant_id = duplocloud_tenant.myapp.tenant_id
-  name      = "base01-test"
+  name      = "myapp-base01-test"
   value     = "tst"
   type      = "duplo_container_env"
 }

--- a/duplocloud/resource_duplo_azure_key_vault_secret.go
+++ b/duplocloud/resource_duplo_azure_key_vault_secret.go
@@ -23,7 +23,7 @@ func duploAzureKeyVaultSecretSchema() map[string]*schema.Schema {
 			ValidateFunc: validation.IsUUID,
 		},
 		"name": {
-			Description: "Specifies the name of the Key Vault Secret. Changing this forces a new resource to be created.",
+			Description: "Specifies the name of the Key Vault Secret. Must start with the tenant's account name (case-insensitive); the Duplo backend filters list results by this prefix, so secrets without it cannot be retrieved after creation. Changing this forces a new resource to be created.",
 			Type:        schema.TypeString,
 			ForceNew:    true,
 			Required:    true,
@@ -129,6 +129,10 @@ func resourceAzureKeyVaultSecretCreate(ctx context.Context, d *schema.ResourceDa
 	log.Printf("[TRACE] resourceAzureKeyVaultSecretCreate(%s, %s): start", tenantID, name)
 	c := m.(*duplosdk.Client)
 
+	if diags := validateKeyVaultSecretNamePrefix(c, tenantID, name); diags != nil {
+		return diags
+	}
+
 	rq := expandAzureKeyVaultSecret(d)
 	err = c.KeyVaultSecretCreate(tenantID, rq)
 	if err != nil {
@@ -180,6 +184,28 @@ func resourceAzureKeyVaultSecretDelete(ctx context.Context, d *schema.ResourceDa
 	}
 
 	log.Printf("[TRACE] resourceAzureKeyVaultSecretDelete(%s, %s): end", tenantID, name)
+	return nil
+}
+
+// validateKeyVaultSecretNamePrefix ensures the secret name starts with the tenant's
+// account name (case-insensitive). The Duplo backend's ListKeyVaultSecretsForTenant
+// filters list results by this prefix, so a secret without it would be created in
+// Azure but never returned by the post-create lookup, causing the provider to hang
+// until the create timeout expires.
+func validateKeyVaultSecretNamePrefix(c *duplosdk.Client, tenantID, name string) diag.Diagnostics {
+	tenant, err := c.GetTenantForUser(tenantID)
+	if err != nil {
+		return diag.Errorf("Unable to fetch tenant %s: %s", tenantID, err)
+	}
+	if tenant == nil {
+		return diag.Errorf("tenant %s not found", tenantID)
+	}
+	if !strings.HasPrefix(strings.ToLower(name), strings.ToLower(tenant.AccountName)) {
+		return diag.Errorf(
+			"azure key vault secret name %q must start with the tenant's account name %q (case-insensitive); the Duplo backend filters list results by this prefix and secrets without it cannot be retrieved after creation",
+			name, tenant.AccountName,
+		)
+	}
 	return nil
 }
 

--- a/examples/resources/duplocloud_azure_key_vault_secret/resource.tf
+++ b/examples/resources/duplocloud_azure_key_vault_secret/resource.tf
@@ -5,7 +5,7 @@ resource "duplocloud_tenant" "myapp" {
 
 resource "duplocloud_azure_key_vault_secret" "myapp" {
   tenant_id = duplocloud_tenant.myapp.tenant_id
-  name      = "base01-test"
+  name      = "myapp-base01-test"
   value     = "tst"
   type      = "duplo_container_env"
 }

--- a/examples/resources/duplocloud_azure_key_vault_secret/resource.tf
+++ b/examples/resources/duplocloud_azure_key_vault_secret/resource.tf
@@ -5,7 +5,7 @@ resource "duplocloud_tenant" "myapp" {
 
 resource "duplocloud_azure_key_vault_secret" "myapp" {
   tenant_id = duplocloud_tenant.myapp.tenant_id
-  name      = "myapp-base01-test"
+  name      = "${duplocloud_tenant.myapp.account_name}-test"
   value     = "tst"
   type      = "duplo_container_env"
 }


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-41523](https://app.clickup.com/t/8655600/DUPLO-41523)

## Overview

Creating a `duplocloud_azure_key_vault_secret` whose `name` does not start with the tenant's account name caused `terraform apply` to hang for ~1 hour and then fail with `expected azure key vault secret '...' to be retrieved, but got: nil`.

Root cause: the Duplo backend's `ListKeyVaultSecretsForTenant` (`AzureClient.cs:1494`) filters list results by `Identifier.Name.ToLower().StartsWith(tenantName)`. The secret is created in Azure successfully, but the post-create lookup goes through the filtered list and never finds it, so `waitForResourceToBePresentAfterCreate` polls until the 60-minute create timeout expires.

## Summary of changes

This PR does the following:

- Add `validateKeyVaultSecretNamePrefix` in `resource_duplo_azure_key_vault_secret.go` that runs before the create POST, fetches the tenant via `c.GetTenantForUser`, and fails fast with a clear error if `name` (case-insensitive) does not start with `tenant.AccountName`.
- Update the `name` attribute description to document the prefix requirement and regenerate `docs/resources/azure_key_vault_secret.md`.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None