### PR TITLE
DUPLO-43187 TF: Allow S3 encryption with CMK

### DIFF
--- a/docs/data-sources/s3_bucket.md
+++ b/docs/data-sources/s3_bucket.md
@@ -62,6 +62,7 @@ output "bucket_domain_name" {
 
 Read-Only:
 
+- `kms_key_id` (String)
 - `method` (String)
 
 

--- a/docs/resources/s3_bucket.md
+++ b/docs/resources/s3_bucket.md
@@ -163,6 +163,29 @@ resource "duplocloud_s3_bucket" "bucket" {
 }
 ```
 
+### Create an S3 bucket encrypted with a specific tenant KMS key (CMK)
+
+```terraform
+data "duplocloud_tenant" "tenant" {
+  name = "preprod"
+}
+
+resource "duplocloud_s3_bucket" "bucket" {
+  tenant_id           = data.duplocloud_tenant.tenant.id
+  name                = "data"
+  allow_public_access = false
+  enable_access_logs  = false
+  enable_versioning   = true
+  managed_policies    = ["ssl"]
+  default_encryption {
+    method = "TenantKms"
+    # The KMS key ID or ARN must belong to the tenant or plan.
+    # Omit kms_key_id to use the default tenant KMS key.
+    kms_key_id = "arn:aws:kms:us-west-2:123456789012:key/5ae7e54b-553e-42ef-936e-5f554df6bf9a"
+  }
+}
+```
+
 ### Deploy an S3 bucket with hardened security settings
 
 ```terraform
@@ -263,6 +286,7 @@ resource "duplocloud_s3_bucket" "static_assets" {
 
 Optional:
 
+- `kms_key_id` (String) The tenant KMS key ID or ARN to use for encryption.  Only applicable when `method` is `TenantKms`.  When omitted, the default tenant KMS key is used.
 - `method` (String) Default encryption method.  Must be one of: `None`, `Sse`, `AwsKms`, `TenantKms`. Defaults to `Sse`.
 
 

--- a/duplocloud/data_source_duplo_s3_bucket.go
+++ b/duplocloud/data_source_duplo_s3_bucket.go
@@ -69,6 +69,11 @@ func dataSourceS3Bucket() *schema.Resource {
 							Type:        schema.TypeString,
 							Computed:    true,
 						},
+						"kms_key_id": {
+							Description: "The tenant KMS key ARN used for encryption, when a specific key is selected.",
+							Type:        schema.TypeString,
+							Computed:    true,
+						},
 					},
 				},
 			},
@@ -150,7 +155,8 @@ func flattenS3BucketData(d *schema.ResourceData, tenantID string, name string, d
 	d.Set("enable_access_logs", duplo.EnableAccessLogs)
 	d.Set("allow_public_access", duplo.AllowPublicAccess)
 	d.Set("default_encryption", []map[string]interface{}{{
-		"method": duplo.DefaultEncryption,
+		"method":     duplo.DefaultEncryption,
+		"kms_key_id": duplo.EncryptionKmsKeyId,
 	}})
 	d.Set("managed_policies", duplo.Policies)
 	d.Set("tags", keyValueToState("tags", duplo.Tags))

--- a/duplocloud/resource_duplo_s3_bucket.go
+++ b/duplocloud/resource_duplo_s3_bucket.go
@@ -94,12 +94,13 @@ func s3BucketSchema() map[string]*schema.Schema {
 						Default:      "Sse",
 						ValidateFunc: validation.StringInSlice([]string{"None", "Sse", "AwsKms", "TenantKms"}, false),
 					},
-					// RESERVED FOR THE FUTURE
-					//
-					//"kms_key_id": {
-					//	Type:     schema.TypeString,
-					//	Optional: true,
-					//},
+					"kms_key_id": {
+						Description: "The tenant KMS key ID or ARN to use for encryption.  Only applicable when `method` is `TenantKms`.  " +
+							"When omitted, the default tenant KMS key is used.",
+						Type:             schema.TypeString,
+						Optional:         true,
+						DiffSuppressFunc: diffSuppressS3KmsKeyId,
+					},
 				},
 			},
 		},
@@ -139,8 +140,33 @@ func resourceS3Bucket() *schema.Resource {
 			Create: schema.DefaultTimeout(20 * time.Minute),
 			Delete: schema.DefaultTimeout(20 * time.Minute),
 		},
-		Schema: s3BucketSchema(),
+		Schema:        s3BucketSchema(),
+		CustomizeDiff: validateS3BucketEncryption,
 	}
