### PR TITLE
DUPLO-44491 TF: ecache replica count change silently lost when combined with multi-az/failover

### DIFF
--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -730,6 +730,13 @@ func ecacheInstanceWaitUntilAvailable(ctx context.Context, c *duplosdk.Client, t
 			if err != nil {
 				return 0, "", err
 			}
+
+			// EcacheInstanceGet reports an instance it cannot find as (nil, nil). Hold the
+			// wait in a pending state rather than dereferencing it - a read that comes back
+			// empty should not end the wait, and must not panic the provider.
+			if resp == nil {
+				return &duplosdk.DuploEcacheInstance{}, "processing", nil
+			}
 			if resp.InstanceStatus == "" {
 				resp.InstanceStatus = "processing"
 			}
@@ -757,6 +764,13 @@ func ecacheInstanceWaitUntilUnavailable(ctx context.Context, c *duplosdk.Client,
 			resp, err := c.EcacheInstanceGet(tenantID, name)
 			if err != nil {
 				return 0, "", err
+			}
+
+			// EcacheInstanceGet reports an instance it cannot find as (nil, nil). Hold the
+			// wait in its pending state rather than dereferencing it, so an empty read is
+			// treated as "has not transitioned yet" instead of panicking the provider.
+			if resp == nil {
+				return &duplosdk.DuploEcacheInstance{}, "available", nil
 			}
 			if resp.InstanceStatus == "" {
 				resp.InstanceStatus = "processing"

--- a/duplocloud/resource_duplo_ecache_instance.go
+++ b/duplocloud/resource_duplo_ecache_instance.go
@@ -9,6 +9,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
@@ -23,6 +24,14 @@ import (
 
 const (
 	TOTALECACHENAMELENGTH = 40
+)
+
+// Bounds for ecacheInstanceWaitUntilSettled. Scaling replicas on a large cache is the slow
+// case; the wait returns as soon as the value lands, so the timeout is only an upper bound.
+// These are variables so that tests can shorten them.
+var (
+	ecacheSettleTimeout      = 30 * time.Minute
+	ecacheSettlePollInterval = 30 * time.Second
 )
 
 func ecacheInstanceSchema() map[string]*schema.Schema {
@@ -760,6 +769,59 @@ func ecacheInstanceWaitUntilUnavailable(ctx context.Context, c *duplosdk.Client,
 	return err
 }
 
+// ecacheInstanceWaitUntilSettled polls an ECache instance until a requested change is
+// actually visible on the instance, and reports the last reading it saw.
+//
+// The update endpoints are fire-and-forget: they return success as soon as the request is
+// accepted, and the two status waits above cannot tell "the change finished" apart from
+// "the change never started" - ecacheInstanceWaitUntilUnavailable discards its error by
+// design, and ecacheInstanceWaitUntilAvailable returns immediately while the instance is
+// still available. Checking the value itself is what stops a dropped request from being
+// reported as a successful apply, and stops a later phase from running against nodes that
+// do not exist yet.
+func ecacheInstanceWaitUntilSettled(ctx context.Context, c *duplosdk.Client, tenantID, name, what string, settled func(*duplosdk.DuploEcacheInstance) bool) (*duplosdk.DuploEcacheInstance, error) {
+	// The refresh goroutine outlives the wait when the context is cancelled, so the last
+	// reading is guarded rather than read straight off the closure.
+	var (
+		mu   sync.Mutex
+		last *duplosdk.DuploEcacheInstance
+	)
+	stateConf := &retry.StateChangeConf{
+		Pending:      []string{"pending"},
+		Target:       []string{"settled"},
+		MinTimeout:   ecacheSettlePollInterval,
+		PollInterval: ecacheSettlePollInterval,
+		Timeout:      ecacheSettleTimeout,
+		Refresh: func() (interface{}, string, error) {
+			resp, err := c.EcacheInstanceGet(tenantID, name)
+			if err != nil {
+				return 0, "", err
+			}
+
+			// EcacheInstanceGet reports an instance it cannot find as (nil, nil), so keep
+			// polling rather than dereferencing it.
+			if resp == nil {
+				return &duplosdk.DuploEcacheInstance{}, "pending", nil
+			}
+			mu.Lock()
+			last = resp
+			mu.Unlock()
+
+			// Only trust the reading once the instance has come to rest - a read taken
+			// mid-modification still carries the previous configuration.
+			if resp.InstanceStatus != "available" || !settled(resp) {
+				return resp, "pending", nil
+			}
+			return resp, "settled", nil
+		},
+	}
+	log.Printf("[DEBUG] ecacheInstanceWaitUntilSettled (%s, %s): waiting for %s", tenantID, name, what)
+	_, err := stateConf.WaitForStateContext(ctx)
+	mu.Lock()
+	defer mu.Unlock()
+	return last, err
+}
+
 func parseECacheInstanceIdParts(id string) (tenantID, name string, err error) {
 	idParts := strings.SplitN(id, "/", 5)
 	if len(idParts) == 5 {
@@ -1216,6 +1278,11 @@ func resourceDuploEcacheInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 				return diag.Errorf("Error waiting for ECache instance '%s' to be available after disabling multi_az: %s", id, err)
 			}
 			time.Sleep(time.Duration(90) * time.Second)
+			if _, werr := ecacheInstanceWaitUntilSettled(ctx, c, tenantID, name, "multi_az_enabled to turn off", func(i *duplosdk.DuploEcacheInstance) bool {
+				return !i.MultiAZEnabled
+			}); werr != nil {
+				return diag.Errorf("Error disabling multi_az_enabled for ECache instance '%s': the request was accepted but multi_az_enabled never turned off: %s", id, werr)
+			}
 		}
 	}
 
@@ -1240,6 +1307,11 @@ func resourceDuploEcacheInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 				return diag.Errorf("Error waiting for ECache instance '%s' to be available after disabling failover: %s", id, err)
 			}
 			time.Sleep(time.Duration(90) * time.Second)
+			if _, werr := ecacheInstanceWaitUntilSettled(ctx, c, tenantID, name, "automatic_failover_enabled to turn off", func(i *duplosdk.DuploEcacheInstance) bool {
+				return !i.AutomaticFailoverEnabled
+			}); werr != nil {
+				return diag.Errorf("Error disabling automatic_failover_enabled for ECache instance '%s': the request was accepted but automatic_failover_enabled never turned off: %s", id, werr)
+			}
 		}
 	}
 
@@ -1260,6 +1332,19 @@ func resourceDuploEcacheInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 			return diag.Errorf("Error waiting for ECache instance '%s' to be available: %s", id, err)
 		}
 		time.Sleep(time.Duration(90) * time.Second)
