### PR TITLE
DUPLO-43174 TF: Add support for TCP Idle Timeout configuration for NLB listeners in ECS Service

### DIFF
--- a/docs/data-sources/ecs_service.md
+++ b/docs/data-sources/ecs_service.md
@@ -94,6 +94,7 @@ Read-Only:
 - `protocol` (String)
 - `replication_controller_name` (String)
 - `target_group_count` (Number)
+- `tcp_idle_timeout_seconds` (Number)
 - `webaclid` (String)
 
 <a id="nestedobjatt--load_balancer--health_check_config"></a>

--- a/docs/data-sources/ecs_services.md
+++ b/docs/data-sources/ecs_services.md
@@ -101,6 +101,7 @@ Read-Only:
 - `protocol` (String)
 - `replication_controller_name` (String)
 - `target_group_count` (Number)
+- `tcp_idle_timeout_seconds` (Number)
 - `webaclid` (String)
 
 <a id="nestedobjatt--services--load_balancer--health_check_config"></a>

--- a/docs/resources/ecs_service.md
+++ b/docs/resources/ecs_service.md
@@ -201,7 +201,7 @@ Optional:
 - `http_to_https_redirect` (Boolean) Whether or not the load balancer should redirect HTTP to HTTPS.
 - `idle_timeout` (Number) The time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type `application`.
 - `is_internal` (Boolean) Whether or not to create an internal load balancer. Defaults to `false`.
-- `tcp_idle_timeout_seconds` (Number) The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset.
+- `tcp_idle_timeout_seconds` (Number) The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.
 - `webaclid` (String) The ARN of a web application firewall to associate this load balancer.
 
 Read-Only:

--- a/docs/resources/ecs_service.md
+++ b/docs/resources/ecs_service.md
@@ -201,6 +201,7 @@ Optional:
 - `http_to_https_redirect` (Boolean) Whether or not the load balancer should redirect HTTP to HTTPS.
 - `idle_timeout` (Number) The time in seconds that the connection is allowed to be idle. Only valid for Load Balancers of type `application`.
 - `is_internal` (Boolean) Whether or not to create an internal load balancer. Defaults to `false`.
+- `tcp_idle_timeout_seconds` (Number) The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset.
 - `webaclid` (String) The ARN of a web application firewall to associate this load balancer.
 
 Read-Only:

--- a/duplocloud/resource_duplo_ecs_service.go
+++ b/duplocloud/resource_duplo_ecs_service.go
@@ -204,6 +204,12 @@ func ecsServiceSchema() map[string]*schema.Schema {
 						Optional:    true,
 						Computed:    true,
 					},
+					"tcp_idle_timeout_seconds": {
+						Description:  "The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset.",
+						Type:         schema.TypeInt,
+						Optional:     true,
+						ValidateFunc: validation.IntBetween(60, 6000),
+					},
 					"webaclid": {
 						Description: "The ARN of a web application firewall to associate this load balancer.",
 						Type:        schema.TypeString,
@@ -696,6 +702,7 @@ func ecsLoadBalancersToState(name string, lbcs *[]duplosdk.DuploEcsServiceLbConf
 		jo["health_check_url"] = lbc.HealthCheckURL
 		jo["certificate_arn"] = lbc.CertificateArn
 		jo["index"] = lbc.LbIndex
+		jo["tcp_idle_timeout_seconds"] = lbc.TcpIdleTimeoutSeconds
 		hcConfig := ecsLoadBalancersHealthCheckConfigToState(lbc.HealthCheckConfig)
 		if hcConfig != nil {
 			jo["health_check_config"] = []interface{}{hcConfig}
@@ -791,6 +798,7 @@ func ecsLoadBalancerFromState(d *schema.ResourceData, lb map[string]interface{})
 		CertificateArn:            lb["certificate_arn"].(string),
 		TgCount:                   lb["target_group_count"].(int),
 		IdleTimeout:               lb["idle_timeout"].(int),
+		TcpIdleTimeoutSeconds:     lb["tcp_idle_timeout_seconds"].(int),
 	}
 
 	if lb["health_check_config"] != nil {

--- a/duplocloud/resource_duplo_ecs_service.go
+++ b/duplocloud/resource_duplo_ecs_service.go
@@ -205,9 +205,10 @@ func ecsServiceSchema() map[string]*schema.Schema {
 						Computed:    true,
 					},
 					"tcp_idle_timeout_seconds": {
-						Description:  "The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset.",
+						Description:  "The time in seconds that a TCP connection is allowed to be idle. Only applicable for TCP/TLS listeners on Load Balancers of type `network` (`lb_type = 6`). Valid values are between `60` and `6000`. AWS defaults to `350` when unset; the applied value is reflected in state once the backend reports it.",
 						Type:         schema.TypeInt,
 						Optional:     true,
+						Computed:     true,
 						ValidateFunc: validation.IntBetween(60, 6000),
 					},
 					"webaclid": {

--- a/duplosdk/ecs_service.go
+++ b/duplosdk/ecs_service.go
@@ -22,6 +22,7 @@ type DuploEcsServiceLbConfig struct {
 	HealthCheckConfig         *DuploEcsServiceLbHealthCheckConfig `json:"HealthCheckConfig,omitempty"`
 	LbIndex                   int                                 `json:"LbIndex"`
 	IdleTimeout               int                                 `json:"IdleTimeout,omitempty"`
+	TcpIdleTimeoutSeconds     int                                 `json:"TcpIdleTimeoutSeconds,omitempty"`
 }
 
 type DuploEcsServiceLbHealthCheckConfig struct {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/8655600/DUPLO-43174

## Overview

Adds support for configuring the TCP idle timeout on NLB TCP/TLS listeners created for ECS services, exposing the backend's `LBConfiguration.TcpIdleTimeoutSeconds` (backend PR duplocloud-internal/duplo#5359).

## Summary of changes

This PR does the following:

- Adds `tcp_idle_timeout_seconds` to the `load_balancer` block of `duplocloud_ecs_service` (Optional, validated to the AWS range 60–6000; AWS defaults to 350 when unset)
- Adds `TcpIdleTimeoutSeconds` to the `DuploEcsServiceLbConfig` SDK struct and wires it through the expand/flatten functions (ECS data sources pick it up via the shared schema)
- Regenerates docs

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
