### PR TITLE
DUPLO-43568 TF: fix Aurora Serverless v2 scaling update 404 by repointing to auroraToV2Serverless route

### DIFF
--- a/duplosdk/rds_instance.go
+++ b/duplosdk/rds_instance.go
@@ -387,7 +387,7 @@ func (c *Client) UpdateRdsCluster(tenantID string, duploObject DuploRdsUpdateClu
 func (c *Client) RdsModifyAuroraV2ServerlessInstanceSize(tenantID string, duploObject DuploRdsModifyAuroraV2ServerlessInstanceSize) ClientError {
 	return c.postAPI(
 		fmt.Sprintf("RdsModifyAuroraV2ServerlessInstanceSize(%s, %s)", tenantID, duploObject.ClusterIdentifier),
-		fmt.Sprintf("v3/subscriptions/%s/aws/modifyAuroraV2Serverless", tenantID),
+		fmt.Sprintf("v3/subscriptions/%s/aws/rds/cluster/%s/auroraToV2Serverless", tenantID, duploObject.ClusterIdentifier),
 		&duploObject,
 		nil,
 	)


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/86ajaxcy5 (DUPLO-43568)

## Overview

Updating an Aurora Serverless v2 RDS instance's `v2_scaling_configuration` failed with a 404 from the portal:

```
url: https://<portal>/v3/subscriptions/<sub>/aws/modifyAuroraV2Serverless, status: 404,
message: {"Message":"No HTTP resource was found that matches the request URI '.../aws/modifyAuroraV2Serverless'."}
```

`RdsModifyAuroraV2ServerlessInstanceSize` POSTed to `v3/subscriptions/%s/aws/modifyAuroraV2Serverless` — a route the backend has never registered (verified across `master` and all release branches). The 404 only fires on the update path (create uses a different endpoint), so it went unnoticed until a customer modified scaling on an existing `db.serverless` instance. The sibling read-replica call (`EnableReadReplicaServerlessCreation`) already uses the correct route; this brings the instance-update path in line with it. No backend change required.

## Summary of changes

This PR does the following:

- Repoint `RdsModifyAuroraV2ServerlessInstanceSize` from the nonexistent `aws/modifyAuroraV2Serverless` route to `v3/subscriptions/%s/aws/rds/cluster/%s/auroraToV2Serverless` (backend action `ModifyAuroraToV2Serverless`), which builds a scaling-only `ModifyDBCluster` and is safe/idempotent for an already-serverless cluster.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