+
+		// The replica endpoint reports success once the request is accepted, so confirm the
+		// count actually landed before the failover and multi_az phases run against it.
+		last, werr := ecacheInstanceWaitUntilSettled(ctx, c, tenantID, name, fmt.Sprintf("the replica count to reach %d", newReplicas), func(i *duplosdk.DuploEcacheInstance) bool {
+			return i.Replicas == newReplicas
+		})
+		if werr != nil {
+			observed := "an unknown count"
+			if last != nil {
+				observed = strconv.Itoa(last.Replicas)
+			}
+			return diag.Errorf("Error updating replicas for ECache instance '%s': requested %d, but the instance still reports %s - the request was accepted but never applied: %s", id, newReplicas, observed, werr)
+		}
 	}
 
 	// --- Phase 3: Enable failover and multi_az after replica changes ---
@@ -1288,6 +1373,11 @@ func resourceDuploEcacheInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 				return diag.Errorf("Error waiting for ECache instance '%s' to be available after enabling failover: %s", id, err)
 			}
 			time.Sleep(time.Duration(90) * time.Second)
+			if _, werr := ecacheInstanceWaitUntilSettled(ctx, c, tenantID, name, "automatic_failover_enabled to turn on", func(i *duplosdk.DuploEcacheInstance) bool {
+				return i.AutomaticFailoverEnabled
+			}); werr != nil {
+				return diag.Errorf("Error enabling automatic_failover_enabled for ECache instance '%s': the request was accepted but automatic_failover_enabled never turned on: %s", id, werr)
+			}
 		}
 	}
 
@@ -1315,6 +1405,11 @@ func resourceDuploEcacheInstanceUpdate(ctx context.Context, d *schema.ResourceDa
 				return diag.Errorf("Error waiting for ECache instance '%s' to be available after enabling multi_az: %s", id, err)
 			}
 			time.Sleep(time.Duration(90) * time.Second)
