### PR TITLE
DUPLO-43269 TF: mark launch template latest_version/default_version computed on in-place version update

### DIFF
--- a/duplocloud/resource_duplo_aws_launch_template.go
+++ b/duplocloud/resource_duplo_aws_launch_template.go
@@ -670,6 +670,20 @@ func flattenBlockDeviceMappings(bdms []duplosdk.DuploLaunchTemplateBlockDeviceMa
 }
 
 func launchtemplateValidation(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
+	// On an in-place update, changing a version-affecting attribute causes AWS to create a new
+	// launch template version. The computed latest_version / default_version must be marked as
+	// "known after apply" so dependents (e.g. duplocloud_aws_launch_template_default_version wired
+	// to latest_version) don't lock a stale version number and fail with "inconsistent final plan".
+	if diff.Id() != "" {
+		for _, a := range []string{"instance_type", "ami", "block_device_mapping", "instance_requirements"} {
+			if diff.HasChange(a) {
+				diff.SetNewComputed("latest_version")
+				diff.SetNewComputed("default_version")
+				break
+			}
+		}
+	}
+
 	ir, ok := diff.GetOk("instance_requirements")
 	if ok {
 		irList, ok := ir.([]interface{})

--- a/duplocloud/resource_duplo_aws_launch_template.go
+++ b/duplocloud/resource_duplo_aws_launch_template.go
@@ -677,8 +677,12 @@ func launchtemplateValidation(ctx context.Context, diff *schema.ResourceDiff, me
 	if diff.Id() != "" {
 		for _, a := range []string{"instance_type", "ami", "block_device_mapping", "instance_requirements"} {
 			if diff.HasChange(a) {
-				diff.SetNewComputed("latest_version")
-				diff.SetNewComputed("default_version")
+				if err := diff.SetNewComputed("latest_version"); err != nil {
+					return err
+				}
+				if err := diff.SetNewComputed("default_version"); err != nil {
+					return err
+				}
 				break
 			}
 		}


### PR DESCRIPTION
## ClickUp Ticket

<!-- Required: Link to the ClickUp ticket -->
<!-- Example: https://app.clickup.com/t/8655600/DUPLO-12345 -->

**ClickUp Ticket ID:** https://app.clickup.com/t/86ahzjdbg

## Overview

`duplocloud_aws_launch_template` failed apply with "Provider produced inconsistent final plan" on `default_version` when updated in place in a way that creates a new launch template version (e.g. changing `instance_type`), and a dependent `duplocloud_aws_launch_template_default_version` was wired to `lt.latest_version`.

## Summary of changes

This PR does the following:

- In `launchtemplateValidation` (CustomizeDiff), on an in-place update where a version-affecting attribute (`instance_type`, `ami`, `block_device_mapping`, `instance_requirements`) changes, mark the computed `latest_version` and `default_version` as "known after apply" via `SetNewComputed`, so dependents don't lock a stale version number.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
