### PR TITLE
DUPLO-32885 TF: allow setting duplo_service replicas to 0

### DIFF
--- a/duplosdk/replication_controller.go
+++ b/duplosdk/replication_controller.go
@@ -149,7 +149,7 @@ type DuploReplicationControllerCreateRequest struct {
 	NetworkId                         string                 `json:"NetworkId"`
 	Cloud                             int                    `json:"Cloud"`
 	AgentPlatform                     int                    `json:"AgentPlatform"`
-	Replicas                          int                    `json:"Replicas,omitempty"`
+	Replicas                          int                    `json:"Replicas"`
 	ReplicasMatchingAsgName           string                 `json:"ReplicasMatchingAsgName,omitempty"`
 	ForceStatefulSet                  bool                   `json:"ForceStatefulSet,omitempty"`
 	IsDaemonset                       bool                   `json:"IsDaemonset"`
@@ -178,7 +178,7 @@ type DuploReplicationControllerUpdateRequest struct {
 	Name                              string                 `json:"Name"`
 	Image                             string                 `json:"DockerImage"`
 	AgentPlatform                     int                    `json:"AgentPlatform"`
-	Replicas                          int                    `json:"Replicas,omitempty"`
+	Replicas                          int                    `json:"Replicas"`
 	ReplicasMatchingAsgName           string                 `json:"ReplicasMatchingAsgName,omitempty"`
 	ForceStatefulSet                  bool                   `json:"ForceStatefulSet,omitempty"`
 	IsDaemonset                       bool                   `json:"IsDaemonset"`


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/86a9xv3c5

## Overview

`duplocloud_duplo_service` could not set `replicas` to 0. The plan/apply showed `1 -> 0`, but the running service kept its previous replica count.

## Summary of changes

This PR does the following:

- Removed `omitempty` from the `Replicas` JSON tag on `DuploReplicationControllerCreateRequest` and `DuploReplicationControllerUpdateRequest` in `duplosdk/replication_controller.go`. With `omitempty`, a value of 0 was dropped from the request body, so the backend never received `Replicas: 0` and left the count unchanged. The field is now always serialized.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
