### PR TITLE
DUPLO-43320 TF: support custom KMS key on RDS Global secondary clusters

### DIFF
--- a/docs/resources/aws_rds_global_secondary.md
+++ b/docs/resources/aws_rds_global_secondary.md
@@ -55,6 +55,7 @@ resource "duplocloud_aws_rds_global_secondary" "gs" {
 
 ### Optional
 
+- `kms_key_id` (String) Optional custom KMS key (key ID or ARN) used to encrypt the secondary cluster's storage. The key must belong to the secondary tenant or its plan. When omitted, the secondary tenant's default KMS key is used.
 - `make_headless` (Boolean) It removes the reader instances under secondary cluster by retaining the secondary cluster, Valid during updation Defaults to `false`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/duplocloud/resource_duplo_aws_rds_global_database.go
+++ b/duplocloud/resource_duplo_aws_rds_global_database.go
@@ -69,6 +69,13 @@ func duploAwsRdsGlobalDatabaseSchema() map[string]*schema.Schema {
 			DiffSuppressFunc: diffSuppressWhenCreating,
 			Optional:         true,
 		},
+		"kms_key_id": {
+			Description: "Optional custom KMS key (key ID or ARN) used to encrypt the secondary cluster's storage. " +
+				"The key must belong to the secondary tenant or its plan. When omitted, the secondary tenant's default KMS key is used.",
+			Type:     schema.TypeString,
+			Optional: true,
+			ForceNew: true,
+		},
 	}
 }
 
@@ -141,7 +148,8 @@ func resourceAwsRdsGlobalDatabaseCreate(ctx context.Context, d *schema.ResourceD
 	identifier := d.Get("cluster_identifier").(string)
 	secTenantId := d.Get("secondary_tenant_id").(string)
 	req := duplosdk.DuploRDSGlobalDatabase{
-		TenantID: secTenantId,
+		TenantID:           secTenantId,
+		EncryptionKmsKeyId: d.Get("kms_key_id").(string),
 	}
 	log.Printf("[TRACE] resourceAwsRdsGlobalDatabaseCreate(%s, %s, %s, %s): start", tenantID, identifier, secRegion, secTenantId)
 	c := m.(*duplosdk.Client)

--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -608,7 +608,8 @@ type DuploRDSGlobalDatabaseRegionInfo struct {
 }
 
 type DuploRDSGlobalDatabase struct {
-	TenantID string `json:"tenantId"`
+	TenantID           string `json:"tenantId"`
+	EncryptionKmsKeyId string `json:"EncryptionKmsKeyId,omitempty"`
 }
 
 func (c *Client) CreateRDSDBSecondaryDB(tenantID, instanceId, region string, rq DuploRDSGlobalDatabase) (*DuploRDSGlobalDatabaseResponse, ClientError) {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-43320](https://app.clickup.com/t/86aj29ut9)

## Overview

Adds support for specifying a custom KMS key when adding a Global RDS secondary region, instead of always encrypting the secondary cluster with the secondary tenant's default KMS key. This is the Terraform provider counterpart to backend PR duplocloud-internal/duplo#5497 (DUPLO-43318), which added the optional `EncryptionKmsKeyId` field to the add-region request.

## Summary of changes

This PR does the following:

- Add an optional `kms_key_id` attribute to `duplocloud_aws_rds_global_secondary`.
- Send it as `EncryptionKmsKeyId` (omitempty) on the add-region request; when unset, behavior is unchanged (secondary tenant's default key).
- Mark `kms_key_id` as `ForceNew` and do not read it back: the add-region API only accepts the key at create time and never returns it on GET, so reading it back would cause perpetual drift.
- Regenerate resource docs.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
