### PR TITLE
DUPLO-44385: Wire trusted_key_groups through cloudfront cache behaviors

### DIFF
--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -2362,13 +2362,34 @@ func preserveUnmanagedTrustedKeyGroups(d *schema.ResourceData, existingCfd, upda
 		return
 	}
 	updatedItems := *updatedCfd.CacheBehaviors.Items
-	existingItems := *existingCfd.CacheBehaviors.Items
+	configured := make([]bool, len(updatedItems))
 	for i := range updatedItems {
-		if i >= len(existingItems) {
-			continue // newly added behavior, nothing existing to preserve
+		configured[i] = cacheBehaviorConfiguresTrustedKeyGroups(raw, "ordered_cache_behavior", i)
+	}
+	mergeUnmanagedTrustedKeyGroups(updatedItems, *existingCfd.CacheBehaviors.Items, configured)
+}
+
+// mergeUnmanagedTrustedKeyGroups copies TrustedKeyGroups from existingItems onto
+// updatedItems in place, for any index whose configured flag is false.
+//
+// ordered_cache_behavior is a TypeList, so inserting, removing, or reordering a
+// behavior shifts indices - matching updatedItems[i] to existingItems[i] would
+// preserve the wrong behavior's TrustedKeyGroups onto the wrong path. PathPattern is
+// required and AWS treats it as the unique identity of a cache behavior, so we match
+// on that instead. An updated item whose PathPattern has no existing match (a
+// genuinely new behavior) is left as expand computed it.
+func mergeUnmanagedTrustedKeyGroups(updatedItems, existingItems []duplosdk.DuploAwsCloudfrontCacheBehavior, configured []bool) {
+	existingByPath := make(map[string]*duplosdk.DuploAwsCloudfrontCacheBehavior, len(existingItems))
+	for i := range existingItems {
+		existingByPath[existingItems[i].PathPattern] = &existingItems[i]
+	}
+
+	for i := range updatedItems {
+		if i < len(configured) && configured[i] {
+			continue
 		}
-		if !cacheBehaviorConfiguresTrustedKeyGroups(raw, "ordered_cache_behavior", i) {
-			updatedItems[i].TrustedKeyGroups = existingItems[i].TrustedKeyGroups
+		if existing, ok := existingByPath[updatedItems[i].PathPattern]; ok {
+			updatedItems[i].TrustedKeyGroups = existing.TrustedKeyGroups
 		}
 	}
 }

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -2394,20 +2394,37 @@ func mergeUnmanagedTrustedKeyGroups(updatedItems, existingItems []duplosdk.Duplo
 	}
 }
 
