### PR TITLE
DUPLO-43330 TF: Support Aurora Serverless v2 auto-pause (min_capacity=0 + seconds_until_auto_pause)

### DIFF
--- a/docs/data-sources/rds_instance.md
+++ b/docs/data-sources/rds_instance.md
@@ -105,3 +105,4 @@ Read-Only:
 
 - `max_capacity` (Number)
 - `min_capacity` (Number)
+- `seconds_until_auto_pause` (Number)

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -470,7 +470,7 @@ If you don't know the available engine versions for your RDS instance, you can u
 			| aurora-iopt1 | Provisioned IOPS, similar to io1   | Varies                | Aurora databases needing guaranteed, high-performance IOPS. Aurora I/O-Optimized storage offers provisioned IOPS for Aurora clusters that require consistently high performance for critical workloads.                   |
 - `store_details_in_secret_manager` (Boolean) Whether or not to store RDS details in the AWS secrets manager.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `v2_scaling_configuration` (Block List, Max: 1) Serverless v2_scaling_configuration min and max scaling capacity. This configuration is only applicable for serverless instances (see [below for nested schema](#nestedblock--v2_scaling_configuration))
+- `v2_scaling_configuration` (Block List, Max: 1) Serverless v2 scaling configuration specifying the min and max scaling capacity (in ACUs). This configuration is only applicable for serverless instances. (see [below for nested schema](#nestedblock--v2_scaling_configuration))
 
 ### Read-Only
 
@@ -518,7 +518,11 @@ Optional:
 Required:
 
 - `max_capacity` (Number) Specifies max scaling capacity.
-- `min_capacity` (Number) Specifies min scaling capacity.
+- `min_capacity` (Number) Specifies min scaling capacity. Set to `0` to enable Aurora Serverless v2 auto-pause (scale to zero) for idle clusters.
+
+Optional:
+
+- `seconds_until_auto_pause` (Number) The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
 
 ## Import
 

--- a/duplocloud/data_source_duplo_rds_instance.go
+++ b/duplocloud/data_source_duplo_rds_instance.go
@@ -175,6 +175,11 @@ func dataSourceDuploRdsInstance() *schema.Resource {
 							Type:        schema.TypeFloat,
 							Computed:    true,
 						},
+						"seconds_until_auto_pause": {
+							Description: "Idle time in seconds (no connections or activity while at min_capacity) before Aurora Serverless v2 auto-pauses the cluster. Only applies when min_capacity is 0.",
+							Type:        schema.TypeInt,
+							Computed:    true,
+						},
 					},
 				},
 			},

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -261,14 +261,14 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 			Computed:    true,
 		},
 		"v2_scaling_configuration": {
-			Description: "Serverless v2_scaling_configuration min and max scaling capacity. This configuration is only applicable for serverless instances",
+			Description: "Serverless v2 scaling configuration specifying the min and max scaling capacity (in ACUs). This configuration is only applicable for serverless instances.",
 			Type:        schema.TypeList,
 			MaxItems:    1,
 			Optional:    true,
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"min_capacity": {
-						Description: "Specifies min scaling capacity.",
+						Description: "Specifies min scaling capacity. Set to `0` to enable Aurora Serverless v2 auto-pause (scale to zero) for idle clusters.",
 						Type:        schema.TypeFloat,
 						Required:    true,
 					},
@@ -276,6 +276,12 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 						Description: "Specifies max scaling capacity.",
 						Type:        schema.TypeFloat,
 						Required:    true,
+					},
+					"seconds_until_auto_pause": {
+						Description:  "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).",
+						Type:         schema.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntBetween(300, 86400),
 					},
 				},
 			},
