### PR TITLE
DUPLO-43369 chore: cherrypick to hotfix/0.2.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ my-test/
 .terraform.tfstate.lock.info
 .env
 .github/agents/
+
+# superpowers scratch + internal design/plan docs (not shipped in this public repo)
+.superpowers/
+docs/superpowers/

--- a/docs/resources/asg_profile.md
+++ b/docs/resources/asg_profile.md
@@ -450,7 +450,7 @@ Optional:
 
 - `on_demand_allocation_strategy` (String) Strategy for allocating On-Demand instances (e.g. `prioritized`).
 - `on_demand_base_capacity` (Number) Minimum number of On-Demand instances in the group.
-- `on_demand_percentage_above_base_capacity` (Number) Percentage of On-Demand instances above the base capacity (0-100).
+- `on_demand_percentage_above_base_capacity` (Number) Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.
 - `spot_allocation_strategy` (String) Strategy for allocating Spot instances (e.g. `capacity-optimized`, `price-capacity-optimized`, `lowest-price`).
 - `spot_instance_pools` (Number) Number of Spot pools for allocation (only used with `lowest-price` strategy).
 - `spot_max_price` (String) Maximum price per unit hour for Spot instances.

--- a/duplocloud/resource_duplo_asg_profile.go
+++ b/duplocloud/resource_duplo_asg_profile.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -307,9 +308,10 @@ func autoscalingGroupSchema() map[string]*schema.Schema {
 								Optional:    true,
 							},
 							"on_demand_percentage_above_base_capacity": {
-								Description: "Percentage of On-Demand instances above the base capacity (0-100).",
-								Type:        schema.TypeInt,
-								Optional:    true,
+								Description:      "Percentage of On-Demand instances above the base capacity (0-100). Set explicitly to `0` for 100% Spot above base capacity. Omit to leave it unmanaged: on create AWS applies its default of 100% On-Demand, and on an existing ASG the current value is left unchanged.",
+								Type:             schema.TypeInt,
+								Optional:         true,
+								DiffSuppressFunc: suppressOmittedOnDemandPercentage,
 							},
 							"spot_allocation_strategy": {
 								Description: "Strategy for allocating Spot instances (e.g. `capacity-optimized`, `price-capacity-optimized`, `lowest-price`).",
@@ -870,6 +872,21 @@ func expandAsgProfile(d *schema.ResourceData) *duplosdk.DuploAsgProfile {
 	return asgProfile
 }
 
+// suppressOmittedOnDemandPercentage suppresses the diff for
+// on_demand_percentage_above_base_capacity only when the user omitted it from config.
+// The backend converges the stored value to 100 (its coercion default), which flatten
+// writes into state; without this, an omitted config (0) perpetually diffs against
+// state (100). An explicitly-written value (including 0) is NOT suppressed, so real
+// changes still apply. Reads GetRawConfig so it sees what the user wrote, not state.
+//
+// Suppress only a KNOWN omission. A value that is unknown at plan time (e.g. driven by
+// a variable or another resource's computed output) must not be suppressed — doing so
+// would hide a real pending change — so we gate on `known`.
+func suppressOmittedOnDemandPercentage(k, old, new string, d *schema.ResourceData) bool {
+	_, explicit, known := asgConfiguredOnDemandPercentage(d.GetRawConfig())
+	return known && !explicit
+}
+
 func expandAsgMixedInstancesPolicy(d *schema.ResourceData) *duplosdk.DuploAsgMixedInstancesPolicy {
 	v, ok := d.GetOk("mixed_instances_policy")
 	if !ok || len(v.([]interface{})) == 0 {
@@ -943,9 +960,11 @@ func expandAsgMixedInstancesPolicy(d *schema.ResourceData) *duplosdk.DuploAsgMix
 			val := v.(int)
 			distribution.OnDemandBaseCapacity = &val
 		}
-		if v, ok := distMap["on_demand_percentage_above_base_capacity"]; ok {
-			val := v.(int)
+		if pct, explicit, _ := asgConfiguredOnDemandPercentage(d.GetRawConfig()); explicit {
+			val := pct
+			flag := true
 			distribution.OnDemandPercentageAboveBaseCapacity = &val
+			distribution.OnDemandPercentageAboveBaseCapacityExplicit = &flag
 		}
 		if v, ok := distMap["spot_instance_pools"]; ok && v.(int) > 0 {
 			val := v.(int)
@@ -955,6 +974,68 @@ func expandAsgMixedInstancesPolicy(d *schema.ResourceData) *duplosdk.DuploAsgMix
 	}
 
 	return policy
+}
+
+// asgConfiguredOnDemandPercentage extracts
+// mixed_instances_policy[0].instances_distribution[0].on_demand_percentage_above_base_capacity
+// from the raw config (via GetRawConfig; works with both *schema.ResourceData and
+// *schema.ResourceDiff). Mirrors the s3ConfiguredKmsKeyId pattern.
+//
+//   - explicit is true only for a known, non-null value the user wrote (including 0).
+//     expand sends that value plus the Explicit flag so a literal 0 is honored instead
+//     of coerced to 100.
+//   - known is false when the attribute (or an enclosing block) is unknown at plan time
+//     — e.g. driven by a variable or another resource's computed output. An unknown
+//     value must NOT be treated as "omitted"; suppressing its diff would hide a real
+//     pending change (same pitfall guarded against in s3ConfiguredKmsKeyId). Callers
+//     must not suppress when known is false.
+//
+// A genuine omission (the attribute or an enclosing block absent/null in config) returns
+// (0, false, true): a known omission, which is the only case a caller may suppress.
+func asgConfiguredOnDemandPercentage(raw cty.Value) (value int, explicit bool, known bool) {
+	if !raw.IsKnown() {
+		return 0, false, false
+	}
+	if raw.IsNull() {
+		return 0, false, true
+	}
+	mip := raw.GetAttr("mixed_instances_policy")
+	if !mip.IsKnown() {
+		return 0, false, false
+	}
+	if mip.IsNull() || mip.LengthInt() == 0 {
+		return 0, false, true
+	}
+	mipBlock := mip.AsValueSlice()[0]
+	if !mipBlock.IsKnown() {
+		return 0, false, false
+	}
+	if mipBlock.IsNull() {
+		return 0, false, true
+	}
+	dist := mipBlock.GetAttr("instances_distribution")
+	if !dist.IsKnown() {
+		return 0, false, false
+	}
+	if dist.IsNull() || dist.LengthInt() == 0 {
+		return 0, false, true
+	}
+	distBlock := dist.AsValueSlice()[0]
+	if !distBlock.IsKnown() {
+		return 0, false, false
+	}
+	if distBlock.IsNull() {
+		return 0, false, true
+	}
+	pct := distBlock.GetAttr("on_demand_percentage_above_base_capacity")
+	if !pct.IsKnown() {
+		return 0, false, false
+	}
+	if pct.IsNull() {
+		return 0, false, true
+	}
+	i64, _ := pct.AsBigFloat().Int64()
+	return int(i64), true, true
 }
 
 func flattenAsgMixedInstancesPolicy(policy *duplosdk.DuploAsgMixedInstancesPolicy) []interface{} {

--- a/duplocloud/resource_duplo_asg_profile_helpers_test.go
+++ b/duplocloud/resource_duplo_asg_profile_helpers_test.go
@@ -1,0 +1,106 @@
+package duplocloud
+
+import (
+	"testing"
+
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/stretchr/testify/assert"
+)
+
+// buildAsgRawConfig wraps an instances_distribution attribute map into the
+// nested cty shape GetRawConfig() produces:
+// { mixed_instances_policy = [ { instances_distribution = [ { <distAttrs> } ] } ] }
+func buildAsgRawConfig(distAttrs map[string]cty.Value) cty.Value {
+	return cty.ObjectVal(map[string]cty.Value{
+		"mixed_instances_policy": cty.ListVal([]cty.Value{
+			cty.ObjectVal(map[string]cty.Value{
+				"instances_distribution": cty.ListVal([]cty.Value{
+					cty.ObjectVal(distAttrs),
+				}),
+			}),
+		}),
+	})
+}
+
+func TestAsgConfiguredOnDemandPercentage_Omitted_NotExplicitButKnown(t *testing.T) {
+	raw := buildAsgRawConfig(map[string]cty.Value{
+		"on_demand_percentage_above_base_capacity": cty.NullVal(cty.Number),
+	})
+
+	value, explicit, known := asgConfiguredOnDemandPercentage(raw)
+
+	assert.False(t, explicit)
+	assert.True(t, known) // a known omission — safe to suppress
+	assert.Equal(t, 0, value)
+}
+
+func TestAsgConfiguredOnDemandPercentage_ExplicitZero_IsExplicit(t *testing.T) {
+	raw := buildAsgRawConfig(map[string]cty.Value{
+		"on_demand_percentage_above_base_capacity": cty.NumberIntVal(0),
+	})
+
+	value, explicit, known := asgConfiguredOnDemandPercentage(raw)
+
+	assert.True(t, explicit)
+	assert.True(t, known)
+	assert.Equal(t, 0, value)
+}
+
+func TestAsgConfiguredOnDemandPercentage_ExplicitNonZero_IsExplicit(t *testing.T) {
+	raw := buildAsgRawConfig(map[string]cty.Value{
+		"on_demand_percentage_above_base_capacity": cty.NumberIntVal(40),
+	})
+
+	value, explicit, known := asgConfiguredOnDemandPercentage(raw)
+
+	assert.True(t, explicit)
+	assert.True(t, known)
+	assert.Equal(t, 40, value)
+}
+
+// The regression this fix targets: a value unknown at plan time (e.g. driven by a
+// variable or another resource's computed output) must be reported not-explicit AND
+// not-known, so the caller does NOT suppress its diff.
+func TestAsgConfiguredOnDemandPercentage_UnknownValue_NotExplicitNotKnown(t *testing.T) {
+	raw := buildAsgRawConfig(map[string]cty.Value{
+		"on_demand_percentage_above_base_capacity": cty.UnknownVal(cty.Number),
+	})
+
+	value, explicit, known := asgConfiguredOnDemandPercentage(raw)
+
+	assert.False(t, explicit)
+	assert.False(t, known) // unknown, not omitted — must not be suppressed
+	assert.Equal(t, 0, value)
+}
+
+func TestAsgConfiguredOnDemandPercentage_NoMixedInstancesPolicy_NotExplicitButKnown(t *testing.T) {
+	raw := cty.ObjectVal(map[string]cty.Value{
+		"mixed_instances_policy": cty.NullVal(cty.List(cty.EmptyObject)),
+	})
+
+	value, explicit, known := asgConfiguredOnDemandPercentage(raw)
+
+	assert.False(t, explicit)
+	assert.True(t, known) // block absent => attribute known-omitted
+	assert.Equal(t, 0, value)
+}
+
+func TestAsgConfiguredOnDemandPercentage_UnknownMixedInstancesPolicy_NotKnown(t *testing.T) {
+	raw := cty.ObjectVal(map[string]cty.Value{
+		"mixed_instances_policy": cty.UnknownVal(cty.List(cty.EmptyObject)),
+	})
+
+	value, explicit, known := asgConfiguredOnDemandPercentage(raw)
+
+	assert.False(t, explicit)
+	assert.False(t, known) // whole block pending => can't decide, must not suppress
+	assert.Equal(t, 0, value)
+}
+
+func TestAsgConfiguredOnDemandPercentage_NullRaw_NotExplicitButKnown(t *testing.T) {
+	value, explicit, known := asgConfiguredOnDemandPercentage(cty.NullVal(cty.EmptyObject))
+
+	assert.False(t, explicit)
+	assert.True(t, known)
+	assert.Equal(t, 0, value)
+}

--- a/duplosdk/asg.go
+++ b/duplosdk/asg.go
@@ -76,12 +76,13 @@ type DuploAsgIntRange struct {
 }
 
 type DuploAsgInstancesDistribution struct {
-	OnDemandAllocationStrategy          string `json:"OnDemandAllocationStrategy,omitempty"`
-	OnDemandBaseCapacity                *int   `json:"OnDemandBaseCapacity,omitempty"`
-	OnDemandPercentageAboveBaseCapacity *int   `json:"OnDemandPercentageAboveBaseCapacity,omitempty"`
-	SpotAllocationStrategy              string `json:"SpotAllocationStrategy,omitempty"`
-	SpotInstancePools                   *int   `json:"SpotInstancePools,omitempty"`
-	SpotMaxPrice                        string `json:"SpotMaxPrice,omitempty"`
+	OnDemandAllocationStrategy                  string `json:"OnDemandAllocationStrategy,omitempty"`
+	OnDemandBaseCapacity                        *int   `json:"OnDemandBaseCapacity,omitempty"`
+	OnDemandPercentageAboveBaseCapacity         *int   `json:"OnDemandPercentageAboveBaseCapacity,omitempty"`
+	OnDemandPercentageAboveBaseCapacityExplicit *bool  `json:"OnDemandPercentageAboveBaseCapacityExplicit,omitempty"`
+	SpotAllocationStrategy                      string `json:"SpotAllocationStrategy,omitempty"`
+	SpotInstancePools                           *int   `json:"SpotInstancePools,omitempty"`
+	SpotMaxPrice                                string `json:"SpotMaxPrice,omitempty"`
 }
 
 type DuploAsgProfileDeleteReq struct {


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** DUPLO-43369

## Overview

## Summary of changes

Squashed cherry-pick of PR #1528 onto hotfix/0.12.16. The PR landed on develop as merge commit f19fa32f27d5b8d4fd04ecb22b7bbb5d0d769686; it is replayed here as a single squashed commit rather than as a merge, matching the intended merge strategy.

(cherry picked from commit f19fa32f27d5b8d4fd04ecb22b7bbb5d0d769686)

Cherrypick was applied cleanly with no reported merge conflicts

This PR does the following:

- See description

## Testing performed

- [ ] Using unit tests
- [ ] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

None expected, QA recommended
