### PR TITLE
DUPLO-43443 TF: reject seconds_until_auto_pause when min_capacity > 0

### DIFF
--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -1285,8 +1285,16 @@ func validateRDSParameters(ctx context.Context, diff *schema.ResourceDiff, m int
 		}
 	}
 	if v, ok := diff.GetOk("v2_scaling_configuration"); ok {
-		if len(v.([]interface{})) > 0 && s != "db.serverless" {
+		cfgList := v.([]interface{})
+		if len(cfgList) > 0 && s != "db.serverless" {
 			return fmt.Errorf("Cannot set v2 scaling configuration for provisioned rds instance")
+		}
+		if len(cfgList) > 0 {
+			cfg := cfgList[0].(map[string]interface{})
+			minCap := cfg["min_capacity"].(float64)
+			if secUntilPause, ok := cfg["seconds_until_auto_pause"]; ok && secUntilPause.(int) > 0 && minCap > 0 {
+				return fmt.Errorf("seconds_until_auto_pause can only be set when min_capacity is 0 (auto-pause requires scaling to zero ACUs)")
+			}
 		}
 	}
 	if diff.Get("multi_az").(bool) && (eng == 8 || eng == 9 || eng == 16) {

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -1290,10 +1290,19 @@ func validateRDSParameters(ctx context.Context, diff *schema.ResourceDiff, m int
 			return fmt.Errorf("Cannot set v2 scaling configuration for provisioned rds instance")
 		}
 		if len(cfgList) > 0 {
-			cfg := cfgList[0].(map[string]interface{})
-			minCap := cfg["min_capacity"].(float64)
-			if secUntilPause, ok := cfg["seconds_until_auto_pause"]; ok && secUntilPause.(int) > 0 && minCap > 0 {
-				return fmt.Errorf("seconds_until_auto_pause can only be set when min_capacity is 0 (auto-pause requires scaling to zero ACUs)")
+			cfg, ok := cfgList[0].(map[string]interface{})
+			if !ok {
+				return nil
+			}
+			minCap, ok := cfg["min_capacity"].(float64)
+			if !ok {
+				return nil
+			}
+			if secUntilPause, ok := cfg["seconds_until_auto_pause"]; ok {
+				secVal, ok := secUntilPause.(int)
+				if ok && secVal > 0 && minCap != 0 {
+					return fmt.Errorf("seconds_until_auto_pause can only be set when min_capacity is 0 (auto-pause requires scaling to zero ACUs)")
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/8655600/DUPLO-43443

## Overview

Add validation to reject `seconds_until_auto_pause` when `min_capacity > 0` in Aurora Serverless v2 scaling configuration. Per AWS rules, auto-pause only works when the cluster can scale to zero ACUs.

## Summary of changes

This PR does the following:

- Add validation in `validateRDSParameters` CustomizeDiff to check that `seconds_until_auto_pause` is only set when `min_capacity` is 0
- Return clear error message explaining the constraint

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None