+			if _, werr := ecacheInstanceWaitUntilSettled(ctx, c, tenantID, name, "multi_az_enabled to turn on", func(i *duplosdk.DuploEcacheInstance) bool {
+				return i.MultiAZEnabled
+			}); werr != nil {
+				return diag.Errorf("Error enabling multi_az_enabled for ECache instance '%s': the request was accepted but multi_az_enabled never turned on: %s", id, werr)
+			}
 		}
 	}
 

--- a/duplocloud/resource_duplo_ecache_instance_settle_test.go
+++ b/duplocloud/resource_duplo_ecache_instance_settle_test.go
@@ -98,3 +98,30 @@ func TestEcacheInstanceWaitUntilSettled(t *testing.T) {
 		}
 	})
 }
+
+// TestEcacheInstanceStatusWaitsSurviveUnreadableInstance covers the status waits against an
+// instance EcacheInstanceGet cannot read: it reports that as (nil, nil), which both waits
+// used to dereference.
+func TestEcacheInstanceStatusWaitsSurviveUnreadableInstance(t *testing.T) {
+	t.Run("wait until available", func(t *testing.T) {
+		srv, c := ecacheSettleServer(t, []string{`{}`})
+		defer srv.Close()
+
+		// The wait's own timeout is 40 minutes, so bound it from the context instead.
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		if err := ecacheInstanceWaitUntilAvailable(ctx, c, "t1", "qagrpg"); err == nil {
+			t.Fatal("expected the wait to keep polling an unreadable instance until the context expired")
+		}
+	})
+
+	t.Run("wait until unavailable", func(t *testing.T) {
+		srv, c := ecacheSettleServer(t, []string{`{}`})
+		defer srv.Close()
+
+		if err := ecacheInstanceWaitUntilUnavailable(context.Background(), c, "t1", "qagrpg", time.Second); err == nil {
+			t.Fatal("expected the wait to keep polling an unreadable instance until it timed out")
+		}
+	})
+}