+}
+
+// validateS3BucketEncryption ensures default_encryption.kms_key_id is only set when
+// the encryption method is TenantKms - the backend ignores it for any other method.
+func validateS3BucketEncryption(ctx context.Context, diff *schema.ResourceDiff, m interface{}) error {
+	method := diff.Get("default_encryption.0.method").(string)
+	kmsKeyId := diff.Get("default_encryption.0.kms_key_id").(string)
+	if kmsKeyId != "" && method != "TenantKms" {
+		return fmt.Errorf("default_encryption.kms_key_id can only be set when default_encryption.method is \"TenantKms\" (got %q)", method)
+	}
+	return nil
+}
+
+// diffSuppressS3KmsKeyId suppresses spurious drift between a bare KMS key ID supplied
+// in config and the full key ARN the backend returns (which ends in "key/<key-id>").
+func diffSuppressS3KmsKeyId(k, old, new string, d *schema.ResourceData) bool {
+	if old == new {
+		return true
+	}
+	if old == "" || new == "" {
+		return false
+	}
+	// Treat an ARN and the bare key ID it embeds as equivalent.
+	return strings.HasSuffix(old, "/"+new) || strings.HasSuffix(new, "/"+old)
 }
 
 // READ resource
@@ -398,6 +424,9 @@ func resourceS3BucketUpdateOldApi(ctx context.Context, d *schema.ResourceData, m
 	if v, ok := defaultEncryption["method"]; ok && v != nil {
 		duploObject.DefaultEncryption = v.(string)
 	}
+	if v, ok := defaultEncryption["kms_key_id"]; ok && v != nil {
+		duploObject.EncryptionKmsKeyId = v.(string)
+	}
 
 	// Set the managed policies.
 	if v, ok := getAsStringArray(d, "managed_policies"); ok && v != nil {
@@ -428,7 +457,8 @@ func resourceS3BucketSetData(d *schema.ResourceData, tenantID string, name strin
 	d.Set("enable_access_logs", duplo.EnableAccessLogs)
 	d.Set("allow_public_access", duplo.AllowPublicAccess)
 	d.Set("default_encryption", []map[string]interface{}{{
-		"method": duplo.DefaultEncryption,
+		"method":     duplo.DefaultEncryption,
+		"kms_key_id": duplo.EncryptionKmsKeyId,
 	}})
 	userAdded, ok := d.GetOk("managed_policies")
 	if ok {
@@ -480,6 +510,9 @@ func fillS3BucketRequest(duploObject *duplosdk.DuploS3BucketSettingsRequest, d *
 	}
 	if v, ok := defaultEncryption["method"]; ok && v != nil {
 		duploObject.DefaultEncryption = v.(string)
+	}
+	if v, ok := defaultEncryption["kms_key_id"]; ok && v != nil {
+		duploObject.EncryptionKmsKeyId = v.(string)
 	}
 
 	if v, ok := d.GetOk("region"); ok && v != nil {

--- a/duplocloud/resource_duplo_s3_bucket.go
+++ b/duplocloud/resource_duplo_s3_bucket.go
@@ -148,8 +148,17 @@ func resourceS3Bucket() *schema.Resource {
 // validateS3BucketEncryption ensures default_encryption.kms_key_id is only set when
 // the encryption method is TenantKms - the backend ignores it for any other method.
 func validateS3BucketEncryption(ctx context.Context, diff *schema.ResourceDiff, m interface{}) error {
-	method := diff.Get("default_encryption.0.method").(string)
-	kmsKeyId := diff.Get("default_encryption.0.kms_key_id").(string)
+	v, ok := diff.GetOk("default_encryption")
+	if !ok || v == nil {
+		return nil
+	}
+	blocks := v.([]interface{})
+	if len(blocks) == 0 || blocks[0] == nil {
+		return nil
+	}
+	mp := blocks[0].(map[string]interface{})
+	method, _ := mp["method"].(string)
+	kmsKeyId, _ := mp["kms_key_id"].(string)
 	if kmsKeyId != "" && method != "TenantKms" {
 		return fmt.Errorf("default_encryption.kms_key_id can only be set when default_encryption.method is \"TenantKms\" (got %q)", method)
 	}

--- a/duplocloud/resource_duplo_s3_bucket.go
+++ b/duplocloud/resource_duplo_s3_bucket.go
@@ -99,6 +99,7 @@ func s3BucketSchema() map[string]*schema.Schema {
 							"When omitted, the default tenant KMS key is used.",
 						Type:             schema.TypeString,
 						Optional:         true,
+						Computed:         true,
 						DiffSuppressFunc: diffSuppressS3KmsKeyId,
 					},
 				},

--- a/duplosdk/tenant_aws_cloud_resources.go
+++ b/duplosdk/tenant_aws_cloud_resources.go
@@ -89,6 +89,7 @@ type DuploS3Bucket struct {
 	EnableAccessLogs     bool                   `json:"EnableAccessLogs,omitempty"`
 	AllowPublicAccess    bool                   `json:"AllowPublicAccess,omitempty"`
 	DefaultEncryption    string                 `json:"DefaultEncryption,omitempty"`
+	EncryptionKmsKeyId   string                 `json:"EncryptionKmsKeyId,omitempty"`
 	Policies             []string               `json:"Policies,omitempty"`
 	Tags                 *[]DuploKeyStringValue `json:"Tags,omitempty"`
 	CorsAllowedHostNames []string               `json:"CorsAllowedHostNames,omitempty"`
@@ -250,14 +251,15 @@ type DuploS3BucketRequest struct {
 
 // DuploS3BucketSettingsRequest represents a request to create an S3 bucket resource
 type DuploS3BucketSettingsRequest struct {
-	Name              string   `json:"Name,omitempty"`
-	Region            string   `json:"Region,omitempty"`
-	Location          string   `json:"Location,omitempty"`
-	EnableVersioning  bool     `json:"EnableVersioning,omitempty"`
-	EnableAccessLogs  bool     `json:"EnableAccessLogs,omitempty"`
-	AllowPublicAccess bool     `json:"AllowPublicAccess,omitempty"`
-	DefaultEncryption string   `json:"DefaultEncryption,omitempty"`
-	Policies          []string `json:"Policies,omitempty"`
+	Name               string   `json:"Name,omitempty"`
+	Region             string   `json:"Region,omitempty"`
+	Location           string   `json:"Location,omitempty"`
+	EnableVersioning   bool     `json:"EnableVersioning,omitempty"`
+	EnableAccessLogs   bool     `json:"EnableAccessLogs,omitempty"`
+	AllowPublicAccess  bool     `json:"AllowPublicAccess,omitempty"`
+	DefaultEncryption  string   `json:"DefaultEncryption,omitempty"`
+	EncryptionKmsKeyId string   `json:"EncryptionKmsKeyId,omitempty"`
+	Policies           []string `json:"Policies,omitempty"`
 }
 
 type DuploS3BucketReplication struct {

--- a/templates/resources/s3_bucket.md.tmpl
+++ b/templates/resources/s3_bucket.md.tmpl
@@ -163,6 +163,29 @@ resource "duplocloud_s3_bucket" "bucket" {
 }
 ```
 
+### Create an S3 bucket encrypted with a specific tenant KMS key (CMK)
+
+```terraform
+data "duplocloud_tenant" "tenant" {
+  name = "preprod"
+}
+
+resource "duplocloud_s3_bucket" "bucket" {
+  tenant_id           = data.duplocloud_tenant.tenant.id
+  name                = "data"
+  allow_public_access = false
+  enable_access_logs  = false
+  enable_versioning   = true
+  managed_policies    = ["ssl"]
+  default_encryption {
+    method = "TenantKms"
+    # The KMS key ID or ARN must belong to the tenant or plan.
+    # Omit kms_key_id to use the default tenant KMS key.
+    kms_key_id = "arn:aws:kms:us-west-2:123456789012:key/5ae7e54b-553e-42ef-936e-5f554df6bf9a"
+  }
+}
+```
+
 ### Deploy an S3 bucket with hardened security settings
 
 ```terraform


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-43187](https://app.clickup.com/t/86ahv43z9)

## Overview

Adds support for encrypting an S3 bucket with a specific tenant KMS key (CMK), backing the API added in duplocloud-internal/duplo#5455. Previously `default_encryption.method = "TenantKms"` could only use the default tenant KMS key.

## Summary of changes

This PR does the following:

- Adds a `kms_key_id` attribute to the `default_encryption` block of `duplocloud_s3_bucket` (and exposes it read-only on the data source), wired to the new `EncryptionKmsKeyId` API field.
- Adds plan-time validation that `kms_key_id` is only set when `method = "TenantKms"`.
- Adds a `DiffSuppressFunc` so a bare key ID in config and the full key ARN returned by the backend are treated as equivalent (no spurious drift).
- Updates docs/examples.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
