### PR TITLE
DUPLO-43652 TF: mark seconds_until_auto_pause Computed so AWS default round-trips without drift

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -522,7 +522,7 @@ Required:
 
 Optional:
 
-- `seconds_until_auto_pause` (Number) The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300 and that value is reflected in state.
+- `seconds_until_auto_pause` (Number) The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
 
 ## Import
 

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -522,7 +522,7 @@ Required:
 
 Optional:
 
-- `seconds_until_auto_pause` (Number) The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+- `seconds_until_auto_pause` (Number) The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300 and that value is reflected in state.
 
 ## Import
 

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -278,9 +278,10 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 						Required:    true,
 					},
 					"seconds_until_auto_pause": {
-						Description:  "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).",
+						Description:  "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300 and that value is reflected in state.",
 						Type:         schema.TypeInt,
 						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.IntBetween(300, 86400),
 					},
 				},

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -278,7 +278,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 						Required:    true,
 					},
 					"seconds_until_auto_pause": {
-						Description:  "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300 and that value is reflected in state.",
+						Description:  "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.",
 						Type:         schema.TypeInt,
 						Optional:     true,
 						Computed:     true,
@@ -1040,6 +1040,14 @@ func expandV2ScalingConfiguration(cfg []interface{}) *duplosdk.V2ScalingConfigur
 	if v, ok := m["seconds_until_auto_pause"]; ok {
 		out.SecondsUntilAutoPause = v.(int)
 	}
+	// Auto-pause only applies at min_capacity 0. seconds_until_auto_pause is
+	// Computed, so when the user omits it the plan carries the prior state value
+	// forward; with a nonzero min_capacity that leftover must not reach the API
+	// (an explicitly configured value is already rejected at plan time). The
+	// zero value is dropped from the request via omitempty.
+	if out.MinCapacity != 0 {
+		out.SecondsUntilAutoPause = 0
+	}
 	// max_capacity is always required for a serverless v2 config, so a zero value
 	// means the block was not populated. min_capacity may legitimately be 0
 	// (auto-pause / scale-to-zero), so it must not be treated as "unset".
@@ -1299,11 +1307,22 @@ func validateRDSParameters(ctx context.Context, diff *schema.ResourceDiff, m int
 			if !ok {
 				return nil
 			}
-			if secUntilPause, ok := cfg["seconds_until_auto_pause"]; ok {
-				secVal, ok := secUntilPause.(int)
-				if ok && secVal > 0 && minCap != 0 {
-					return fmt.Errorf("seconds_until_auto_pause can only be set when min_capacity is 0 (auto-pause requires scaling to zero ACUs)")
+			// seconds_until_auto_pause is Computed, so the planned value carries the
+			// prior state value forward when the attribute is omitted from config
+			// (it can't be unset by removing it). Only reject the min_capacity
+			// conflict when the value is explicitly in the raw config; a
+			// carried-forward value is dropped by expandV2ScalingConfiguration.
+			secondsConfigured := false
+			if raw := diff.GetRawConfig(); !raw.IsNull() {
+				if rawV2 := raw.GetAttr("v2_scaling_configuration"); !rawV2.IsNull() && rawV2.IsKnown() && rawV2.LengthInt() > 0 {
+					if block := rawV2.AsValueSlice()[0]; block.IsKnown() {
+						sec := block.GetAttr("seconds_until_auto_pause")
+						secondsConfigured = sec.IsKnown() && !sec.IsNull()
+					}
 				}
+			}
+			if secVal, ok := cfg["seconds_until_auto_pause"].(int); ok && secVal > 0 && minCap != 0 && secondsConfigured {
+				return fmt.Errorf("seconds_until_auto_pause can only be set when min_capacity is 0 (auto-pause requires scaling to zero ACUs)")
 			}
 		}
 	}


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/86ajej9e2 (DUPLO-43652)

## Overview

When an Aurora Serverless v2 instance is created with `min_capacity = 0` and `seconds_until_auto_pause` omitted, AWS applies its default of 300s, but Terraform state records `0`. `seconds_until_auto_pause` was `Optional` (not `Computed`), so the provider could not reflect an AWS-assigned default into state without a "provider produced inconsistent result after apply" / perpetual-drift error — so the omitted value stays `0`.

The underlying reason state shows `0` (rather than `300`) is backend DUPLO-43441 (the synced RDS view returns `SecondsUntilAutoPause: 0` instead of the live AWS value). This PR is the provider half: it makes the field able to absorb the AWS-assigned default cleanly. On its own it prevents drift; the correct value (`300`) is reflected once the backend fix lands.

## Summary of changes

This PR does the following:

- Add `Computed: true` to `seconds_until_auto_pause` (keeps `Optional` and the 300–86400 range validation) so an AWS-assigned default round-trips into state without drift.
- Regenerate `docs/resources/rds_instance.md` for the updated description.

The read flatten is intentionally left unchanged: its existing defensive branch still preserves an explicitly-configured value while the backend returns 0, avoiding drift for that case.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
