### PR TITLE
DUPLO-41190 TF: derive invoke_arn partition from Lambda ARN for GovCloud

### DIFF
--- a/duplocloud/resource_duplo_aws_lambda_function.go
+++ b/duplocloud/resource_duplo_aws_lambda_function.go
@@ -829,13 +829,18 @@ func getInvokeARN(lambdaARN string) (string, error) {
 	if len(parts) < 6 {
 		return "", fmt.Errorf("invalid Lambda ARN: expected at least 6 colon-separated parts, got %d", len(parts))
 	}
+	partition := parts[1]
+	if partition == "" {
+		return "", fmt.Errorf("invalid Lambda ARN: partition is missing")
+	}
 	region := parts[3]
 	if region == "" {
 		return "", fmt.Errorf("invalid Lambda ARN: region is missing")
 	}
 
 	invokeARN := fmt.Sprintf(
-		"arn:aws:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations",
+		"arn:%s:apigateway:%s:lambda:path/2015-03-31/functions/%s/invocations",
+		partition,
 		region,
 		lambdaARN,
 	)


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-41190](https://app.clickup.com/t/8655600/DUPLO-41190)

## Overview

API Gateway Event creation failed in AWS GovCloud with a `400 Invalid ARN specified in the request` error. The `invoke_arn` attribute on `duplocloud_aws_lambda_function` was built with a hardcoded `arn:aws` partition, producing a mixed-partition ARN (an `arn:aws` apigateway ARN wrapping an `arn:aws-us-gov` Lambda ARN), which AWS rejected.

## Summary of changes

This PR does the following:

- `getInvokeARN` now derives the partition from the source Lambda ARN instead of hardcoding `aws`, so both commercial (`aws`) and GovCloud (`aws-us-gov`) produce valid invoke ARNs.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None