### PR TITLE
DUPLO-44337 TF: fix null dns_name from duplocloud_duplo_service_lbconfigs after provider upgrade

### DIFF
--- a/duplosdk/replication_controller.go
+++ b/duplosdk/replication_controller.go
@@ -373,7 +373,52 @@ func (c *Client) ReplicationControllerLbConfigurationList(tenantID string, name 
 	for _, lb := range rp.Template.LBConfigurations {
 		lbs = append(lbs, *lb)
 	}
+	if err := c.populateLbRuntimeFields(tenantID, name, lbs); err != nil {
+		return nil, err
+	}
 	return &lbs, nil
+}
+
+// populateLbRuntimeFields overlays runtime-only fields (DnsName, FrontendIP, CloudName,
+// BeProtocolVersion) onto LB configs read from the v3 replication controller endpoint, which
+// returns the stored template without them. The legacy GetLBConfigurations endpoint populates
+// these at read time.
+func (c *Client) populateLbRuntimeFields(tenantID, name string, lbs []DuploLbConfiguration) ClientError {
+	if len(lbs) == 0 {
+		return nil
+	}
+	allLbs, err := c.LbConfigurationList(tenantID)
+	if err != nil {
+		if err.Status() == 404 || err.Status() == 405 {
+			return nil
+		}
+		return err
+	}
+	if allLbs == nil {
+		return nil
+	}
+
+	// LbIndex can be zero across configs on portals without the UseLbIndex feature, so match on
+	// a composite key. Both lists serialize the same backend objects, so the keys line up exactly.
+	lbKey := func(lb *DuploLbConfiguration) string {
+		return fmt.Sprintf("%d/%s/%s/%d", lb.LbType, lb.Protocol, lb.Port, lb.LbIndex)
+	}
+	runtimeLbs := make(map[string]*DuploLbConfiguration, len(lbs))
+	for i := range *allLbs {
+		lb := &(*allLbs)[i]
+		if lb.ReplicationControllerName == name {
+			runtimeLbs[lbKey(lb)] = lb
+		}
+	}
+	for i := range lbs {
+		if src, ok := runtimeLbs[lbKey(&lbs[i])]; ok {
+			lbs[i].DnsName = src.DnsName
+			lbs[i].FrontendIP = src.FrontendIP
+			lbs[i].CloudName = src.CloudName
+			lbs[i].BeProtocolVersion = src.BeProtocolVersion
+		}
+	}
+	return nil
 }
 
 // ReplicationControllerLbConfigurationBulkUpdate bulk updates a replication controller's lb configuration via the Duplo API.

--- a/duplosdk/replication_controller.go
+++ b/duplosdk/replication_controller.go
@@ -2,6 +2,7 @@ package duplosdk
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 )
@@ -373,10 +374,32 @@ func (c *Client) ReplicationControllerLbConfigurationList(tenantID string, name 
 	for _, lb := range rp.Template.LBConfigurations {
 		lbs = append(lbs, *lb)
 	}
+	// Template.LBConfigurations is a map, so iteration order is randomized per read. The legacy
+	// GetLBConfigurations endpoint returned a stable array; without a deterministic order here,
+	// lbconfigs[N] references flap between plan and apply ("Provider produced inconsistent
+	// final plan").
+	sortLbConfigurations(lbs)
 	if err := c.populateLbRuntimeFields(tenantID, name, lbs); err != nil {
 		return nil, err
 	}
 	return &lbs, nil
+}
+
+// sortLbConfigurations orders LB configs by LbIndex (assigned in creation order by the backend),
+// falling back to LbType/Protocol/Port for portals where LbIndex is not populated.
+func sortLbConfigurations(lbs []DuploLbConfiguration) {
+	sort.SliceStable(lbs, func(i, j int) bool {
+		if lbs[i].LbIndex != lbs[j].LbIndex {
+			return lbs[i].LbIndex < lbs[j].LbIndex
+		}
+		if lbs[i].LbType != lbs[j].LbType {
+			return lbs[i].LbType < lbs[j].LbType
+		}
+		if lbs[i].Protocol != lbs[j].Protocol {
+			return lbs[i].Protocol < lbs[j].Protocol
+		}
+		return lbs[i].Port < lbs[j].Port
+	})
 }
 
 // populateLbRuntimeFields overlays runtime-only fields (DnsName, FrontendIP, CloudName,

--- a/duplosdk/replication_controller_test.go
+++ b/duplosdk/replication_controller_test.go
@@ -1,0 +1,43 @@
+package duplosdk
+
+import "testing"
+
+func TestSortLbConfigurationsByLbIndex(t *testing.T) {
+	lbs := []DuploLbConfiguration{
+		{LbIndex: 3, Protocol: "http", Port: "8080"},
+		{LbIndex: 1, Protocol: "http", Port: "80"},
+		{LbIndex: 2, Protocol: "tcp", Port: "443"},
+	}
+
+	sortLbConfigurations(lbs)
+
+	for i, want := range []int{1, 2, 3} {
+		if lbs[i].LbIndex != want {
+			t.Errorf("position %d: got LbIndex %d, want %d", i, lbs[i].LbIndex, want)
+		}
+	}
+}
+
+func TestSortLbConfigurationsWithoutLbIndex(t *testing.T) {
+	// Portals without the UseLbIndex feature leave LbIndex zero on every config; the
+	// fallback keys must still give a deterministic order.
+	lbs := []DuploLbConfiguration{
+		{LbType: 1, Protocol: "tcp", Port: "443"},
+		{LbType: 1, Protocol: "http", Port: "8080"},
+		{LbType: 0, Protocol: "http", Port: "80"},
+		{LbType: 1, Protocol: "http", Port: "3000"},
+	}
+
+	sortLbConfigurations(lbs)
+
+	got := make([]string, 0, len(lbs))
+	for _, lb := range lbs {
+		got = append(got, lb.Port)
+	}
+	want := []string{"80", "3000", "8080", "443"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got order %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/86ak5q7yt

## Overview

Since v0.12.10, `duplocloud_duplo_service_lbconfigs` returns `dns_name` (and `frontend_ip`, `cloud_name`, `backend_protocol_version`) as null. The LB config read was switched to the v3 replication controller endpoint, which returns the stored template without the runtime fields that the legacy `GetLBConfigurations` endpoint populates at read time. The same switch also made the LB config list ordering random (the template is a map), so `lbconfigs[N]` references on multi-LB services flap between plan and apply with "Provider produced inconsistent final plan".

## Summary of changes

This PR does the following:

- Keeps the v3 by-name read as the source of the LB config spec in `ReplicationControllerLbConfigurationList`
- Overlays the runtime-only fields (`DnsName`, `FrontendIP`, `CloudName`, `BeProtocolVersion`) from the legacy `GetLBConfigurations` endpoint, matching configs on a composite key; skips the overlay gracefully if the legacy endpoint returns 404/405
- Sorts the LB config list deterministically (by `LbIndex`, falling back to `LbType`/`Protocol`/`Port`) to restore the stable ordering the legacy endpoint provided, fixing "Provider produced inconsistent final plan" on services with multiple LB configs

## Testing performed

- [x] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None