### PR TITLE
DUPLO-43322 TF: Fix 400 when switching event target between input and input_transformer

### DIFF
--- a/duplocloud/resource_duplo_aws_cloudwatch_event_target.go
+++ b/duplocloud/resource_duplo_aws_cloudwatch_event_target.go
@@ -227,10 +227,13 @@ func expandCloudWatchEventTarget(d *schema.ResourceData) *duplosdk.DuploCloudWat
 	target := &duplosdk.DuploCloudWatchEventTarget{
 		Id:      d.Get("target_id").(string),
 		Arn:     d.Get("target_arn").(string),
-		Input:   d.Get("input").(string),
 		RoleArn: d.Get("role_arn").(string),
 	}
 
+	// AWS EventBridge accepts only one of Input / InputPath / InputTransformer
+	// per target. Since `input` is Computed, its old value lingers in state when
+	// the user switches to `input_transformer`, so we must send exactly one of
+	// them — never both (otherwise PutTargets returns a 400).
 	if v, ok := d.GetOk("input_transformer"); ok {
 		list := v.([]interface{})
 		if len(list) > 0 && list[0] != nil {
@@ -246,6 +249,8 @@ func expandCloudWatchEventTarget(d *schema.ResourceData) *duplosdk.DuploCloudWat
 			}
 			target.InputTransformer = it
 		}
+	} else {
+		target.Input = d.Get("input").(string)
 	}
 
 	return target

--- a/duplocloud/resource_duplo_aws_cloudwatch_event_target.go
+++ b/duplocloud/resource_duplo_aws_cloudwatch_event_target.go
@@ -230,10 +230,10 @@ func expandCloudWatchEventTarget(d *schema.ResourceData) *duplosdk.DuploCloudWat
 		RoleArn: d.Get("role_arn").(string),
 	}
 
-	// AWS EventBridge accepts only one of Input / InputPath / InputTransformer
-	// per target. Since `input` is Computed, its old value lingers in state when
-	// the user switches to `input_transformer`, so we must send exactly one of
-	// them — never both (otherwise PutTargets returns a 400).
+	// AWS EventBridge accepts at most one of Input / InputPath / InputTransformer per target.
+	// Since `input` is Computed, its old value can linger in state when the user switches
+	// to `input_transformer`, so we must ensure we never send both (otherwise PutTargets
+	// returns a 400).
 	if v, ok := d.GetOk("input_transformer"); ok {
 		list := v.([]interface{})
 		if len(list) > 0 && list[0] != nil {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/86aj2m6t7

## Overview

Fixes a 400 from AWS EventBridge `PutTargets` when updating a `duplocloud_aws_cloudwatch_event_target` from `input` (constant JSON) to `input_transformer`. The provider was sending both fields in the request; EventBridge accepts only one of `Input` / `InputPath` / `InputTransformer` per target.

Root cause: `input` is `Optional + Computed`, so its old value lingered in state after the user switched to `input_transformer`, and `expandCloudWatchEventTarget` set `Input` unconditionally — sending both. (The schema `ConflictsWith` only validates config, not the stale state value.)

## Summary of changes

This PR does the following:

- `expandCloudWatchEventTarget` now sends exactly one of `Input` / `InputTransformer` — `Input` is only set when no `input_transformer` block is configured.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None