### PR TITLE
DUPLO-44452 TF: resolve tenant name via user-scoped lookup so non-admin users can manage SNS/SQS

### DIFF
--- a/duplocloud/data_source_duplo_ecs_task_definition.go
+++ b/duplocloud/data_source_duplo_ecs_task_definition.go
@@ -58,7 +58,7 @@ func dataSourceDuploEcsTaskDefinitionRead(ctx context.Context, d *schema.Resourc
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("Duplocloud resource tenant information'\n%s", err)
+		return diag.Errorf("Unable to retrieve tenant %s information: %s", tenantID, cerr)
 	}
 	prefix, err := c.GetResourcePrefixWithoutTenant("duploservices")
 	if err != nil {

--- a/duplocloud/data_source_duplo_ecs_task_definition.go
+++ b/duplocloud/data_source_duplo_ecs_task_definition.go
@@ -51,7 +51,7 @@ func dataSourceDuploEcsTaskDefinitionRead(ctx context.Context, d *schema.Resourc
 		return diag.Errorf("Unable to read tenant %s ECS task definition '%s': not found", tenantID, arn)
 	}
 	d.SetId(fmt.Sprintf("%s/%s", tenantID, arn))
-	tenant, cerr := c.TenantGetV2(tenantID)
+	tenant, cerr := c.GetTenantForUser(tenantID)
 	if cerr != nil {
 		if cerr.Status() == 404 {
 			log.Printf("Tenant %s not found", tenantID)

--- a/duplocloud/resource_duplo_aws_sqs_queue.go
+++ b/duplocloud/resource_duplo_aws_sqs_queue.go
@@ -407,7 +407,7 @@ func validateSQSName(c *duplosdk.Client, tId, name string, fifo bool) error {
 			errMsg = fmt.Sprintf("invalid name format. Queue name must start with a letter, contain only letters, numbers, underscores, or hyphens, and be at most %d characters", 1+allowedLen)
 		}
 	} else {
-		rp, cerr := c.TenantGetV2(tId)
+		rp, cerr := c.GetTenantForUser(tId)
 		if cerr != nil {
 			return fmt.Errorf("failed to get tenant %s: %w", tId, cerr)
 		}

--- a/duplocloud/resource_duplo_ecs_task_definition.go
+++ b/duplocloud/resource_duplo_ecs_task_definition.go
@@ -345,7 +345,7 @@ func resourceDuploEcsTaskDefinitionRead(ctx context.Context, d *schema.ResourceD
 			d.SetId("")
 			return nil
 		}
-		return diag.Errorf("Duplocloud resource tenant information'\n%s", err)
+		return diag.Errorf("Unable to retrieve tenant %s information: %s", tenantID, cerr)
 	}
 	prefix, err := c.GetResourcePrefixWithoutTenant("duploservices")
 	if err != nil {

--- a/duplocloud/resource_duplo_ecs_task_definition.go
+++ b/duplocloud/resource_duplo_ecs_task_definition.go
@@ -338,7 +338,7 @@ func resourceDuploEcsTaskDefinitionRead(ctx context.Context, d *schema.ResourceD
 		d.SetId("")
 		return nil
 	}
-	tenant, cerr := c.TenantGetV2(tenantID)
+	tenant, cerr := c.GetTenantForUser(tenantID)
 	if cerr != nil {
 		if cerr.Status() == 404 {
 			log.Printf("Tenant %s not found", tenantID)

--- a/duplocloud/resource_duplo_s3_replication.go
+++ b/duplocloud/resource_duplo_s3_replication.go
@@ -182,7 +182,7 @@ func getS3BucketReplication(c *duplosdk.Client, tenantID, name string) ([]map[st
 	if duplo == nil || len(duplo.Rule) == 0 {
 		return nil, nil
 	}
-	tenantInfo, err := c.TenantGetV2(tenantID)
+	tenantInfo, err := c.GetTenantForUser(tenantID)
 	if err != nil {
 		return nil, err
 	}

--- a/duplosdk/utils.go
+++ b/duplosdk/utils.go
@@ -100,7 +100,7 @@ func (c *Client) GetDuploServicesPrefix(tenantID, prefix string) (string, Client
 
 // GetResourcePrefix builds a duplo resource prefix, given a tenant ID.
 func (c *Client) GetResourcePrefix(prefix, tenantID string) (string, ClientError) {
-	tenant, err := c.TenantGetV3(tenantID)
+	tenant, err := c.GetTenantForUser(tenantID)
 	if err != nil {
 		return "", err
 	}

--- a/duplosdk/utils_test.go
+++ b/duplosdk/utils_test.go
@@ -1,0 +1,57 @@
+package duplosdk
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/internal/duplosdktest"
+)
+
+// setupTenantListServer serves the user-scoped tenant list and rejects every
+// other path the way the portal rejects a non-admin user (DUPLO-44452).
+func setupTenantListServer(t *testing.T, body string) (*httptest.Server, *Client, *[]string) {
+	paths := []string{}
+	srv := duplosdktest.SetupHttptest(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		paths = append(paths, req.URL.Path)
+		if req.URL.Path != "/admin/GetTenantsForUser" {
+			res.WriteHeader(http.StatusForbidden)
+			res.Write([]byte(`{"Message":"Access is forbidden for this user"}`)) // nolint
+			return
+		}
+		res.Header().Set("Content-Type", "application/json")
+		res.Write([]byte(body)) // nolint
+	}))
+	c, err := NewClient(srv.URL, "FAKE")
+	assert.Nil(t, err, err)
+	return srv, c, &paths
+}
+
+// GetResourcePrefix must resolve the tenant name through the user-scoped tenant
+// list so that non-admin tenant users can read prefixed resources.
+func TestGetResourcePrefix_UsesUserScopedTenantLookup(t *testing.T) {
+	srv, c, paths := setupTenantListServer(t,
+		`[{"TenantId":"other","AccountName":"other"},{"TenantId":"t1","AccountName":"myapp"}]`)
+	defer duplosdktest.TeardownHttptest(srv)
+
+	prefix, err := c.GetResourcePrefix("duploservices", "t1")
+
+	assert.Nil(t, err)
+	assert.Equal(t, "duploservices-myapp", prefix)
+	assert.Equal(t, []string{"/admin/GetTenantsForUser"}, *paths)
+}
+
+// A tenant the user cannot see must surface as a 404 so callers can clear state.
+func TestGetResourcePrefix_TenantNotVisible(t *testing.T) {
+	srv, c, _ := setupTenantListServer(t, `[{"TenantId":"other","AccountName":"other"}]`)
+	defer duplosdktest.TeardownHttptest(srv)
+
+	prefix, err := c.GetResourcePrefix("duploservices", "t1")
+
+	assert.Equal(t, "", prefix)
+	if assert.NotNil(t, err) {
+		assert.Equal(t, http.StatusNotFound, err.Status())
+	}
+}


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/8655600/DUPLO-44452

## Overview

Non-admin tenant users get `403 Access is forbidden for this user` from `v3/admin/tenant/{id}` at plan time for `duplocloud_aws_sns_topic` and `duplocloud_aws_sqs_queue`. The shared resource-prefix helper resolves the tenant name through an admin-only endpoint, while the sibling name helper used by most other resources already goes through the user-scoped tenant list.

## Summary of changes

This PR does the following:

- `GetResourcePrefix` resolves the tenant name via `GetTenantForUser` (`admin/GetTenantsForUser`, user-scoped) instead of `TenantGetV3` (`v3/admin/tenant/{id}`, admin-only), matching `GetResourceName`. This covers SNS, SQS and the other resources that share the helper.
- SQS name validation, ECS task definition (resource and data source) and S3 replication resolve the tenant name the same way instead of via `v2/admin/TenantV2/{id}`, which is also admin-only.
- Unit tests for `GetResourcePrefix` asserting the user-scoped endpoint is used and that a tenant the user cannot see surfaces as 404.

## Testing performed

- [x] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
