### PR TITLE
DUPLO-43303 TF: Add InputTransformer support for cloudwatch event target

### DIFF
--- a/docs/resources/aws_cloudwatch_event_target.md
+++ b/docs/resources/aws_cloudwatch_event_target.md
@@ -64,13 +64,26 @@ resource "duplocloud_aws_cloudwatch_event_target" "cw_etarget2" {
 ### Optional
 
 - `event_bus_name` (String) The event bus to associate with the rule. If you omit this, the default event bus is used.
-- `input` (String) Valid JSON text passed to the target.
+- `input` (String) Valid JSON text passed to the target. Conflicts with `input_transformer`.
+- `input_transformer` (Block List, Max: 1) Settings used to transform the matched event before passing it to the target. Conflicts with `input`. (see [below for nested schema](#nestedblock--input_transformer))
 - `role_arn` (String) The Amazon Resource Name (ARN) associated with the role that is used for target invocation.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--input_transformer"></a>
+### Nested Schema for `input_transformer`
+
+Required:
+
+- `input_template` (String) Template that defines the payload passed to the target. Variables defined in `input_paths` are referenced using `<name>` syntax.
+
+Optional:
+
+- `input_paths` (Map of String) Map of variable names to JSONPath expressions that extract values from the event. The variable names can be referenced in `input_template` using `<name>` syntax.
+
 
 <a id="nestedblock--timeouts"></a>
 ### Nested Schema for `timeouts`

--- a/duplocloud/resource_duplo_aws_cloudwatch_event_target.go
+++ b/duplocloud/resource_duplo_aws_cloudwatch_event_target.go
@@ -53,10 +53,33 @@ func awsCloudWatchEventTargetSchema() map[string]*schema.Schema {
 			Computed:    true,
 		},
 		"input": {
-			Description: "Valid JSON text passed to the target. ",
-			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
+			Description:   "Valid JSON text passed to the target. Conflicts with `input_transformer`.",
+			Type:          schema.TypeString,
+			Optional:      true,
+			Computed:      true,
+			ConflictsWith: []string{"input_transformer"},
+		},
+		"input_transformer": {
+			Description:   "Settings used to transform the matched event before passing it to the target. Conflicts with `input`.",
+			Type:          schema.TypeList,
+			Optional:      true,
+			MaxItems:      1,
+			ConflictsWith: []string{"input"},
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"input_paths": {
+						Description: "Map of variable names to JSONPath expressions that extract values from the event. The variable names can be referenced in `input_template` using `<name>` syntax.",
+						Type:        schema.TypeMap,
+						Optional:    true,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+					},
+					"input_template": {
+						Description: "Template that defines the payload passed to the target. Variables defined in `input_paths` are referenced using `<name>` syntax.",
+						Type:        schema.TypeString,
+						Required:    true,
+					},
+				},
+			},
 		},
 	}
 }
@@ -104,8 +127,12 @@ func resourceAwsCloudWatchEventTargetRead(ctx context.Context, d *schema.Resourc
 		return nil
 	}
 	d.Set("tenant_id", tenantID)
-	d.Set("arn", duplo.Arn)
+	d.Set("rule_name", ruleName)
+	d.Set("target_id", duplo.Id)
+	d.Set("target_arn", duplo.Arn)
 	d.Set("role_arn", duplo.RoleArn)
+	d.Set("input", duplo.Input)
+	d.Set("input_transformer", flattenCloudWatchInputTransformer(duplo.InputTransformer))
 
 	log.Printf("[TRACE] resourceAwsCloudWatchEventTargetRead(%s, %s, %s): end", tenantID, ruleName, targetId)
 	return nil
@@ -144,7 +171,24 @@ func resourceAwsCloudWatchEventTargetCreate(ctx context.Context, d *schema.Resou
 }
 
 func resourceAwsCloudWatchEventTargetUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	return nil
+	tenantID := d.Get("tenant_id").(string)
+	ruleName := d.Get("rule_name").(string)
+	log.Printf("[TRACE] resourceAwsCloudWatchEventTargetUpdate(%s, %s): start", tenantID, ruleName)
+	c := m.(*duplosdk.Client)
+
+	rq := expandCloudWatchEventTarget(d)
+	err := c.DuploCloudWatchEventTargetsCreate(tenantID, &duplosdk.DuploCloudWatchEventTargets{
+		Rule:         ruleName,
+		EventBusName: d.Get("event_bus_name").(string),
+		Targets:      &[]duplosdk.DuploCloudWatchEventTarget{*rq},
+	})
+	if err != nil {
+		return diag.Errorf("Error updating tenant %s cloudwatch event target '%s': %s", tenantID, rq.Id, err)
+	}
+
+	diags := resourceAwsCloudWatchEventTargetRead(ctx, d, m)
+	log.Printf("[TRACE] resourceAwsCloudWatchEventTargetUpdate(%s, %s): end", tenantID, ruleName)
+	return diags
 }
 
 func resourceAwsCloudWatchEventTargetDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
