### PR TITLE
DUPLO-43327 TF: bump deprecated Node20 actions and CodeQL v3 across hotfix workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -33,20 +33,20 @@ jobs:
 
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@v5
 
             - name: Setup Go
-              uses: actions/setup-go@v5
+              uses: actions/setup-go@v6
               with:
                   go-version-file: go.mod
 
             - name: Initialize CodeQL
-              uses: github/codeql-action/init@v3
+              uses: github/codeql-action/init@v4
               with:
                   languages: ${{ matrix.language }}
 
             - name: Autobuild
-              uses: github/codeql-action/autobuild@v3
+              uses: github/codeql-action/autobuild@v4
 
             - name: Perform CodeQL Analysis
-              uses: github/codeql-action/analyze@v3
+              uses: github/codeql-action/analyze@v4

--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
           cache: false
@@ -34,10 +34,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.20.0'
           cache: false

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.20.0'
       -

--- a/.github/workflows/finish-hotfix.yml
+++ b/.github/workflows/finish-hotfix.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: master                 # Always finish hotfixes from the "merged to" master
           fetch-depth: 0

--- a/.github/workflows/finish-release.yml
+++ b/.github/workflows/finish-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: master                 # Always finish releases from the "merged to" master
           fetch-depth: 0
@@ -41,7 +41,7 @@ jobs:
       - finish-release
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: develop
           fetch-depth: 0

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -17,10 +17,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Validate PR Description
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prBody = context.payload.pull_request.body || '';
@@ -86,7 +86,7 @@ jobs:
 
       - name: Add validation comment
         if: success()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const comment = '✅ **PR Validation Passed**\n\nAll required sections are present and ClickUp ticket ID is included.';

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -9,13 +9,13 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
       -
         name: Unshallow
         run: git fetch --prune --unshallow
       -
         name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '^1.20.0'
       -
@@ -48,7 +48,7 @@ jobs:
     steps:
       -
         name: Publish the release
-        uses: actions/github-script@v5
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.DUPLO_GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/start-hotfix.yml
+++ b/.github/workflows/start-hotfix.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: master                # Always hotfix from master
           fetch-depth: 0

--- a/.github/workflows/start-release.yml
+++ b/.github/workflows/start-release.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: develop                # Always release from develop
           fetch-depth: 0


### PR DESCRIPTION
## ClickUp Ticket

**ClickUp Ticket ID:** https://app.clickup.com/t/86aj2u3y0

## Overview

The earlier Node20 fixes for this ticket landed on develop only, so the hotfix line (cut from master) still runs the deprecated action versions — the run Sandhya linked (dev-test on hotfix/0.12.19) warns about actions/checkout@v3 and actions/setup-go@v5. This applies the same bumps to the hotfix branch so they reach master with the release.

## Summary of changes

This PR does the following:

- Bumps `actions/checkout` to v5, `actions/setup-go` to v6, and `actions/github-script` to v8 across all workflows
- Bumps `github/codeql-action/*` from v3 to v4 in `codeql-analysis.yml`

## Testing performed

- [ ] Using unit tests
- [x] Manually, on my local system
- [ ] Manually, on a remote test system

## Describe any breaking changes

- None
