### PR TITLE
DUPLO-43250 TF: Ecache: Allow update of Engine type from Redis -> Valkey

### DIFF
--- a/docs/resources/ecache_instance.md
+++ b/docs/resources/ecache_instance.md
@@ -201,7 +201,7 @@ Should be one of:
    - `1` : Memcache
    - `2` : Valkey
 
- Defaults to `0`.
+Changing `cache_type` from `0` (Redis) to `2` (Valkey) performs an in-place engine upgrade. Any other change to `cache_type` forces replacement of the instance. Defaults to `0`.
 - `enable_cluster_mode` (Boolean) Flag to enable/disable redis/valkey cluster mode. Cluster mode should be enabled if the instance acts as the primary for a global datastore.
 - `encryption_at_rest` (Boolean) Enables encryption-at-rest. Defaults to `false`.
 - `encryption_in_transit` (Boolean) Enables encryption-in-transit. Defaults to `false`.

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -966,9 +966,9 @@ func validateEcacheParameters(ctx context.Context, diff *schema.ResourceDiff, m 
 			// In-place Redis -> Valkey upgrade: the upgrade-engine endpoint sends engine_version as
 			// the target Valkey version. Require it to be a valid Valkey version here; otherwise the
 			// existing Redis version would be sent as the target and rejected by AWS.
-			target := diff.Get("engine_version").(string)
+			target := engVer
 			if vd := validValkeyVersionString(target, cty.Path{cty.GetAttrStep{Name: "engine_version"}}); vd.HasError() {
-				return fmt.Errorf("engine_version must be set to a valid Valkey version (e.g. 7.2 or above) when changing cache_type from Redis (0) to Valkey (2); got %q", target)
+				return fmt.Errorf("engine_version must be set to a valid Valkey version (format <major>.<minor>, e.g. 7.0) when changing cache_type from Redis (0) to Valkey (2); got %q", target)
 			}
 		} else {
 			// Every other cache_type change requires replacement.

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -962,7 +962,16 @@ func validateEcacheParameters(ctx context.Context, diff *schema.ResourceDiff, m 
 	if diff.Id() != "" && diff.HasChange("cache_type") {
 		oldRaw, newRaw := diff.GetChange("cache_type")
 		oldType, newType := oldRaw.(int), newRaw.(int)
-		if !(oldType == 0 && newType == 2) {
+		if oldType == 0 && newType == 2 {
+			// In-place Redis -> Valkey upgrade: the upgrade-engine endpoint sends engine_version as
+			// the target Valkey version. Require it to be a valid Valkey version here; otherwise the
+			// existing Redis version would be sent as the target and rejected by AWS.
+			target := diff.Get("engine_version").(string)
+			if vd := validValkeyVersionString(target, cty.Path{cty.GetAttrStep{Name: "engine_version"}}); vd.HasError() {
+				return fmt.Errorf("engine_version must be set to a valid Valkey version (e.g. 7.2 or above) when changing cache_type from Redis (0) to Valkey (2); got %q", target)
+			}
+		} else {
+			// Every other cache_type change requires replacement.
 			if err := diff.ForceNew("cache_type"); err != nil {
 				return err
 			}

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -77,10 +77,11 @@ func ecacheInstanceSchema() map[string]*schema.Schema {
 				"Should be one of:\n\n" +
 				"   - `0` : Redis\n" +
 				"   - `1` : Memcache\n" +
-				"   - `2` : Valkey\n\n",
+				"   - `2` : Valkey\n\n" +
+				"Changing `cache_type` from `0` (Redis) to `2` (Valkey) performs an in-place engine upgrade. " +
+				"Any other change to `cache_type` forces replacement of the instance.",
 			Type:         schema.TypeInt,
 			Optional:     true,
-			ForceNew:     true,
 			Default:      0,
 			ValidateFunc: validation.IntBetween(0, 2),
 		},
@@ -956,6 +957,18 @@ func validateEcacheParameters(ctx context.Context, diff *schema.ResourceDiff, m 
 		}
 	}
 
+	// cache_type is not declared ForceNew so that an in-place Redis -> Valkey engine upgrade is
+	// possible. Every other cache_type change still requires replacement, so force it here.
+	if diff.Id() != "" && diff.HasChange("cache_type") {
+		oldRaw, newRaw := diff.GetChange("cache_type")
+		oldType, newType := oldRaw.(int), newRaw.(int)
+		if !(oldType == 0 && newType == 2) {
+			if err := diff.ForceNew("cache_type"); err != nil {
+				return err
+			}
+		}
+	}
+
 	if diff.Id() != "" && diff.HasChange("engine_version") {
 		oldRaw, newRaw := diff.GetChange("engine_version")
 		oldVer, newVer := oldRaw.(string), newRaw.(string)
@@ -1358,8 +1371,35 @@ func resourceDuploEcacheInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 		time.Sleep(time.Duration(90) * time.Second)
 	}
 
+	// Engine upgrade Redis -> Valkey (in-place) — performed via the dedicated upgrade-engine
+	// endpoint, which swaps the engine and sets the target version in one operation. This subsumes
+	// any concurrent engine_version change, so the generic engine_version modify below is skipped.
+	engineUpgraded := false
+	if d.HasChange("cache_type") {
+		oldRaw, newRaw := d.GetChange("cache_type")
+		if oldRaw.(int) == 0 && newRaw.(int) == 2 {
+			targetVersion := d.Get("engine_version").(string)
+			log.Printf("[DEBUG] resourceDuploEcacheInstanceUpdate(%s, %s): upgrading engine Redis -> Valkey (target version %s)", tenantID, name, targetVersion)
+			rq := duplosdk.DuploEcacheUpgradeEngineRequest{
+				Identifier:          identifier,
+				TargetEngineVersion: targetVersion,
+			}
+			cerr := c.EcacheInstanceUpgradeEngine(tenantID, rq)
+			if cerr != nil {
+				return diag.Errorf("Error upgrading engine to Valkey for ECache instance '%s': %s", id, cerr)
+			}
+			_ = ecacheInstanceWaitUntilUnavailable(ctx, c, tenantID, name, 150*time.Second)
+			err = ecacheInstanceWaitUntilAvailable(ctx, c, tenantID, name)
+			if err != nil {
+				return diag.Errorf("Error waiting for ECache instance '%s' to be available after engine upgrade: %s", id, err)
+			}
+			time.Sleep(time.Duration(90) * time.Second)
+			engineUpgraded = true
+		}
+	}
+
 	// Engine version upgrade — last, may reboot nodes
-	if d.HasChange("engine_version") {
+	if !engineUpgraded && d.HasChange("engine_version") {
 		newVal := d.Get("engine_version").(string)
 		log.Printf("[DEBUG] resourceDuploEcacheInstanceUpdate(%s, %s): upgrading engine_version to %s", tenantID, name, newVal)
 		rq := &duplosdk.DuploEcacheModifyRequest{

--- a/duplosdk/ecache_instance.go
+++ b/duplosdk/ecache_instance.go
@@ -228,6 +228,24 @@ func (c *Client) EcacheInstanceModify(tenantID string, rq *DuploEcacheModifyRequ
 		rq, &rp, &conf)
 }
 
+// DuploEcacheUpgradeEngineRequest upgrades an existing Redis replication group to Valkey in place.
+type DuploEcacheUpgradeEngineRequest struct {
+	Identifier          string `json:"Identifier"`
+	TargetEngineVersion string `json:"TargetEngineVersion"`
+}
+
+// EcacheInstanceUpgradeEngine calls the v3 endpoint that upgrades a Redis ECache instance to Valkey.
+// The AWS modify is asynchronous and potentially disruptive; the engine is confirmed by reconciliation.
+func (c *Client) EcacheInstanceUpgradeEngine(tenantID string, rq DuploEcacheUpgradeEngineRequest) ClientError {
+	// The endpoint returns the in-progress ECacheDBInstanceDetails; absorb it into a map since the
+	// authoritative state is fetched by a follow-up read.
+	var rp map[string]interface{}
+	return c.postAPI(
+		fmt.Sprintf("EcacheInstanceUpgradeEngine(%s, %s)", tenantID, rq.Identifier),
+		fmt.Sprintf("v3/subscriptions/%s/aws/ecache/upgrade-engine", tenantID),
+		&rq, &rp)
+}
+
 type LogDeliveryConfigurationUpdateItem struct {
 	DestinationType    string              `json:"DestinationType,omitempty"`
 	LogFormat          string              `json:"LogFormat,omitempty"`

--- a/duplosdk/ecache_instance.go
+++ b/duplosdk/ecache_instance.go
@@ -240,10 +240,13 @@ func (c *Client) EcacheInstanceUpgradeEngine(tenantID string, rq DuploEcacheUpgr
 	// The endpoint returns the in-progress ECacheDBInstanceDetails; absorb it into a map since the
 	// authoritative state is fetched by a follow-up read.
 	var rp map[string]interface{}
-	return c.postAPI(
+	// Like EcacheInstanceModify, this is a long-running AWS modify that can fail transiently with a
+	// 400 while the cluster is still transitioning, so retry with backoff to match that pattern.
+	conf := NewRetryConf()
+	return c.postAPIWithRetry(
 		fmt.Sprintf("EcacheInstanceUpgradeEngine(%s, %s)", tenantID, rq.Identifier),
 		fmt.Sprintf("v3/subscriptions/%s/aws/ecache/upgrade-engine", tenantID),
-		&rq, &rp)
+		&rq, &rp, &conf)
 }
 
 type LogDeliveryConfigurationUpdateItem struct {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/8655600/DUPLO-43250

## Overview

Allows upgrading an existing `duplocloud_ecache_instance` engine from Redis to Valkey in place, instead of forcing a destroy/recreate.

## Summary of changes

This PR does the following:

- Adds SDK `EcacheInstanceUpgradeEngine` calling the new backend endpoint `POST v3/subscriptions/{id}/aws/ecache/upgrade-engine` (from duplocloud-internal/duplo#5466).
- Makes `cache_type` conditionally `ForceNew`: a change from `0` (Redis) to `2` (Valkey) is now an in-place engine upgrade; every other `cache_type` change still forces replacement.
- On update, a Redis→Valkey transition calls the upgrade-engine endpoint with the new `engine_version` as the target version; the generic `engine_version` modify is skipped since the upgrade subsumes it.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