@@ -180,12 +224,48 @@ func resourceAwsCloudWatchEventTargetDelete(ctx context.Context, d *schema.Resou
 }
 
 func expandCloudWatchEventTarget(d *schema.ResourceData) *duplosdk.DuploCloudWatchEventTarget {
-	return &duplosdk.DuploCloudWatchEventTarget{
+	target := &duplosdk.DuploCloudWatchEventTarget{
 		Id:      d.Get("target_id").(string),
 		Arn:     d.Get("target_arn").(string),
 		Input:   d.Get("input").(string),
 		RoleArn: d.Get("role_arn").(string),
 	}
+
+	if v, ok := d.GetOk("input_transformer"); ok {
+		list := v.([]interface{})
+		if len(list) > 0 && list[0] != nil {
+			m := list[0].(map[string]interface{})
+			it := &duplosdk.DuploCloudWatchInputTransformer{
+				InputTemplate: m["input_template"].(string),
+			}
+			if paths, ok := m["input_paths"].(map[string]interface{}); ok && len(paths) > 0 {
+				it.InputPathsMap = make(map[string]string, len(paths))
+				for k, val := range paths {
+					it.InputPathsMap[k] = val.(string)
+				}
+			}
+			target.InputTransformer = it
+		}
+	}
+
+	return target
+}
+
+func flattenCloudWatchInputTransformer(it *duplosdk.DuploCloudWatchInputTransformer) []interface{} {
+	if it == nil {
+		return nil
+	}
+	m := map[string]interface{}{
+		"input_template": it.InputTemplate,
+	}
+	if len(it.InputPathsMap) > 0 {
+		paths := make(map[string]interface{}, len(it.InputPathsMap))
+		for k, v := range it.InputPathsMap {
+			paths[k] = v
+		}
+		m["input_paths"] = paths
+	}
+	return []interface{}{m}
 }
 
 func parseAwsCloudWatchEventTargetIdParts(id string) (tenantID, ruleName, targetId string, err error) {

--- a/duplosdk/aws_cloudwatch.go
+++ b/duplosdk/aws_cloudwatch.go
@@ -36,10 +36,16 @@ type DuploCloudWatchEventTargetsDeleteReq struct {
 }
 
 type DuploCloudWatchEventTarget struct {
-	Arn     string `json:"Arn"`
-	Id      string `json:"Id,omitempty"`
-	RoleArn string `json:"RoleArn,omitempty"`
-	Input   string `json:"Input,omitempty"`
+	Arn              string                           `json:"Arn"`
+	Id               string                           `json:"Id,omitempty"`
+	RoleArn          string                           `json:"RoleArn,omitempty"`
+	Input            string                           `json:"Input,omitempty"`
+	InputTransformer *DuploCloudWatchInputTransformer `json:"InputTransformer,omitempty"`
+}
+
+type DuploCloudWatchInputTransformer struct {
+	InputPathsMap map[string]string `json:"InputPathsMap,omitempty"`
+	InputTemplate string            `json:"InputTemplate,omitempty"`
 }
 
 type DuploCloudWatchRunCommandTarget struct {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/86aj15wk5

## Overview

Adds `input_transformer` support to `duplocloud_aws_cloudwatch_event_target` so EventBridge targets can transform the matched event payload (e.g. format GuardDuty findings into a readable SNS/email message) via Terraform. The backend already forwards the native AWS `PutTargets` request untouched, so this is a provider-only change.

## Summary of changes

This PR does the following:

- Add `InputTransformer` (`InputPathsMap` + `InputTemplate`) to the `DuploCloudWatchEventTarget` SDK struct.
- Add an `input_transformer` block (`input_paths` map + required `input_template`) to the resource schema, mutually exclusive with `input` via `ConflictsWith`.
- Wire the field through `expand`/`flatten`; fix `Read` to populate `input_transformer`/`input`/`target_arn`/`target_id` (it previously set a non-existent `arn` key, causing drift).
- Implement the previously no-op `Update` via the idempotent `PutTargets` endpoint so the field is editable in place.
- Regenerate docs.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None