### PR TITLE
DUPLO-43554 TF: retry secondary ecache delete until global datastore association clears

### DIFF
--- a/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
+++ b/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
@@ -230,9 +230,29 @@ func resourceDuploEcacheReplicationGroupDelete(ctx context.Context, d *schema.Re
 
 	}
 	log.Printf("[TRACE] Secondary cluster %s disassociated \n Started cluster cleanup", fullName)
-	err = c.EcacheInstanceDelete(secTenantId, name)
-	if err != nil {
-		return diag.FromErr(err)
+
+	// After disassociation, the backend clears the secondary instance's
+	// GlobalReplicationGroupId asynchronously once AWS finishes detaching. The member can
+	// disappear from the global datastore's member list (what the wait above polls) before
+	// the stored instance is updated, and the delete guard rejects with a 400
+	// ("...associated with Global Datastore") until it clears. Retry the delete until the
+	// association clears (or the configured delete timeout expires) instead of failing on
+	// the first attempt.
+	delErr := retry.RetryContext(ctx, d.Timeout("delete"), func() *retry.RetryError {
+		cerr := c.EcacheInstanceDelete(secTenantId, name)
+		if cerr != nil {
+			if cerr.Status() == 404 {
+				return nil // already gone
+			}
+			if cerr.Status() == 400 && strings.Contains(cerr.Error(), "associated with Global Datastore") {
+				return retry.RetryableError(cerr)
+			}
+			return retry.NonRetryableError(cerr)
+		}
+		return nil
+	})
+	if delErr != nil {
+		return diag.FromErr(delErr)
 	}
 
 	// Wait up to 60 seconds for Duplo to show the object as deleted.


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-43554](https://app.clickup.com/t/8655600/DUPLO-43554)

## Overview

`terraform destroy` of a `duplocloud_ecache_associate_global_secondary_cluster` intermittently fails: after disassociating the secondary from the global datastore, the provider deletes the secondary instance too soon and the backend rejects it with `400 ... cannot be deleted because is associated with Global Datastore`. The disassociation clears the stored instance's `GlobalReplicationGroupId` asynchronously, slightly after the member leaves the global datastore's member list (which is what the existing wait polls) — an eventual-consistency race. It succeeds on a later re-apply once the association has cleared.

## Summary of changes

This PR does the following:

- Wraps the secondary `EcacheInstanceDelete` call in `resourceDuploEcacheReplicationGroupDelete` with `retry.RetryContext(ctx, d.Timeout("delete"), ...)`.
- Treats the specific `400 "...associated with Global Datastore"` as retryable so the delete waits for the backend to clear the association instead of failing on the first attempt.
- Treats `404` as already-deleted (success); any other error fails fast.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
