### PR TITLE
DUPLO-43647 [Bug] k8s_worker_os = "Windows" is silently ignored on AWS/EKS — Windows pods fail to schedule

### DIFF
--- a/duplocloud/resource_duplo_service.go
+++ b/duplocloud/resource_duplo_service.go
@@ -316,10 +316,10 @@ func duploServiceSchema() map[string]*schema.Schema {
 			Default:      "Linux",
 			ForceNew:     true,
 			ValidateFunc: validation.StringInSlice([]string{"Linux", "Windows"}, false),
-			DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
-				cloud := d.Get("cloud").(int)
-				return cloud != 2
-			},
+			//DiffSuppressFunc: func(k, old, new string, d *schema.ResourceData) bool {
+			//	cloud := d.Get("cloud").(int)
+			//	return cloud != 2
+			//},
 		},
 	}
 }


### PR DESCRIPTION
## ClickUp Ticket
**ClickUp Ticket ID: DUPLO-43647**

## Overview

## Summary of changes
Removed diff suppress function
This PR does the following:

- Removed diff suppress function on k8s_worker_os and made it available for all clouds
- ...

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- ...