--- a/duplocloud/resource_duplo_ecache_instance_settle_test.go
+++ b/duplocloud/resource_duplo_ecache_instance_settle_test.go
@@ -1,0 +1,100 @@
+package duplocloud
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/duplocloud/terraform-provider-duplocloud/duplosdk"
+)
+
+// ecacheSettleServer serves a canned ECache instance, advancing through the supplied
+// readings one poll at a time and repeating the last one forever.
+func ecacheSettleServer(t *testing.T, readings []string) (*httptest.Server, *duplosdk.Client) {
+	t.Helper()
+	var n int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := readings[n]
+		if n < len(readings)-1 {
+			n++
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+	c, err := duplosdk.NewClient(srv.URL, "fake-token")
+	if err != nil {
+		t.Fatalf("NewClient: %s", err)
+	}
+	return srv, c
+}
+
+func ecacheReading(status string, replicas int, failover, multiAz bool) string {
+	return fmt.Sprintf(`{"Identifier":"duplo-qagrpg","Name":"qagrpg","InstanceStatus":%q,`+
+		`"Replicas":%d,"AutomaticFailoverEnabled":%t,"MultiAZEnabled":%t}`,
+		status, replicas, failover, multiAz)
+}
+
+// TestEcacheInstanceWaitUntilSettled covers the DUPLO-44491 regression: the replica
+// endpoint answers "accepted", not "applied", so an update that never reached the cache
+// used to be reported as a successful apply.
+func TestEcacheInstanceWaitUntilSettled(t *testing.T) {
+	prevTimeout, prevPoll := ecacheSettleTimeout, ecacheSettlePollInterval
+	ecacheSettleTimeout, ecacheSettlePollInterval = time.Second, 50*time.Millisecond
+	defer func() { ecacheSettleTimeout, ecacheSettlePollInterval = prevTimeout, prevPoll }()
+
+	wantReplicas := func(n int) func(*duplosdk.DuploEcacheInstance) bool {
+		return func(i *duplosdk.DuploEcacheInstance) bool { return i.Replicas == n }
+	}
+
+	t.Run("settles once the count lands", func(t *testing.T) {
+		srv, c := ecacheSettleServer(t, []string{
+			ecacheReading("modifying", 4, false, false),
+			ecacheReading("available", 1, false, false),
+		})
+		defer srv.Close()
+
+		last, err := ecacheInstanceWaitUntilSettled(context.Background(), c, "t1", "qagrpg", "replicas", wantReplicas(1))
+		if err != nil {
+			t.Fatalf("expected the wait to settle, got: %s", err)
+		}
+		if last == nil || last.Replicas != 1 {
+			t.Fatalf("expected the last reading to report 1 replica, got %+v", last)
+		}
+	})
+
+	t.Run("fails when the count never changes", func(t *testing.T) {
+		srv, c := ecacheSettleServer(t, []string{ecacheReading("available", 4, false, false)})
+		defer srv.Close()
+
+		last, err := ecacheInstanceWaitUntilSettled(context.Background(), c, "t1", "qagrpg", "replicas", wantReplicas(1))
+		if err == nil {
+			t.Fatal("expected an error when the requested replica count never lands")
+		}
+		// The caller reports this value back to the user, so it has to survive the timeout.
+		if last == nil || last.Replicas != 4 {
+			t.Fatalf("expected the last reading to report 4 replicas, got %+v", last)
+		}
+	})
+
+	t.Run("does not trust a reading taken mid-modification", func(t *testing.T) {
+		srv, c := ecacheSettleServer(t, []string{ecacheReading("modifying", 1, false, false)})
+		defer srv.Close()
+
+		if _, err := ecacheInstanceWaitUntilSettled(context.Background(), c, "t1", "qagrpg", "replicas", wantReplicas(1)); err == nil {
+			t.Fatal("expected the wait to keep polling while the instance is still modifying")
+		}
+	})
+
+	t.Run("keeps polling when the instance cannot be read", func(t *testing.T) {
+		// EcacheInstanceGet reports a missing instance as (nil, nil); the wait must not panic.
+		srv, c := ecacheSettleServer(t, []string{`{}`})
+		defer srv.Close()
+
+		if _, err := ecacheInstanceWaitUntilSettled(context.Background(), c, "t1", "qagrpg", "replicas", wantReplicas(1)); err == nil {
+			t.Fatal("expected the wait to time out rather than settle on an unreadable instance")
+		}
+	})
+}


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/8655600/DUPLO-44491

## Overview

Changing `replicas` in the same apply as `multi_az_enabled` / `automatic_failover_enabled` could report success without the replica count changing on the cache.

Every phase of the ecache update is fire-and-forget. `EcacheInstanceUpdateReplicas` returns once the request is accepted, not once it is applied, and the update then waits only on instance status, which cannot tell "the change finished" apart from "the change never started": `ecacheInstanceWaitUntilUnavailable` discards its error by design, `ecacheInstanceWaitUntilAvailable` returns immediately while the instance is still available, and a blind 90s sleep follows. A dropped request therefore ends the phase as a success.

That also explains the reverse repro landing on `replicas=2` with both flags still off: phase 2 did not wait for the replica increase to finish, so phase 3 tried to enable failover against nodes that did not exist yet.

## Summary of changes

This PR does the following:

- Adds `ecacheInstanceWaitUntilSettled`, which polls the instance until the requested value is visible and the instance is back to `available`, since a read taken mid-modification still carries the previous configuration.
- Uses it in all five update phases - disabling multi_az, disabling failover, the replica count, enabling failover and enabling multi_az - so a later phase cannot run against a change that has not landed, and a dropped request fails with the requested and observed values instead of reporting success.
- Guards all three waits against `EcacheInstanceGet` reporting an instance it cannot find as `(nil, nil)`. The two existing status waits dereferenced that and panicked the provider.
- Adds unit tests over the waits: the new wait settles once the value lands, times out with the last reading preserved, and refuses a reading taken mid-modification; all three keep polling on an unreadable instance instead of panicking.

## Testing performed

- [x] Using unit tests
- [ ] Manually, on my local system
- [x] Manually, on a remote test system

Verified on test24 (backend `master`, GitSha `f9918164`) against both repro cases in the ticket. Each result was read back from the API, not just from Terraform state, and each was followed by a clean re-plan.

| Run | Change in one apply | Result |
| --- | --- | --- |
| Create | 0 -> 4 replicas, failover and multi_az on | applied, 7m09s |
| Repro 1 | 4 -> 1 replicas, both flags off | replicas 1, both flags false - previously reported success while the cache stayed at 4 |
| Reset | 3 -> 1 replicas, failover off | applied |
| Repro 2 | 1 -> 3 replicas, both flags on | replicas 3, both flags true - previously landed on replicas 2 with both flags never enabled |

The backend applies every change once each phase is allowed to settle, so this behaves as the timing fix; the new error path did not trigger.

## Describe any breaking changes

- None

