### PR TITLE
DUPLO-43563 TF: add force_update to k8_helm_release

### DIFF
--- a/docs/resources/k8_helm_release.md
+++ b/docs/resources/k8_helm_release.md
@@ -53,6 +53,7 @@ resource "duplocloud_k8_helm_release" "release" {
 
 ### Optional
 
+- `force_update` (Boolean) When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field. Defaults to `false`.
 - `interval` (String) Interval related to helm release Defaults to `5m0s`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `values` (String) Customise an helm chart.

--- a/duplocloud/resource_duplo_helm_release.go
+++ b/duplocloud/resource_duplo_helm_release.go
@@ -117,6 +117,12 @@ func resourceHelmRelease() *schema.Resource {
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
+			"force_update": {
+				Description: "When `true`, sets FluxCD's `spec.upgrade.force` so the release is delete-and-recreated on upgrade instead of patched. Use this to unblock chart upgrades on adopted releases where a field changes shape (e.g. an `env` entry moving from `value` to `valueFrom`) and Kubernetes Server-Side Apply cannot clear the stale field.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+			},
 		},
 	}
 }
@@ -144,7 +150,7 @@ func resourceHelmReleaseRead(ctx context.Context, d *schema.ResourceData, m inte
 		return nil
 	}
 
-	flattenErr := flattenHelmRelease(d, *duplo)
+	flattenErr := flattenHelmRelease(d, tenantID, *duplo)
 	if flattenErr != nil {
 		diag.Errorf("%s", flattenErr.Error())
 	}
@@ -258,6 +264,10 @@ func expandHelmRelease(d *schema.ResourceData) (duplosdk.DuploHelmRelease, error
 		}
 	}
 
