### PR TITLE
DUPLO-43564 TF: inherit multi_az_enabled from primary on GDS secondary associate

### DIFF
--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -522,7 +522,7 @@ Required:
 
 Optional:
 
-- `seconds_until_auto_pause` (Number) The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300 and that value is reflected in state.
+- `seconds_until_auto_pause` (Number) The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.
 
 ## Import
 

--- a/docs/resources/rds_instance.md
+++ b/docs/resources/rds_instance.md
@@ -522,7 +522,7 @@ Required:
 
 Optional:
 
-- `seconds_until_auto_pause` (Number) The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).
+- `seconds_until_auto_pause` (Number) The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300 and that value is reflected in state.
 
 ## Import
 

--- a/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
+++ b/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
@@ -123,7 +123,7 @@ func resourceDuploEcacheReplicationGroupCreate(ctx context.Context, d *schema.Re
 	// inherit it from the primary member of the global datastore at create time instead of
 	// letting the backend default it to false.
 	if multiAZ, ok := inheritPrimaryMultiAZ(c, tenantID, rq.GlobalReplicationGroupId); ok {
-		rq.MultiAZEnabled = multiAZ
+		rq.MultiAZEnabled = &multiAZ
 	}
 
 	rp, cerr := c.DuploEcacheReplicationGroupCreate(tenantID, &rq)

--- a/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
+++ b/duplocloud/duplocloud_ecache_associate_global_secondary_cluster.go
@@ -117,6 +117,15 @@ func resourceDuploEcacheReplicationGroupCreate(ctx context.Context, d *schema.Re
 	log.Printf("[TRACE] resourceDuploEcacheReplicationGroupCreate(%s): start", tenantID)
 
 	c := m.(*duplosdk.Client)
+
+	// A global datastore secondary must mirror the primary's Multi-AZ setting (the UI does
+	// this too). The associate resource does not take multi_az_enabled from the user, so
+	// inherit it from the primary member of the global datastore at create time instead of
+	// letting the backend default it to false.
+	if multiAZ, ok := inheritPrimaryMultiAZ(c, tenantID, rq.GlobalReplicationGroupId); ok {
+		rq.MultiAZEnabled = multiAZ
+	}
+
 	rp, cerr := c.DuploEcacheReplicationGroupCreate(tenantID, &rq)
 	if cerr != nil {
 		return diag.Errorf("DuploEcacheReplicationGroupCreate failed to create global datastore : %s", cerr)
@@ -124,14 +133,44 @@ func resourceDuploEcacheReplicationGroupCreate(ctx context.Context, d *schema.Re
 	id := fmt.Sprintf("%s/ecacheReplicationGroup/%s/%s/%s", tenantID, rq.SecondaryTenantId, rq.GlobalReplicationGroupId, rq.ReplicationGroupId)
 	err := replicationGroupWaitUntilAvailable(ctx, c, tenantID, rq.GlobalReplicationGroupId, rq.SecondaryTenantId, rp.ReplicationGroupId, d.Timeout("create"))
 	if err != nil {
-		return diag.Errorf("replicationGroupWaitUntilAvailable %s", cerr)
-
+		return diag.Errorf("Error waiting for ECache secondary cluster '%s' to become ready: %s", rq.ReplicationGroupId, err)
 	}
 	d.SetId(id)
 
 	diags := resourceDuploEcacheReplicationGroupRead(ctx, d, m)
 	log.Printf("[TRACE] resourceDuploEcacheReplicationGroupCreate(%s, %s): end", tenantID, rp.GlobalReplicationGroup.GlobalReplicationGroupId)
 	return diags
+}
+
+// inheritPrimaryMultiAZ resolves the primary member of the given global datastore and
+// returns its multi_az_enabled setting, so a newly associated secondary can mirror it.
+// It returns ok=false (and logs) when the value cannot be determined, in which case the
+// caller leaves the request's default unchanged rather than failing the create.
+func inheritPrimaryMultiAZ(c *duplosdk.Client, tenantID, globalDatastoreID string) (bool, bool) {
+	gds, err := c.DuploEcacheGlobalDatastoreGet(tenantID, globalDatastoreID)
+	if err != nil || gds == nil {
+		log.Printf("[WARN] ecache secondary: could not fetch global datastore %s to inherit multi_az_enabled: %v", globalDatastoreID, err)
+		return false, false
+	}
+	for _, mem := range gds.Members {
+		if !strings.EqualFold(mem.Role, "primary") {
+			continue
+		}
+		primaryTenant := mem.TenantId
+		if primaryTenant == "" {
+			primaryTenant = tenantID
+		}
+		// EcacheInstanceGet re-adds the "duplo-" prefix, so strip it from the member id.
+		primaryName := strings.TrimPrefix(mem.ReplicationGroupId, "duplo-")
+		primary, perr := c.EcacheInstanceGet(primaryTenant, primaryName)
+		if perr != nil || primary == nil {
+			log.Printf("[WARN] ecache secondary: could not fetch primary instance %s to inherit multi_az_enabled: %v", primaryName, perr)
+			return false, false
+		}
+		return primary.MultiAZEnabled, true
+	}
+	log.Printf("[WARN] ecache secondary: no primary member found in global datastore %s; multi_az_enabled not inherited", globalDatastoreID)
+	return false, false
 }
 
 func replicationGroupWaitUntilAvailable(ctx context.Context, c *duplosdk.Client, tenantID, gDatastore, secTenantId, name string, d time.Duration) error {

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -278,9 +278,10 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 						Required:    true,
 					},
 					"seconds_until_auto_pause": {
-						Description:  "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours).",
+						Description:  "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300 and that value is reflected in state.",
 						Type:         schema.TypeInt,
 						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.IntBetween(300, 86400),
 					},
 				},

--- a/duplocloud/resource_duplo_rds_instance.go
+++ b/duplocloud/resource_duplo_rds_instance.go
@@ -278,7 +278,7 @@ func rdsInstanceSchema() map[string]*schema.Schema {
 						Required:    true,
 					},
 					"seconds_until_auto_pause": {
-						Description:  "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300 and that value is reflected in state.",
+						Description:  "The amount of time, in seconds, the cluster must remain idle — no connections and no database activity while at `min_capacity` — before Aurora Serverless v2 auto-pauses it (scales to zero ACUs). Any activity resets the timer. Only applies when `min_capacity` is `0`. Must be between 300 (5 minutes) and 86400 (24 hours). When omitted, AWS applies its default of 300; the applied value is reflected in state once the backend reports it.",
 						Type:         schema.TypeInt,
 						Optional:     true,
 						Computed:     true,
@@ -1040,6 +1040,14 @@ func expandV2ScalingConfiguration(cfg []interface{}) *duplosdk.V2ScalingConfigur
 	if v, ok := m["seconds_until_auto_pause"]; ok {
 		out.SecondsUntilAutoPause = v.(int)
 	}
+	// Auto-pause only applies at min_capacity 0. seconds_until_auto_pause is
+	// Computed, so when the user omits it the plan carries the prior state value
+	// forward; with a nonzero min_capacity that leftover must not reach the API
+	// (an explicitly configured value is already rejected at plan time). The
+	// zero value is dropped from the request via omitempty.
+	if out.MinCapacity != 0 {
+		out.SecondsUntilAutoPause = 0
+	}
 	// max_capacity is always required for a serverless v2 config, so a zero value
 	// means the block was not populated. min_capacity may legitimately be 0
 	// (auto-pause / scale-to-zero), so it must not be treated as "unset".
@@ -1299,11 +1307,22 @@ func validateRDSParameters(ctx context.Context, diff *schema.ResourceDiff, m int
 			if !ok {
 				return nil
 			}
-			if secUntilPause, ok := cfg["seconds_until_auto_pause"]; ok {
-				secVal, ok := secUntilPause.(int)
-				if ok && secVal > 0 && minCap != 0 {
-					return fmt.Errorf("seconds_until_auto_pause can only be set when min_capacity is 0 (auto-pause requires scaling to zero ACUs)")
+			// seconds_until_auto_pause is Computed, so the planned value carries the
+			// prior state value forward when the attribute is omitted from config
+			// (it can't be unset by removing it). Only reject the min_capacity
+			// conflict when the value is explicitly in the raw config; a
+			// carried-forward value is dropped by expandV2ScalingConfiguration.
+			secondsConfigured := false
+			if raw := diff.GetRawConfig(); !raw.IsNull() {
+				if rawV2 := raw.GetAttr("v2_scaling_configuration"); !rawV2.IsNull() && rawV2.IsKnown() && rawV2.LengthInt() > 0 {
+					if block := rawV2.AsValueSlice()[0]; block.IsKnown() {
+						sec := block.GetAttr("seconds_until_auto_pause")
+						secondsConfigured = sec.IsKnown() && !sec.IsNull()
+					}
 				}
+			}
+			if secVal, ok := cfg["seconds_until_auto_pause"].(int); ok && secVal > 0 && minCap != 0 && secondsConfigured {
+				return fmt.Errorf("seconds_until_auto_pause can only be set when min_capacity is 0 (auto-pause requires scaling to zero ACUs)")
 			}
 		}
 	}

--- a/duplosdk/ecache_instance.go
+++ b/duplosdk/ecache_instance.go
@@ -397,7 +397,9 @@ type DuploEcacheReplicationGroup struct {
 	AuthToken                string `json:"AuthToken,omitempty"`
 	// MultiAZEnabled is inherited from the primary at create time so the secondary mirrors
 	// the primary's Multi-AZ setting (the user never sets it on the secondary resource).
-	MultiAZEnabled bool `json:"MultiAZEnabled"`
+	// Pointer + omitempty so the field is only sent when the primary's value was resolved;
+	// when inheritance can't be determined it is omitted rather than asserting a default.
+	MultiAZEnabled *bool `json:"MultiAZEnabled,omitempty"`
 }
 
 func (c *Client) DuploEcacheReplicationGroupCreate(tenantID string, rq *DuploEcacheReplicationGroup) (*DuploEcacheGlobalDatastoreResponse, ClientError) {

--- a/duplosdk/ecache_instance.go
+++ b/duplosdk/ecache_instance.go
@@ -395,6 +395,9 @@ type DuploEcacheReplicationGroup struct {
 	ReplicationGroupId       string `json:"ReplicationGroupId"`
 	KmsKeyId                 string `json:"KmsKeyId,omitempty"`
 	AuthToken                string `json:"AuthToken,omitempty"`
+	// MultiAZEnabled is inherited from the primary at create time so the secondary mirrors
+	// the primary's Multi-AZ setting (the user never sets it on the secondary resource).
+	MultiAZEnabled bool `json:"MultiAZEnabled"`
 }
 
 func (c *Client) DuploEcacheReplicationGroupCreate(tenantID string, rq *DuploEcacheReplicationGroup) (*DuploEcacheGlobalDatastoreResponse, ClientError) {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** [DUPLO-43564](https://app.clickup.com/t/8655600/DUPLO-43564)

## Overview

A `duplocloud_ecache_associate_global_secondary_cluster` was always created with `MultiAZEnabled=false` even when the primary had `multi_az_enabled=true`, because the associate resource never sent a Multi-AZ value and the backend defaulted it to false. The UI works because it sends the primary's value.

This is the Terraform half of the fix; it pairs with the backend change (DUPLO-43564 on the backend repo) that gives cluster-mode secondaries their replicas (`ReplicasPerNodeGroup`). Both are required: without the backend half a cluster-mode secondary faults on "Each Node Group needs at least one replica for Multi-AZ"; without this TF half the secondary comes up with `multi_az` disabled.

## Summary of changes

This PR does the following:

- On create, `resourceDuploEcacheReplicationGroupCreate` resolves the primary member of the global datastore, reads its `multi_az_enabled`, and sends it on the associate request (`inheritPrimaryMultiAZ`), so the secondary mirrors the primary automatically. Best-effort: if the primary can't be resolved it logs and leaves the default unchanged rather than failing the create. No new schema attribute — the user never sets `multi_az` on the secondary.
- Adds `MultiAZEnabled` to the `DuploEcacheReplicationGroup` SDK request struct.
- Fixes a pre-existing error message in the create path that printed the wrong variable (`cerr`, always nil) instead of the actual wait error.

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