-// cacheBehaviorConfiguresTrustedKeyGroups reports whether trusted_key_groups is actually
-// present in the raw config for the cache behavior at blockName[index], as opposed to
-// merely present in d.Get() via a carried-forward Computed value.
+// cacheBehaviorConfiguresTrustedKeyGroups reports whether trusted_key_groups should be
+// treated as managed by config for the cache behavior at blockName[index], as opposed to
+// genuinely absent (which lets the caller preserve whatever is already on the backend).
+//
+// An unknown block/attribute (e.g. trusted_key_groups derived from another resource's
+// attribute that isn't resolved yet) is treated as managed, not absent: GetRawConfig
+// reflects what Terraform sent for this apply, and while a fully-resolved apply should
+// have no unknowns left, treating "we can't tell yet" as "absent" would let the caller
+// clobber a real, pending config value with stale existing data - the same class of bug
+// this whole preserve mechanism exists to prevent. Only a known null (the attribute is
+// truly absent from config) counts as absent.
 func cacheBehaviorConfiguresTrustedKeyGroups(raw cty.Value, blockName string, index int) bool {
 	block := raw.GetAttr(blockName)
-	if block.IsNull() || !block.IsKnown() || block.LengthInt() <= index {
+	if block.IsNull() {
+		return false
+	}
+	if !block.IsKnown() {
+		return true
+	}
+	if block.LengthInt() <= index {
 		return false
 	}
 	behavior := block.Index(cty.NumberIntVal(int64(index)))
-	if !behavior.IsKnown() || behavior.IsNull() {
+	if behavior.IsNull() {
 		return false
 	}
+	if !behavior.IsKnown() {
+		return true
+	}
 	trustedKeyGroups := behavior.GetAttr("trusted_key_groups")
-	return trustedKeyGroups.IsKnown() && !trustedKeyGroups.IsNull()
+	return !trustedKeyGroups.IsKnown() || !trustedKeyGroups.IsNull()
 }
 
 func validateCloudDistributionParameters(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -1167,7 +1167,11 @@ func expandAwsCloudfrontDistributionDefaultCacheBehavior(m map[string]interface{
 
 	}
 
-	// TODO Handle "trusted_key_groups"
+	if v, ok := m["trusted_key_groups"]; ok {
+		dcb.TrustedKeyGroups = expandTrustedKeyGroups(v.([]interface{}))
+	} else {
+		dcb.TrustedKeyGroups = expandTrustedKeyGroups([]interface{}{})
+	}
 
 	if v, ok := m["trusted_signers"]; ok {
 		dcb.TrustedSigners = expandTrustedSigners(v.([]interface{}))
@@ -1235,7 +1239,11 @@ func expandAwsCloudfrontDistributionCacheBehavior(m map[string]interface{}) dupl
 		}
 	}
 
-	// TODO Handle "trusted_key_groups"
+	if v, ok := m["trusted_key_groups"]; ok {
+		cb.TrustedKeyGroups = expandTrustedKeyGroups(v.([]interface{}))
+	} else {
+		cb.TrustedKeyGroups = expandTrustedKeyGroups([]interface{}{})
+	}
 
 	if v, ok := m["trusted_signers"]; ok {
 		cb.TrustedSigners = expandTrustedSigners(v.([]interface{}))
@@ -1335,6 +1343,19 @@ func expandQueryStringCacheKeys(d []interface{}) *duplosdk.DuploCFDStringItems {
 		Quantity: len(d),
 		Items:    expandStringList(d),
 	}
+}
+
+func expandTrustedKeyGroups(s []interface{}) *duplosdk.DuploCFDTrustedKeyGroups {
+	var tkg duplosdk.DuploCFDTrustedKeyGroups
+	if len(s) > 0 {
+		tkg.Quantity = len(s)
+		tkg.Items = expandStringList(s)
+		tkg.Enabled = true
+	} else {
+		tkg.Quantity = 0
+		tkg.Enabled = false
+	}
+	return &tkg
 }
 
 func expandTrustedSigners(s []interface{}) *duplosdk.DuploCFDTrustedSigners {
@@ -1805,6 +1826,9 @@ func flattenCloudFrontDefaultCacheBehavior(dcb *duplosdk.DuploAwsCloudfrontDefau
 	if len(dcb.TrustedSigners.Items) > 0 {
 		m["trusted_signers"] = flattenTrustedSigners(dcb.TrustedSigners)
 	}
+	if dcb.TrustedKeyGroups != nil && len(dcb.TrustedKeyGroups.Items) > 0 {
+		m["trusted_key_groups"] = flattenTrustedKeyGroups(dcb.TrustedKeyGroups)
+	}
 	if dcb.AllowedMethods != nil {
 		m["allowed_methods"] = flattenAllowedMethods(dcb.AllowedMethods)
 	}
@@ -1871,6 +1895,13 @@ func flattenCookieNames(cn *duplosdk.DuploCFDStringItems) []interface{} {
 func flattenTrustedSigners(ts *duplosdk.DuploCFDTrustedSigners) []interface{} {
 	if ts.Items != nil {
 		return flattenStringList(ts.Items)
+	}
+	return []interface{}{}
+}
+
+func flattenTrustedKeyGroups(tkg *duplosdk.DuploCFDTrustedKeyGroups) []interface{} {
+	if tkg.Items != nil {
+		return flattenStringList(tkg.Items)
 	}
 	return []interface{}{}
 }
@@ -1958,6 +1989,9 @@ func flattenCacheBehavior(cb duplosdk.DuploAwsCloudfrontCacheBehavior) map[strin
 
 	if len(cb.TrustedSigners.Items) > 0 {
 		m["trusted_signers"] = flattenTrustedSigners(cb.TrustedSigners)
+	}
+	if cb.TrustedKeyGroups != nil && len(cb.TrustedKeyGroups.Items) > 0 {
+		m["trusted_key_groups"] = flattenTrustedKeyGroups(cb.TrustedKeyGroups)
 	}
 	if cb.AllowedMethods != nil {
 		m["allowed_methods"] = flattenAllowedMethods(cb.AllowedMethods)

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -1347,9 +1347,10 @@ func expandQueryStringCacheKeys(d []interface{}) *duplosdk.DuploCFDStringItems {
 
 func expandTrustedKeyGroups(s []interface{}) *duplosdk.DuploCFDTrustedKeyGroups {
 	var tkg duplosdk.DuploCFDTrustedKeyGroups
-	if len(s) > 0 {
-		tkg.Quantity = len(s)
-		tkg.Items = expandStringList(s)
+	items := expandStringList(s)
+	if len(items) > 0 {
+		tkg.Quantity = len(items)
+		tkg.Items = items
 		tkg.Enabled = true
 	} else {
 		tkg.Quantity = 0

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -2353,7 +2353,8 @@ func preserveUnmanagedTrustedKeyGroups(d *schema.ResourceData, existingCfd, upda
 		return
 	}
 
-	if !cacheBehaviorConfiguresTrustedKeyGroups(raw, "default_cache_behavior", 0) {
+	if !cacheBehaviorConfiguresTrustedKeyGroups(raw, "default_cache_behavior", 0) &&
+		!trustedSignersEnabled(updatedCfd.DefaultCacheBehavior.TrustedSigners) {
 		updatedCfd.DefaultCacheBehavior.TrustedKeyGroups = existingCfd.DefaultCacheBehavior.TrustedKeyGroups
 	}
 
@@ -2369,8 +2370,19 @@ func preserveUnmanagedTrustedKeyGroups(d *schema.ResourceData, existingCfd, upda
 	mergeUnmanagedTrustedKeyGroups(updatedItems, *existingCfd.CacheBehaviors.Items, configured)
 }
 
+// trustedSignersEnabled reports whether a cache behavior's TrustedSigners actively
+// restricts access. CloudFront treats trusted signers and trusted key groups as
+// mutually exclusive on a single behavior - it rejects a request enabling both - so a
+// behavior that's actively using trusted_signers must never have an existing
+// TrustedKeyGroups preserved onto it too.
+func trustedSignersEnabled(ts *duplosdk.DuploCFDTrustedSigners) bool {
+	return ts != nil && ts.Enabled
+}
+
 // mergeUnmanagedTrustedKeyGroups copies TrustedKeyGroups from existingItems onto
-// updatedItems in place, for any index whose configured flag is false.
+// updatedItems in place, for any index whose configured flag is false and whose
+// updated behavior isn't actively using trusted_signers instead (see
+// trustedSignersEnabled).
 //
 // ordered_cache_behavior is a TypeList, so inserting, removing, or reordering a
 // behavior shifts indices - matching updatedItems[i] to existingItems[i] would
@@ -2386,6 +2398,9 @@ func mergeUnmanagedTrustedKeyGroups(updatedItems, existingItems []duplosdk.Duplo
 
 	for i := range updatedItems {
 		if i < len(configured) && configured[i] {
+			continue
+		}
+		if trustedSignersEnabled(updatedItems[i].TrustedSigners) {
 			continue
 		}
 		if existing, ok := existingByPath[updatedItems[i].PathPattern]; ok {

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
 
+	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -993,6 +994,7 @@ func resourceAwsCloudfrontDistributionUpdate(ctx context.Context, d *schema.Reso
 	rq := expandAwsCloudfrontDistributionConfig(d, true)
 	// Update OAI which is generated at backend
 	updateS3OAI(duplo.Distribution.DistributionConfig, rq)
+	preserveUnmanagedTrustedKeyGroups(d, duplo.Distribution.DistributionConfig, rq)
 
 	resp, err := c.AwsCloudfrontDistributionUpdate(tenantID, &duplosdk.DuploAwsCloudfrontDistributionCreate{
 		Id:                   cfdId,
@@ -2330,6 +2332,61 @@ func updateS3OAI(existingCfd, updatedCfd *duplosdk.DuploAwsCloudfrontDistributio
 			}
 		}
 	}
+}
+
+// preserveUnmanagedTrustedKeyGroups keeps a cache behavior's TrustedKeyGroups from being
+// clobbered on update when the corresponding config block doesn't manage that attribute.
+//
+// trusted_key_groups is Optional+Computed so this provider can read back and store key
+// groups attached outside Terraform without fighting a permanent diff. But expand always
+// returns a non-nil TrustedKeyGroups (needed so an explicit trusted_key_groups = [] can
+// disable it), and the backend's distribution-config merge only preserves fields it
+// receives as nil - so without this, an update to any unrelated attribute would silently
+// disable trust enforcement whenever a behavior's trusted_key_groups isn't managed here.
+//
+// We check GetRawConfig (not d.Get) because Optional+Computed lets a stale/computed state
+// value leak into d.Get even when the attribute is genuinely absent from config -
+// GetRawConfig is the only way to see whether the user actually wrote it.
+func preserveUnmanagedTrustedKeyGroups(d *schema.ResourceData, existingCfd, updatedCfd *duplosdk.DuploAwsCloudfrontDistributionConfig) {
+	raw := d.GetRawConfig()
+	if raw.IsNull() || !raw.IsKnown() {
+		return
+	}
+
+	if !cacheBehaviorConfiguresTrustedKeyGroups(raw, "default_cache_behavior", 0) {
+		updatedCfd.DefaultCacheBehavior.TrustedKeyGroups = existingCfd.DefaultCacheBehavior.TrustedKeyGroups
+	}
+
+	if updatedCfd.CacheBehaviors == nil || updatedCfd.CacheBehaviors.Items == nil ||
+		existingCfd.CacheBehaviors == nil || existingCfd.CacheBehaviors.Items == nil {
+		return
+	}
+	updatedItems := *updatedCfd.CacheBehaviors.Items
+	existingItems := *existingCfd.CacheBehaviors.Items
+	for i := range updatedItems {
+		if i >= len(existingItems) {
+			continue // newly added behavior, nothing existing to preserve
+		}
+		if !cacheBehaviorConfiguresTrustedKeyGroups(raw, "ordered_cache_behavior", i) {
+			updatedItems[i].TrustedKeyGroups = existingItems[i].TrustedKeyGroups
+		}
+	}
+}
+
+// cacheBehaviorConfiguresTrustedKeyGroups reports whether trusted_key_groups is actually
+// present in the raw config for the cache behavior at blockName[index], as opposed to
+// merely present in d.Get() via a carried-forward Computed value.
+func cacheBehaviorConfiguresTrustedKeyGroups(raw cty.Value, blockName string, index int) bool {
+	block := raw.GetAttr(blockName)
+	if block.IsNull() || !block.IsKnown() || block.LengthInt() <= index {
+		return false
+	}
+	behavior := block.Index(cty.NumberIntVal(int64(index)))
+	if !behavior.IsKnown() || behavior.IsNull() {
+		return false
+	}
+	trustedKeyGroups := behavior.GetAttr("trusted_key_groups")
+	return trustedKeyGroups.IsKnown() && !trustedKeyGroups.IsNull()
 }
 
 func validateCloudDistributionParameters(ctx context.Context, d *schema.ResourceDiff, m interface{}) error {

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
+	"github.com/hashicorp/go-cty/cty"
 )
 
 func Test_expandTrustedKeyGroups(t *testing.T) {
@@ -86,6 +87,73 @@ func Test_flattenTrustedKeyGroups(t *testing.T) {
 			actual := flattenTrustedKeyGroups(c.given)
 			if !reflect.DeepEqual(actual, c.expected) {
 				t.Errorf("expected %+v, got %+v", c.expected, actual)
+			}
+		})
+	}
+}
+
+func Test_cacheBehaviorConfiguresTrustedKeyGroups(t *testing.T) {
+	behaviorWithValues := cty.ObjectVal(map[string]cty.Value{
+		"trusted_key_groups": cty.ListVal([]cty.Value{cty.StringVal("kg-1")}),
+	})
+	behaviorWithEmptyList := cty.ObjectVal(map[string]cty.Value{
+		"trusted_key_groups": cty.ListValEmpty(cty.String),
+	})
+	behaviorWithoutAttr := cty.ObjectVal(map[string]cty.Value{
+		"trusted_key_groups": cty.NullVal(cty.List(cty.String)),
+	})
+	behaviorObjType := cty.Object(map[string]cty.Type{"trusted_key_groups": cty.List(cty.String)})
+
+	cases := []struct {
+		name     string
+		block    cty.Value
+		index    int
+		expected bool
+	}{
+		{
+			name:     "explicit values present",
+			block:    cty.ListVal([]cty.Value{behaviorWithValues}),
+			index:    0,
+			expected: true,
+		},
+		{
+			name:     "explicit empty list is still configured",
+			block:    cty.ListVal([]cty.Value{behaviorWithEmptyList}),
+			index:    0,
+			expected: true,
+		},
+		{
+			name:     "attribute omitted from config",
+			block:    cty.ListVal([]cty.Value{behaviorWithoutAttr}),
+			index:    0,
+			expected: false,
+		},
+		{
+			name:     "block itself absent",
+			block:    cty.NullVal(cty.List(behaviorObjType)),
+			index:    0,
+			expected: false,
+		},
+		{
+			name:     "index out of range",
+			block:    cty.ListVal([]cty.Value{behaviorWithValues}),
+			index:    1,
+			expected: false,
+		},
+		{
+			name:     "empty block list",
+			block:    cty.ListValEmpty(behaviorObjType),
+			index:    0,
+			expected: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			raw := cty.ObjectVal(map[string]cty.Value{"default_cache_behavior": c.block})
+			actual := cacheBehaviorConfiguresTrustedKeyGroups(raw, "default_cache_behavior", c.index)
+			if actual != c.expected {
+				t.Errorf("expected %v, got %v", c.expected, actual)
 			}
 		})
 	}

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
@@ -1,0 +1,75 @@
+package duplocloud
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
+)
+
+func Test_expandTrustedKeyGroups(t *testing.T) {
+	cases := []struct {
+		name     string
+		given    []interface{}
+		expected *duplosdk.DuploCFDTrustedKeyGroups
+	}{
+		{
+			name:  "empty list disables trusted key groups",
+			given: []interface{}{},
+			expected: &duplosdk.DuploCFDTrustedKeyGroups{
+				Enabled:  false,
+				Quantity: 0,
+			},
+		},
+		{
+			name:  "non-empty list enables trusted key groups",
+			given: []interface{}{"key-group-1", "key-group-2"},
+			expected: &duplosdk.DuploCFDTrustedKeyGroups{
+				Enabled:  true,
+				Quantity: 2,
+				Items:    []string{"key-group-1", "key-group-2"},
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := expandTrustedKeyGroups(c.given)
+			if !reflect.DeepEqual(actual, c.expected) {
+				t.Errorf("expected %+v, got %+v", c.expected, actual)
+			}
+		})
+	}
+}
+
+func Test_flattenTrustedKeyGroups(t *testing.T) {
+	cases := []struct {
+		name     string
+		given    *duplosdk.DuploCFDTrustedKeyGroups
+		expected []interface{}
+	}{
+		{
+			name:     "nil items flattens to empty list",
+			given:    &duplosdk.DuploCFDTrustedKeyGroups{Enabled: false, Quantity: 0},
+			expected: []interface{}{},
+		},
+		{
+			name: "items flatten to string list",
+			given: &duplosdk.DuploCFDTrustedKeyGroups{
+				Enabled:  true,
+				Quantity: 2,
+				Items:    []string{"key-group-1", "key-group-2"},
+			},
+			expected: []interface{}{"key-group-1", "key-group-2"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			actual := flattenTrustedKeyGroups(c.given)
+			if !reflect.DeepEqual(actual, c.expected) {
+				t.Errorf("expected %+v, got %+v", c.expected, actual)
+			}
+		})
+	}
+}

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
@@ -244,4 +244,48 @@ func Test_mergeUnmanagedTrustedKeyGroups(t *testing.T) {
 			t.Errorf("expected explicitly configured value to be kept, got %+v", updated[0].TrustedKeyGroups)
 		}
 	})
+
+	t.Run("a behavior actively using trusted_signers never gets an existing key group preserved onto it", func(t *testing.T) {
+		// Before: "/a/*" was restricted via trusted key groups.
+		existing := []duplosdk.DuploAwsCloudfrontCacheBehavior{
+			{PathPattern: "/a/*", TrustedKeyGroups: protectedTKG},
+		}
+		// After: the user switched "/a/*" to trusted_signers. trusted_key_groups
+		// isn't configured (configured=false), so without the trusted_signers guard
+		// this would incorrectly preserve the old key groups alongside the new
+		// signers - CloudFront rejects having both enabled on one behavior.
+		updated := []duplosdk.DuploAwsCloudfrontCacheBehavior{
+			{
+				PathPattern:      "/a/*",
+				TrustedKeyGroups: &duplosdk.DuploCFDTrustedKeyGroups{Enabled: false},
+				TrustedSigners:   &duplosdk.DuploCFDTrustedSigners{Enabled: true, Quantity: 1, Items: []string{"111122223333"}},
+			},
+		}
+
+		mergeUnmanagedTrustedKeyGroups(updated, existing, []bool{false})
+
+		if updated[0].TrustedKeyGroups.Enabled {
+			t.Errorf("expected trusted key groups to stay disabled while trusted_signers is active, got %+v", updated[0].TrustedKeyGroups)
+		}
+	})
+}
+
+func Test_trustedSignersEnabled(t *testing.T) {
+	cases := []struct {
+		name     string
+		ts       *duplosdk.DuploCFDTrustedSigners
+		expected bool
+	}{
+		{name: "nil", ts: nil, expected: false},
+		{name: "disabled", ts: &duplosdk.DuploCFDTrustedSigners{Enabled: false}, expected: false},
+		{name: "enabled", ts: &duplosdk.DuploCFDTrustedSigners{Enabled: true, Quantity: 1, Items: []string{"111122223333"}}, expected: true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if actual := trustedSignersEnabled(c.ts); actual != c.expected {
+				t.Errorf("expected %v, got %v", c.expected, actual)
+			}
+		})
+	}
 }

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
@@ -158,3 +158,66 @@ func Test_cacheBehaviorConfiguresTrustedKeyGroups(t *testing.T) {
 		})
 	}
 }
+
+func Test_mergeUnmanagedTrustedKeyGroups(t *testing.T) {
+	protectedTKG := &duplosdk.DuploCFDTrustedKeyGroups{Enabled: true, Quantity: 1, Items: []string{"kg-protected"}}
+
+	t.Run("a new behavior inserted at index 0 does not inherit the old index-0 behavior's key groups", func(t *testing.T) {
+		// Before: only "/protected/*" existed, with trusted key groups.
+		existing := []duplosdk.DuploAwsCloudfrontCacheBehavior{
+			{PathPattern: "/protected/*", TrustedKeyGroups: protectedTKG},
+		}
+		// After: user inserts "/public/*" ahead of it. Neither behavior manages
+		// trusted_key_groups in config (configured is all false).
+		updated := []duplosdk.DuploAwsCloudfrontCacheBehavior{
+			{PathPattern: "/public/*", TrustedKeyGroups: &duplosdk.DuploCFDTrustedKeyGroups{Enabled: false}},
+			{PathPattern: "/protected/*", TrustedKeyGroups: &duplosdk.DuploCFDTrustedKeyGroups{Enabled: false}},
+		}
+
+		mergeUnmanagedTrustedKeyGroups(updated, existing, []bool{false, false})
+
+		if updated[0].TrustedKeyGroups.Enabled {
+			t.Errorf("expected /public/* to remain disabled, got %+v", updated[0].TrustedKeyGroups)
+		}
+		if !reflect.DeepEqual(updated[1].TrustedKeyGroups, protectedTKG) {
+			t.Errorf("expected /protected/* to keep its existing key groups, got %+v", updated[1].TrustedKeyGroups)
+		}
+	})
+
+	t.Run("reordering behaviors still preserves by path, not position", func(t *testing.T) {
+		existing := []duplosdk.DuploAwsCloudfrontCacheBehavior{
+			{PathPattern: "/a/*", TrustedKeyGroups: &duplosdk.DuploCFDTrustedKeyGroups{Enabled: false}},
+			{PathPattern: "/b/*", TrustedKeyGroups: protectedTKG},
+		}
+		// Reordered: /b/* is now first.
+		updated := []duplosdk.DuploAwsCloudfrontCacheBehavior{
+			{PathPattern: "/b/*", TrustedKeyGroups: &duplosdk.DuploCFDTrustedKeyGroups{Enabled: false}},
+			{PathPattern: "/a/*", TrustedKeyGroups: &duplosdk.DuploCFDTrustedKeyGroups{Enabled: false}},
+		}
+
+		mergeUnmanagedTrustedKeyGroups(updated, existing, []bool{false, false})
+
+		if !reflect.DeepEqual(updated[0].TrustedKeyGroups, protectedTKG) {
+			t.Errorf("expected /b/* to keep its key groups after reorder, got %+v", updated[0].TrustedKeyGroups)
+		}
+		if updated[1].TrustedKeyGroups.Enabled {
+			t.Errorf("expected /a/* to remain disabled, got %+v", updated[1].TrustedKeyGroups)
+		}
+	})
+
+	t.Run("an explicitly configured behavior is never overwritten", func(t *testing.T) {
+		existing := []duplosdk.DuploAwsCloudfrontCacheBehavior{
+			{PathPattern: "/a/*", TrustedKeyGroups: protectedTKG},
+		}
+		explicit := &duplosdk.DuploCFDTrustedKeyGroups{Enabled: true, Quantity: 1, Items: []string{"kg-explicit"}}
+		updated := []duplosdk.DuploAwsCloudfrontCacheBehavior{
+			{PathPattern: "/a/*", TrustedKeyGroups: explicit},
+		}
+
+		mergeUnmanagedTrustedKeyGroups(updated, existing, []bool{true})
+
+		if !reflect.DeepEqual(updated[0].TrustedKeyGroups, explicit) {
+			t.Errorf("expected explicitly configured value to be kept, got %+v", updated[0].TrustedKeyGroups)
+		}
+	})
+}

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
@@ -30,6 +30,23 @@ func Test_expandTrustedKeyGroups(t *testing.T) {
 				Items:    []string{"key-group-1", "key-group-2"},
 			},
 		},
+		{
+			name:  "quantity matches filtered items when list contains empty strings",
+			given: []interface{}{"key-group-1", "", "key-group-2"},
+			expected: &duplosdk.DuploCFDTrustedKeyGroups{
+				Enabled:  true,
+				Quantity: 2,
+				Items:    []string{"key-group-1", "key-group-2"},
+			},
+		},
+		{
+			name:  "list of only empty strings disables trusted key groups",
+			given: []interface{}{""},
+			expected: &duplosdk.DuploCFDTrustedKeyGroups{
+				Enabled:  false,
+				Quantity: 0,
+			},
+		},
 	}
 
 	for _, c := range cases {

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution_test.go
@@ -103,6 +103,9 @@ func Test_cacheBehaviorConfiguresTrustedKeyGroups(t *testing.T) {
 		"trusted_key_groups": cty.NullVal(cty.List(cty.String)),
 	})
 	behaviorObjType := cty.Object(map[string]cty.Type{"trusted_key_groups": cty.List(cty.String)})
+	behaviorWithUnknownAttr := cty.ObjectVal(map[string]cty.Value{
+		"trusted_key_groups": cty.UnknownVal(cty.List(cty.String)),
+	})
 
 	cases := []struct {
 		name     string
@@ -145,6 +148,27 @@ func Test_cacheBehaviorConfiguresTrustedKeyGroups(t *testing.T) {
 			block:    cty.ListValEmpty(behaviorObjType),
 			index:    0,
 			expected: false,
+		},
+		{
+			// e.g. trusted_key_groups = [some_resource.x.id] where some_resource.x
+			// hasn't resolved yet - must be treated as managed, not absent, or the
+			// caller would clobber the pending value with stale existing data.
+			name:     "attribute value itself is unknown",
+			block:    cty.ListVal([]cty.Value{behaviorWithUnknownAttr}),
+			index:    0,
+			expected: true,
+		},
+		{
+			name:     "behavior object itself is unknown",
+			block:    cty.ListVal([]cty.Value{cty.UnknownVal(behaviorObjType)}),
+			index:    0,
+			expected: true,
+		},
+		{
+			name:     "block itself is unknown",
+			block:    cty.UnknownVal(cty.List(behaviorObjType)),
+			index:    0,
+			expected: true,
 		},
 	}
 

--- a/duplocloud/resource_duplo_aws_cloudfront_distribution_v2.go
+++ b/duplocloud/resource_duplo_aws_cloudfront_distribution_v2.go
@@ -976,6 +976,7 @@ func resourceAwsCloudfrontDistributionV2Update(ctx context.Context, d *schema.Re
 	rq.Comment = d.Get("fullname").(string)
 	// Preserve OAI and OAC from existing config, as these are managed by the backend
 	updateS3OAI(duplo.Distribution.DistributionConfig, rq)
+	preserveUnmanagedTrustedKeyGroups(d, duplo.Distribution.DistributionConfig, rq)
 	resp, err := c.AwsCloudfrontDistributionUpdateV2(tenantID, &duplosdk.DuploAwsCloudfrontDistributionCreateV2{
 		Id:                   cfdId,
 		DistributionConfig:   rq,

--- a/duplosdk/aws_cloudfront_distribution.go
+++ b/duplosdk/aws_cloudfront_distribution.go
@@ -21,6 +21,7 @@ type DuploAwsCloudfrontDefaultCacheBehavior struct {
 	SmoothStreaming            bool                                          `json:"SmoothStreaming"`
 	TargetOriginId             string                                        `json:"TargetOriginId,omitempty"`
 	TrustedSigners             *DuploCFDTrustedSigners                       `json:"TrustedSigners,omitempty"`
+	TrustedKeyGroups           *DuploCFDTrustedKeyGroups                     `json:"TrustedKeyGroups,omitempty"`
 	ViewerProtocolPolicy       *DuploStringValue                             `json:"ViewerProtocolPolicy,omitempty"`
 	ForwardedValues            *DuploCFDForwardedValues                      `json:"ForwardedValues,omitempty"`
 	ResponseHeadersPolicyId    string                                        `json:"ResponseHeadersPolicyId,omitempty"`
@@ -41,6 +42,7 @@ type DuploAwsCloudfrontCacheBehavior struct {
 	SmoothStreaming            bool                                          `json:"SmoothStreaming"`
 	TargetOriginId             string                                        `json:"TargetOriginId"`
 	TrustedSigners             *DuploCFDTrustedSigners                       `json:"TrustedSigners,omitempty"`
+	TrustedKeyGroups           *DuploCFDTrustedKeyGroups                     `json:"TrustedKeyGroups,omitempty"`
 	ViewerProtocolPolicy       *DuploStringValue                             `json:"ViewerProtocolPolicy,omitempty"`
 	ForwardedValues            *DuploCFDForwardedValues                      `json:"ForwardedValues,omitempty"`
 	PathPattern                string                                        `json:"PathPattern"`
@@ -97,6 +99,12 @@ type DuploCFDForwardedValues struct {
 }
 
 type DuploCFDTrustedSigners struct {
+	Enabled  bool     `json:"Enabled"`
+	Items    []string `json:"Items"`
+	Quantity int      `json:"Quantity"`
+}
+
+type DuploCFDTrustedKeyGroups struct {
 	Enabled  bool     `json:"Enabled"`
 	Items    []string `json:"Items"`
 	Quantity int      `json:"Quantity"`


### PR DESCRIPTION
## ClickUp Ticket

trusted_key_groups was already exposed in the schema for both duplocloud_aws_cloudfront_distribution and _v2, but the expand code had a TODO and silently dropped it, so distributions never actually got signed-URL key group restrictions applied. Mirrors the existing trusted_signers expand/flatten pattern.

**ClickUp Ticket ID:** DUPLO-44385

## Overview

## Summary of changes

This PR does the following:

- Wires up terraform configuration "trusted_key_groups" onto the outbound API DTO for distribution configuration (which already supports it)
- Preserves an existing distribution's trusted_key_groups on update when a cache behavior doesn't explicitly manage that attribute in config, instead of forcing it to disabled — applies to both duplocloud_aws_cloudfront_distribution and _v2. Explicitly set trusted_key_groups = [] to disable it.

## Testing performed

- [x] Using unit tests
- [ ] Manually, on my local system
- [x] Manually, on a remote test system

## Describe any breaking changes

trusted_key_groups was previously accepted in the schema but silently dropped — never sent to the backend. Any existing config that already sets it will start being enforced for real after upgrading, which may require signed URLs on a distribution that previously served unrestricted. If you have trusted_key_groups in your config today, verify that's intentional before applying this version. QA recommended.

## Sanity Checking

Runing apply on
```
# ============================================================
# DUPLO-44385: trusted_key_groups manual verification
# Scratch resource, safe to remove once evidence is captured.
# ============================================================
data "duplocloud_tenant" "duplo_44385_test" {
  name = "default"
}

resource "duplocloud_aws_cloudfront_distribution_v2" "duplo_44385_trusted_key_groups_test" {
  tenant_id           = data.duplocloud_tenant.duplo_44385_test.id
  name                = "duplo-44385-tkg-test"
  enabled             = true
  wait_for_deployment = false

  use_origin_access_control = false

  origin {
    domain_name = "my-cf-origin-fdsafdsa.s3.us-east-1.amazonaws.com"
    origin_id   = "duplo-44385-origin"
  }

  default_cache_behavior {
    target_origin_id       = "duplo-44385-origin"
    viewer_protocol_policy = "redirect-to-https"
    allowed_methods        = ["GET", "HEAD"]
    cached_methods         = ["GET", "HEAD"]
    min_ttl                = 0
    default_ttl            = 3600
    max_ttl                = 86400

    forwarded_values {
      query_string = false
      cookies {
        forward = "none"
      }
    }

    trusted_key_groups = ["bc0bef25-8e88-4a63-9f99-f35120539e16"]
  }

  viewer_certificate {
    cloudfront_default_certificate = true
  }
}
```

<img width="1512" height="547" alt="image" src="https://github.com/user-attachments/assets/13f09423-01ca-47df-98c0-defb2684a86d" />
<img width="1512" height="400" alt="image" src="https://github.com/user-attachments/assets/5743c5d5-2f31-4caa-90b5-5162ecc2e4ce" />
<img width="1512" height="498" alt="image" src="https://github.com/user-attachments/assets/4db2b3fb-cd79-4921-ba75-e41105486180" />

```
{
    "Distribution": {
        "ActiveTrustedKeyGroups": {
            "Enabled": true,
            "Items": [
                {
                    "KeyGroupId": "bc0bef25-8e88-4a63-9f99-f35120539e16",
                    "KeyPairIds": {
                        "Items": [
                            "K19MQLGOUORRAT"
                        ],
                        "Quantity": 1
                    }
                }
            ],
            "Quantity": 1
        },
        "ActiveTrustedSigners": {
            "Enabled": false,
            "Items": [],
            "Quantity": 0
        },
        "AliasICPRecordals": [],
        "ARN": "arn:aws:cloudfront::229652554724:distribution/E3FDYVT22KOMT0",
        "DistributionConfig": {
            "CacheBehaviors": {
                "Items": [],
                "Quantity": 0
            },
            "CallerReference": "a69a3052-f11a-450c-85ba-b86decc71cbe",
            "Comment": "duploservices-default-duplo-44385-tkg-test",
            "DefaultCacheBehavior": {
                ...
                "TargetOriginId": "duplo-44385-origin",
                "TrustedKeyGroups": {
                    "Enabled": true,
                    "Items": [
                        "bc0bef25-8e88-4a63-9f99-f35120539e16"
                    ],
                    "Quantity": 1
                },
                "TrustedSigners": {
                    "Enabled": false,
                    "Items": [],
                    "Quantity": 0
                },
                "ViewerProtocolPolicy": {
                    "Value": "redirect-to-https"
                }
            },
            "Origins": {
                "Items": [
                    {
                        "ConnectionAttempts": 3,
                        "ConnectionTimeout": 10,
                        "CustomHeaders": {
                            "Items": [],
                            "Quantity": 0
                        },
                        "DomainName": "my-cf-origin-fdsafdsa.s3.us-east-1.amazonaws.com",
                        "Id": "duplo-44385-origin",
                        "OriginAccessControlId": "",
                        "OriginPath": "",
                        "OriginShield": {
                            "Enabled": false
                        },
                        "S3OriginConfig": {
                            "OriginAccessIdentity": ""
                        }
                    }
                ],
                "Quantity": 1
            },
            "WebACLId": "",
             ...
        },
        "DomainName": "dg08azu55kgjh.cloudfront.net",
        "Id": "E3FDYVT22KOMT0",
        "InProgressInvalidationBatches": 0,
        "LastModifiedTime": "2026-09-11T14:36:19.657+00:00",
        "Status": "Deployed"
    },
    ...
}
```