+	if d.Get("force_update").(bool) {
+		obj.Spec.Upgrade = &duplosdk.HelmUpgrade{Force: true}
+	}
+
 	var err error
 	if val, ok := d.GetOk("values"); ok && val.(string) != "" {
 		err = json.Unmarshal([]byte(d.Get("values").(string)), &obj.Spec.Values)
@@ -265,43 +275,54 @@ func expandHelmRelease(d *schema.ResourceData) (duplosdk.DuploHelmRelease, error
 	return obj, err
 }
 
-func flattenHelmRelease(d *schema.ResourceData, rb duplosdk.DuploHelmRelease) error {
+func flattenHelmRelease(d *schema.ResourceData, tenantID string, rb duplosdk.DuploHelmRelease) error {
+	d.Set("tenant_id", tenantID)
 	d.Set("name", rb.Metadata.Name)
 	d.Set("interval", rb.Spec.Interval)
 	d.Set("release_name", rb.Spec.ReleaseName)
 
-	// Handle both Chart (HelmRepository) and ChartRef (OCIRepository) formats
+	// Handle both Chart (HelmRepository) and ChartRef (OCIRepository) formats.
+	// Set the whole `chart` list at once (not chart.0.* indices) so this also
+	// populates state correctly on import, where the block doesn't yet exist.
 	if rb.Spec.ChartRef != nil {
 		// OCIRepository format - use chartRef
-		d.Set("chart.0.source_type", rb.Spec.ChartRef.Kind)
-		d.Set("chart.0.source_name", rb.Spec.ChartRef.Name)
-		// Set default values for fields not used in OCIRepository format
-		d.Set("chart.0.name", "")
-		d.Set("chart.0.version", "")
-		d.Set("chart.0.interval", "5m0s")
-		d.Set("chart.0.reconcile_strategy", "ChartVersion")
+		d.Set("chart", []interface{}{map[string]interface{}{
+			"source_type": rb.Spec.ChartRef.Kind,
+			"source_name": rb.Spec.ChartRef.Name,
+			// Defaults for fields not used in OCIRepository format
+			"name":               "",
+			"version":            "",
+			"interval":           "5m0s",
+			"reconcile_strategy": "ChartVersion",
+		}})
 	} else if rb.Spec.Chart != nil {
 		// HelmRepository format - use chart.spec
-		d.Set("chart.0.name", rb.Spec.Chart.Spec.Chart)
-		d.Set("chart.0.version", rb.Spec.Chart.Spec.Version)
-		d.Set("chart.0.interval", rb.Spec.Chart.Spec.Interval)
-		d.Set("chart.0.source_type", rb.Spec.Chart.Spec.SourceRef.Kind)
-		d.Set("chart.0.source_name", rb.Spec.Chart.Spec.SourceRef.Name)
-		d.Set("chart.0.reconcile_strategy", rb.Spec.Chart.Spec.ReconcileStrategy)
+		d.Set("chart", []interface{}{map[string]interface{}{
+			"name":               rb.Spec.Chart.Spec.Chart,
+			"version":            rb.Spec.Chart.Spec.Version,
+			"interval":           rb.Spec.Chart.Spec.Interval,
+			"source_type":        rb.Spec.Chart.Spec.SourceRef.Kind,
+			"source_name":        rb.Spec.Chart.Spec.SourceRef.Name,
+			"reconcile_strategy": rb.Spec.Chart.Spec.ReconcileStrategy,
+		}})
 	}
 
-	var err error
+	if rb.Spec.Upgrade != nil {
+		d.Set("force_update", rb.Spec.Upgrade.Force)
+	}
+
 	if rb.Spec.Values != nil {
 		v, err := json.Marshal(rb.Spec.Values)
-		if err == nil {
-			d.Set("values", string(v))
+		if err != nil {
+			return err
 		}
-
-		if err == nil {
-			d.Set("values", string(v))
+		// Skip empty/null collections: an unset `values` is echoed back by the API
+		// as an empty array, which would otherwise show as perpetual drift.
+		if s := string(v); s != "[]" && s != "{}" && s != "null" {
+			d.Set("values", s)
 		}
 	}
-	return err
+	return nil
 }
 
 func helmReleaseWaitUntilReady(ctx context.Context, c *duplosdk.Client, tenantID string, name string, timeout time.Duration) error {

--- a/duplocloud/resource_duplo_helm_release.go
+++ b/duplocloud/resource_duplo_helm_release.go
@@ -152,7 +152,7 @@ func resourceHelmReleaseRead(ctx context.Context, d *schema.ResourceData, m inte
 
 	flattenErr := flattenHelmRelease(d, tenantID, *duplo)
 	if flattenErr != nil {
-		diag.Errorf("%s", flattenErr.Error())
+		return diag.Errorf("%s", flattenErr.Error())
 	}
 	log.Printf("[TRACE] resourceHelmReleaseRead(%s,%s): end", tenantID, name)
 	return nil
@@ -307,21 +307,28 @@ func flattenHelmRelease(d *schema.ResourceData, tenantID string, rb duplosdk.Dup
 		}})
 	}
 
+	// Always set force_update so a previously-set value is cleared if the upgrade
+	// block is absent (e.g. force turned off, or an import of a release without it).
+	force := false
 	if rb.Spec.Upgrade != nil {
-		d.Set("force_update", rb.Spec.Upgrade.Force)
+		force = rb.Spec.Upgrade.Force
 	}
+	d.Set("force_update", force)
 
+	// Normalize the API's echo of an unset `values` (an empty collection) to an
+	// empty string, and always set it. Skipping the set would leave a previously
+	// configured value stuck in state when it is removed from config.
+	values := ""
 	if rb.Spec.Values != nil {
 		v, err := json.Marshal(rb.Spec.Values)
 		if err != nil {
 			return err
 		}
-		// Skip empty/null collections: an unset `values` is echoed back by the API
-		// as an empty array, which would otherwise show as perpetual drift.
 		if s := string(v); s != "[]" && s != "{}" && s != "null" {
-			d.Set("values", s)
+			values = s
 		}
 	}
+	d.Set("values", values)
 	return nil
 }
 

--- a/duplosdk/duplo_helm.go
+++ b/duplosdk/duplo_helm.go
@@ -20,12 +20,20 @@ type DuploHelmSpec struct {
 	Chart       *Chart     `json:"chart,omitempty"`
 	ChartRef    *SourceRef `json:"chartRef,omitempty"`
 	//Values      map[string]interface{} `json:"values,omitempty"`
-	Values          interface{} `json:"values,omitempty"`
-	Insecure        bool        `json:"Insecure,omitempty"`
-	PassCredentials bool        `json:"PassCredentials,omitempty"`
-	Provider        string      `json:"Provider,omitempty"`
-	Suspend         bool        `json:"Suspend,omitempty"`
-	Type            string      `json:"Type,omitempty"`
+	Values          interface{}  `json:"values,omitempty"`
+	Insecure        bool         `json:"Insecure,omitempty"`
+	PassCredentials bool         `json:"PassCredentials,omitempty"`
+	Provider        string       `json:"Provider,omitempty"`
+	Suspend         bool         `json:"Suspend,omitempty"`
+	Type            string       `json:"Type,omitempty"`
+	Upgrade         *HelmUpgrade `json:"upgrade,omitempty"`
+}
+
+// HelmUpgrade maps to FluxCD's HelmRelease spec.upgrade. Setting Force makes
+// helm-controller delete-and-recreate resources on upgrade instead of patching,
+// sidestepping SSA field-ownership gaps on adopted releases.
+type HelmUpgrade struct {
+	Force bool `json:"force"`
 }
 
 type SourceRef struct {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/8655600/DUPLO-43563

## Overview

Adds `force_update` support to `duplocloud_k8_helm_release`, surfacing FluxCD's `spec.upgrade.force` (backend counterpart: DUPLO-43562). This lets adopted / mixed-ownership releases be delete-and-recreated on upgrade instead of patched, unblocking chart upgrades where Kubernetes Server-Side Apply cannot clear a stale field (e.g. an `env` entry moving from `value` to `valueFrom`).

## Summary of changes

This PR does the following:

- Add optional `force_update` (bool, default `false`) to the resource schema; maps to `spec.upgrade.force` via a new `HelmUpgrade` SDK model. Omitted/`false` preserves current behavior.
- Fix a pre-existing perpetual drift where an unset `values` (echoed back by the API as an empty array) was written into state; flatten now skips empty/null collections.
- Fix pre-existing import gaps for this resource: flatten now sets `tenant_id` and sets the `chart` block as a whole list, so `terraform import` round-trips cleanly instead of forcing replacement.
- Regenerate docs for the new attribute.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
