### PR TITLE
DUPLO-43327 TF: Resolve Node20 deprecation warnings in GitHub Actions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,10 +33,10 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Go
-              uses: actions/setup-go@v5
+              uses: actions/setup-go@v6
               with:
                   go-version-file: go.mod
 

--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: false
@@ -34,10 +34,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.20.0'
           cache: false

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.20.0'
       -

--- a/.github/workflows/finish-hotfix.yml
+++ b/.github/workflows/finish-hotfix.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: master                 # Always finish hotfixes from the "merged to" master
           fetch-depth: 0

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: master                 # Always finish releases from the "merged to" master
           fetch-depth: 0
@@ -41,7 +41,7 @@ jobs:
       - finish-release
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: develop
           fetch-depth: 0

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate PR Description
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';
@@ -86,7 +86,7 @@ jobs:
 
       - name: Add validation comment
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const comment = '✅ **PR Validation Passed**\n\nAll required sections are present and ClickUp ticket ID is included.';

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,13 +9,13 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.20.0'
       -
@@ -48,7 +48,7 @@ jobs:
     steps:
       -
         name: Publish the release
-        uses: actions/github-script@v5
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.DUPLO_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/start-hotfix.yml
+++ b/.github/workflows/start-hotfix.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: master                # Always hotfix from master
           fetch-depth: 0

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: develop                # Always release from develop
           fetch-depth: 0


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/86aj2u3y0

## Overview

GitHub surfaces a Node20 deprecation warning on this repo's workflow runs:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v3, actions/setup-go@v5.

This bumps the affected actions to the major versions that natively target the Node24 runtime, eliminating the warnings. Mirrors the approach in duplocloud/actions#112.

## Summary of changes

This PR does the following:

- `actions/checkout@v3`/`@v4` → `@v5` (Node24)
- `actions/setup-go@v5` → `@v6` (Node24)
- `actions/github-script@v5`/`@v7` → `@v8` (Node24)

Out of scope (no Node24 release exists yet; latest majors still target Node20/Node16 and bumping risks breaking changes): `goreleaser/goreleaser-action`, `crazy-max/ghaction-import-gpg`, `golangci/golangci-lint-action`. `github/codeql-action@v3` is a composite action and emits no Node-runtime warning.

Runtime target for each new version verified by reading `runs.using` from the action's `action.yml` at each tag. The `github-script` scripts use only the stable `github.rest.*`/`context`/`core` APIs, which are unchanged in v8.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

Verified all workflow YAML parses cleanly and that no Node20-targeting `checkout`/`setup-go`/`github-script` references remain.

## Describe any breaking changes

- None