@@ -1019,7 +1025,7 @@ func rdsInstanceFromState(d *schema.ResourceData) (*duplosdk.DuploRdsInstance, e
 }
 
 func expandV2ScalingConfiguration(cfg []interface{}) *duplosdk.V2ScalingConfiguration {
-	if len(cfg) < 1 {
+	if len(cfg) < 1 || cfg[0] == nil {
 		return nil
 	}
 	out := &duplosdk.V2ScalingConfiguration{}
@@ -1030,7 +1036,13 @@ func expandV2ScalingConfiguration(cfg []interface{}) *duplosdk.V2ScalingConfigur
 	if v, ok := m["max_capacity"]; ok {
 		out.MaxCapacity = v.(float64)
 	}
-	if out.MinCapacity == 0 || out.MaxCapacity == 0 {
+	if v, ok := m["seconds_until_auto_pause"]; ok {
+		out.SecondsUntilAutoPause = v.(int)
+	}
+	// max_capacity is always required for a serverless v2 config, so a zero value
+	// means the block was not populated. min_capacity may legitimately be 0
+	// (auto-pause / scale-to-zero), so it must not be treated as "unset".
+	if out.MaxCapacity == 0 {
 		return nil
 	}
 	return out
@@ -1091,11 +1103,20 @@ func rdsInstanceToState(duploObject *duplosdk.DuploRdsInstance, d *schema.Resour
 	jo["skip_final_snapshot"] = duploObject.SkipFinalSnapshot
 	jo["store_details_in_secret_manager"] = duploObject.StoreDetailsInSecretManager
 	jo["enable_iam_auth"] = duploObject.EnableIamAuth
-	if duploObject.V2ScalingConfiguration != nil && duploObject.V2ScalingConfiguration.MinCapacity != 0 && duploObject.SizeEx == "db.serverless" {
-		d.Set("v2_scaling_configuration", []map[string]interface{}{{
+	if duploObject.V2ScalingConfiguration != nil && duploObject.V2ScalingConfiguration.MaxCapacity != 0 && duploObject.SizeEx == "db.serverless" {
+		v2 := map[string]interface{}{
 			"min_capacity": duploObject.V2ScalingConfiguration.MinCapacity,
 			"max_capacity": duploObject.V2ScalingConfiguration.MaxCapacity,
-		}})
+		}
+		// The backend does not yet echo SecondsUntilAutoPause back on reads (see
+		// DUPLO-43331). Only overwrite state when the API returns a real value;
+		// otherwise preserve the configured value to avoid spurious drift.
+		if duploObject.V2ScalingConfiguration.SecondsUntilAutoPause != 0 {
+			v2["seconds_until_auto_pause"] = duploObject.V2ScalingConfiguration.SecondsUntilAutoPause
+		} else if v, ok := d.GetOk("v2_scaling_configuration.0.seconds_until_auto_pause"); ok {
+			v2["seconds_until_auto_pause"] = v.(int)
+		}
+		d.Set("v2_scaling_configuration", []map[string]interface{}{v2})
 	}
 	jo["enhanced_monitoring"] = duploObject.MonitoringInterval
 	jo["db_name"] = duploObject.DatabaseName

--- a/duplocloud/resource_duplo_rds_instance_test.go
+++ b/duplocloud/resource_duplo_rds_instance_test.go
@@ -1,0 +1,75 @@
+package duplocloud
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
+)
+
+func TestExpandV2ScalingConfiguration(t *testing.T) {
+	cases := []struct {
+		name     string
+		given    []interface{}
+		expected *duplosdk.V2ScalingConfiguration
+	}{
+		{
+			// Auto-pause: min_capacity 0 is valid and must be preserved (not
+			// treated as "unset"), along with seconds_until_auto_pause.
+			name: "auto-pause with min_capacity 0",
+			given: []interface{}{
+				map[string]interface{}{
+					"min_capacity":             float64(0),
+					"max_capacity":             float64(4),
+					"seconds_until_auto_pause": 3600,
+				},
+			},
+			expected: &duplosdk.V2ScalingConfiguration{
+				MinCapacity:           0,
+				MaxCapacity:           4,
+				SecondsUntilAutoPause: 3600,
+			},
+		},
+		{
+			// Standard config: positive min capacity, no auto-pause.
+			name: "standard min/max without auto-pause",
+			given: []interface{}{
+				map[string]interface{}{
+					"min_capacity":             float64(0.5),
+					"max_capacity":             float64(2),
+					"seconds_until_auto_pause": 0,
+				},
+			},
+			expected: &duplosdk.V2ScalingConfiguration{
+				MinCapacity: 0.5,
+				MaxCapacity: 2,
+			},
+		},
+		{
+			// Empty block -> nil.
+			name:     "empty config",
+			given:    []interface{}{},
+			expected: nil,
+		},
+		{
+			// max_capacity 0 means the block was not populated -> nil.
+			name: "unpopulated block (max_capacity 0)",
+			given: []interface{}{
+				map[string]interface{}{
+					"min_capacity": float64(0),
+					"max_capacity": float64(0),
+				},
+			},
+			expected: nil,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := expandV2ScalingConfiguration(c.given)
+			if !reflect.DeepEqual(got, c.expected) {
+				t.Fatalf("Error matching output and expected: %#v vs %#v", got, c.expected)
+			}
+		})
+	}
+}

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -82,8 +82,12 @@ type DuploRdsInstance struct {
 }
 
 type V2ScalingConfiguration struct {
-	MinCapacity float64 `json:"MinCapacity,omitempty"`
-	MaxCapacity float64 `json:"MaxCapacity,omitempty"`
+	// MinCapacity has no omitempty: a value of 0 is valid (Aurora Serverless v2
+	// scale-to-zero / auto-pause) and must be serialized explicitly so the
+	// backend receives a definite value rather than treating it as unset.
+	MinCapacity           float64 `json:"MinCapacity"`
+	MaxCapacity           float64 `json:"MaxCapacity,omitempty"`
+	SecondsUntilAutoPause int     `json:"SecondsUntilAutoPause,omitempty"`
 }
 
 // DuploRdsInstancePasswordChange is a Duplo SDK object that represents an RDS instance password change

--- a/examples/resources/duplocloud_rds_instance/resource.tf
+++ b/examples/resources/duplocloud_rds_instance/resource.tf
@@ -112,3 +112,23 @@ resource "duplocloud_rds_instance" "mydb" {
   size           = "db.t3.medium"
   snapshot_id    = "rds:duplotest-snapdb-2024-12-17-07-00" //snapshot id is of previously created mysql db of version 5.7.44
 }
+
+// Aurora Serverless v2 with auto-pause (scale to zero) for idle/non-prod clusters.
+resource "duplocloud_rds_instance" "aurora-serverless-autopause" {
+  tenant_id      = duplocloud_tenant.myapp.tenant_id
+  name           = "aurora-serverless"
+  engine         = 9 // AuroraDB
+  engine_version = "8.0.mysql_aurora.3.07.1"
+  size           = "db.serverless"
+
+  master_username = "myuser"
+  master_password = random_password.mypassword.result
+
+  encrypt_storage = true
+
+  v2_scaling_configuration {
+    min_capacity             = 0 // 0 enables auto-pause (scale to zero)
+    max_capacity             = 4
+    seconds_until_auto_pause = 3600 // pause after 1 hour idle
+  }
+}


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-43330](https://app.clickup.com/t/86aj37uby)

## Overview

Adds Aurora Serverless v2 auto-pause support to `duplocloud_rds_instance`. Previously the `v2_scaling_configuration` block only exposed `min_capacity`/`max_capacity` and forbid a zero min capacity, so customers could not scale idle Aurora clusters to 0 ACUs. AWS supports this via `min_capacity = 0` + `seconds_until_auto_pause`, and the DuploCloud backend write path already handles it (`CreateSafeV2ScalingConfiguration`) — the provider just never exposed it.

The original min/max-only block dates to #254 (2023), when AWS's Serverless v2 floor was 0.5 ACU and `min_capacity = 0` was invalid. Scale-to-zero is now supported by AWS, so the old `== 0` guards are obsolete.

## Summary of changes

This PR does the following:

- Adds a `seconds_until_auto_pause` field (Int, Optional, validated 300–86400) to the `v2_scaling_configuration` block.
- Drops `omitempty` from `MinCapacity` in the SDK struct so `0` serializes explicitly (rather than being dropped), and adds `SecondsUntilAutoPause`.
- Relaxes the expand guard to key off `max_capacity` instead of `min_capacity`, so `min_capacity = 0` is a valid, populated config.
- Implements a defensive read in flatten: `seconds_until_auto_pause` is only overwritten from the API when it returns a non-zero value; otherwise the configured value is preserved. This avoids drift while the backend read-back is not yet implemented (tracked in DUPLO-43331), so the provider ships once and needs no second release when the backend catches up.
- Exposes `seconds_until_auto_pause` (Computed) on the `duplocloud_rds_instance` data source.
- Adds an auto-pause usage example and regenerates docs.
- Adds a unit test for `expandV2ScalingConfiguration` covering auto-pause, standard config, empty, and unpopulated-block cases.

## Testing performed

- [x] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

`go build ./...`, `go vet ./duplocloud/...`, and `go test ./duplocloud/ -run TestExpandV2ScalingConfiguration` all pass.

## Describe any breaking changes

- None. `min_capacity > 0` configs continue to behave exactly as before; `seconds_until_auto_pause` is optional and only relevant when `min_capacity = 0`.

## Dependency

- Pairs with backend ticket DUPLO-43331 (round-trip `SecondsUntilAutoPause` in read-back + diff). The defensive flatten means this PR does not depend on that landing first.
